### PR TITLE
add QIDITech (PAHT|PPS)-CF

### DIFF
--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -26,7 +26,7 @@
                     "name": {
                         "$comment": "Name of the filament, must contain {color_name}",
                         "type": "string",
-                        "pattern": "{"
+                        "pattern": "\\{"
                     },
                     "material": {
                         "$comment": "Valid materials must be uppercase letters and numbers, optionally separated by + or -. Optionally ends with -CF or -GF followed by a number. Examples: ABS, ABS-CF, PC+ABS, PC+ABS-CF10.",

--- a/filaments/qiditech.json
+++ b/filaments/qiditech.json
@@ -1,0 +1,39 @@
+{
+	"manufacturer": "QIDI Tech",
+	"filaments": [
+		{
+			"name": "{color_name}",
+			"material": "PPS-CF",
+			"density": 1.3,
+			"weights": [
+				{
+					"weight": 750.0,
+					"spool_weight": 245.0,
+					"spool_type": "plastic"
+				}
+			],
+			"diameters": [ 1.75 ],
+			"extruder_temp_range": [ 310, 350 ],
+			"bed_temp": 100,
+			"fill": "carbon fiber",
+			"colors": [ { "name": "Black", "hex": "000000" } ]
+		},
+		{
+			"name": "{color_name}",
+			"material": "PAHT-CF",
+			"density": 1.2,
+			"weights": [
+				{
+					"weight": 1000.0,
+					"spool_weight": 245.0,
+					"spool_type": "plastic"
+				}
+			],
+			"diameters": [ 1.75 ],
+			"extruder_temp_range": [ 300, 320 ],
+			"bed_temp_range": [ 70, 90 ],
+			"fill": "carbon fiber",
+			"colors": [ { "name": "Black", "hex": "000000" } ]
+		}
+	]
+}


### PR DESCRIPTION
hi,

#1 im a sysadmin, not a dev, so i am not very experienced with git and github procedures :)

#2 the JSON editor i am using (JSONBuddy) complains about the pattern for the filament name. i believe what i changed is the correct way to do it, but i am painfully aware that different validators work differently and the original pattern might have validated fine in others... still, if it doesn't break yours, i guess this is more "universal"

#3 the list for QIDI is not exhaustive, i just added those that i had ordered, will probably add more in the future

#4 what do you think about adding a "list price" to the definition? or was that left out on purpose?

thanks & kr