### PR TITLE
Updated R3D Filament with New Cardboard Spool Weight

### DIFF
--- a/filaments/r3d.json
+++ b/filaments/r3d.json
@@ -7,7 +7,7 @@
             "weights": 
             [
                 {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
-                {"weight": 1000.0, "spool_weight": 100.0, "spool_type": "cardboard"}
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
             ], 
             "diameters": [1.75], 
             "extruder_temp": 245, 


### PR DESCRIPTION
The spool weight has been adjusted from 100g to 140g to align with the latest specifications.