### PR TITLE
fix: remove node16 deprecation warnings in workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install pipx
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Compile filaments

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-    contents: read
-    pages: write
-    id-token: write
+  contents: read
+  pages: write
+  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -57,7 +57,6 @@ jobs:
           path: filaments.json
           if-no-files-found: error
 
-
   # Single deploy job since we're just deploying
   deploy:
     if: ${{ github.event_name != 'pull_request' }}
@@ -86,4 +85,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
Hey there!
I noticed the actions have deprecation wanings (see https://github.com/Donkie/SpoolmanDB/actions/runs/9077454292).

I updated the actions to their latest to use Node20.
Tested and working at https://github.com/StuSerious/SpoolmanDB/actions/runs/9077737446.

I can revert 2f08d78939bd91d89d505dbc8bb5a39f0e277ff6 if it bothers you, but the GH Actions VSCode extension recommends that formatting.