### PR TITLE
materials: add technopolymers

### DIFF
--- a/materials.json
+++ b/materials.json
@@ -14,15 +14,15 @@
         "density": 1.27
     },
     {
-        "material": "Nylon",
+        "material": "PA (Nylon)",
         "density": 1.52
     },
     {
-        "material": "Flexible (TPU)",
+        "material": "TPU (Flexible)",
         "density": 1.21
     },
     {
-        "material": "Polycarbonate (PC)",
+        "material": "PC (Polycarbonate)",
         "density": 1.3
     },
     {
@@ -50,11 +50,11 @@
         "density": 1.05
     },
     {
-        "material": "Polypropylene (PP)",
+        "material": "PP (Polypropylene)",
         "density": 0.9
     },
     {
-        "material": "Acetal (POM)",
+        "material": "POM (Delrin)",
         "density": 1.4
     },
     {
@@ -62,7 +62,7 @@
         "density": 1.18
     },
     {
-        "material": "Semi flexible (FPE)",
+        "material": "FPE (Semi-flexible)",
         "density": 2.16
     }
 ]

--- a/materials.json
+++ b/materials.json
@@ -20,15 +20,15 @@
         "density": 1.27
     },
     {
-        "material": "PA (Nylon)",
+        "material": "Nylon",
         "density": 1.52
     },
     {
-        "material": "TPU (Flexible)",
+        "material": "Flexible (TPU)",
         "density": 1.21
     },
     {
-        "material": "PC (Polycarbonate)",
+        "material": "Polycarbonate (PC)",
         "density": 1.3
     },
     {
@@ -56,11 +56,11 @@
         "density": 1.05
     },
     {
-        "material": "PP (Polypropylene)",
+        "material": "Polypropylene (PP)",
         "density": 0.9
     },
     {
-        "material": "POM (Delrin)",
+        "material": "Acetal (POM)",
         "density": 1.4
     },
     {
@@ -68,7 +68,7 @@
         "density": 1.18
     },
     {
-        "material": "FPE (Semi-flexible)",
+        "material": "Semi flexible (FPE)",
         "density": 2.16
     },
     {

--- a/materials.json
+++ b/materials.json
@@ -64,5 +64,25 @@
     {
         "material": "FPE (Semi-flexible)",
         "density": 2.16
+    },
+    {
+        "material": "PVDF",
+        "density": 1.78
+    },
+    {
+        "material": "PEI (Ultem)",
+        "density": 1.27
+    },
+    {
+        "material": "PEKK",
+        "density": 1.28
+    },
+    {
+        "material": "PEEK",
+        "density": 1.32
+    },
+    {
+        "material": "PPSU",
+        "density": 1.37
     }
 ]


### PR DESCRIPTION
This adds some 3D printable high-end polymers and their densities, that were not yet added to the materials.json file.
I will add more once I go through more of my inventory.

The rationale behind 022fb6383788e4e4f883cc30060d3444bbca2243 is that by largely adopted convention the names of the polymers are written first, than their commercial/everyday name.
While I like it better like this, 022fb6383788e4e4f883cc30060d3444bbca2243 can be easily reverted if you don't agree.
