### PR TITLE
PolyLite (Non-Pro), FlashForge and Extruder Additions and Changes

### DIFF
--- a/filaments/extrudr.json
+++ b/filaments/extrudr.json
@@ -1097,7 +1097,7 @@
         {
             "name": "{color_name}",
             "material": "PETG",
-            "density": 1.3,
+            "density": 1.29,
             "weights": [
                 {
                     "weight": 800.0,

--- a/filaments/extrudr.json
+++ b/filaments/extrudr.json
@@ -1009,11 +1009,6 @@
                     "hex": "00BB2D"
                 },
                 {
-                    "name": "glowEx",
-                    "hex": "00BB2D",
-                    "glow": true
-                },
-                {
                     "name": "White",
                     "hex": "F4F4F4"
                 },
@@ -1096,6 +1091,36 @@
                 {
                     "name": "Neon Yellow",
                     "hex": "FFFF00"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.3,
+            "weights": [
+                {
+                    "weight": 800.0,
+                    "spool_weight": 260.0,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2500.0,
+                    "spool_weight": 600.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp": 230,
+            "bed_temp": 70,
+            "colors": [
+                {
+                    "name": "glowEx",
+                    "hex": "00BB2D",
+                    "glow": true
                 }
             ]
         },

--- a/filaments/fillamentum.json
+++ b/filaments/fillamentum.json
@@ -161,6 +161,10 @@
           {
             "name": "Cobalt Blue",
             "hex": "283355"
+          },
+          {
+            "name": "Everybody's Magenta",
+            "hex": "E1337E"
           }
         ]
       }

--- a/filaments/flashforge.json
+++ b/filaments/flashforge.json
@@ -4,7 +4,7 @@
         {
             "name": "PLA - {color_name}",
             "material": "PLA",
-            "density": 1.24,
+            "density": 1.25,
             "weights": [
                 {
                     "weight": 500.0,
@@ -90,7 +90,7 @@
         {
             "name": "Starter PLA - {color_name}",
             "material": "PLA",
-            "density": 1.24,
+            "density": 1.25,
             "weights": [
                 {
                     "weight": 250.0,
@@ -113,7 +113,7 @@
         {
             "name": "PLA Pro - {color_name}",
             "material": "PLA",
-            "density": 1.24,
+            "density": 1.25,
             "weights": [
                 {
                     "weight": 1000,

--- a/filaments/flashforge.json
+++ b/filaments/flashforge.json
@@ -1,0 +1,228 @@
+{
+    "manufacturer": "FlashForge",
+    "filaments": [
+        {
+            "name": "PLA - {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 500.0,
+                    "spool_weight": 142.0
+                },
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 170.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "0B0203"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "E7E7E7"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "515F6C"
+                },
+                {
+                    "name": "Skin",
+                    "hex": "D4B48F"
+                },
+                {
+                    "name": "Red",
+                    "hex": "D92818"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "172788"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FED212"
+                },
+                {
+                    "name": "Green",
+                    "hex": "149732"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "F08400"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "8C9091"
+                },
+                {
+                    "name": "Light Green",
+                    "hex": "8AC54B"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "F3B4CD"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "50248B"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "984304"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "8D834E"
+                }
+            ]
+        },
+        {
+            "name": "Starter PLA - {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 250.0,
+                    "spool_weight": 142.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Red",
+                    "hex": "D92818",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "PLA Pro - {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 120
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Natural",
+                    "hex": "E7E7E7"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Cool White",
+                    "hex": "F6F5FA"
+                },
+                {
+                    "name": "Black",
+                    "hex": "0B0203"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "9EACAC"
+                },
+                {
+                    "name": "Silver Gray",
+                    "hex": "A2A7A7"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "BBBDBD"
+                },
+                {
+                    "name": "Skin",
+                    "hex": "E7CEA2"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FED212"
+                },
+                {
+                    "name": "Green",
+                    "hex": "149732"
+                },
+                {
+                    "name": "Light Blue",
+                    "hex": "00A3E0"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "172788"
+                },
+                {
+                    "name": "Red",
+                    "hex": "D90C18"
+                },
+                {
+                    "name": "Light Yellow",
+                    "hex": "E4E63F"
+                },
+                {
+                    "name": "Rose",
+                    "hex": "BC4997"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "F3B4CD"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "5C3E93"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "EC6C01"
+                },
+                {
+                    "name": "Light Green",
+                    "hex": "91C536"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "CFA74C"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "984304"
+                },
+                {
+                    "name": "Light Red",
+                    "hex": "DB2F2B"
+                },
+                {
+                    "name": "Traffic Red",
+                    "hex": "B32124"
+                },
+                {
+                    "name": "Light Orange",
+                    "hex": "F08400"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -1013,6 +1013,152 @@
         ]
       },
       {
+        "name": "PolyLite\u2122 PLA {color_name}",
+        "material": "PLA",
+        "density": 1.17,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 1000.0,
+            "spool_weight": 250.0,
+            "spool_type": "plastic"
+          },
+          {
+            "weight": 3000.0,
+            "spool_weight": 425.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 5000.0,
+            "spool_weight": 819.0,
+            "spool_type": "plastic"
+          }
+        ],
+        "diameters": [
+          1.75,
+          2.85
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "08090D"
+          },
+          {
+            "name": "Steel Grey",
+            "hex": "616469"
+          },
+          {
+            "name": "Grey",
+            "hex": "8C9099"
+          },
+          {
+            "name": "Purple",
+            "hex": "6C47B2"
+          },
+          {
+            "name": "Magenta",
+            "hex": "F2306E"
+          },
+          {
+            "name": "Pink",
+            "hex": "F2306E"
+          },
+          {
+            "name": "Wine Red",
+            "hex": "E0191E"
+          },
+          {
+            "name": "Red",
+            "hex": "E72F1D"
+          },
+          {
+            "name": "Brown",
+            "hex": "55331A"
+          },
+          {
+            "name": "White",
+            "hex": "E2DEDB"
+          },
+          {
+            "name": "Orange",
+            "hex": "F67405"
+          },
+          {
+            "name": "Cream",
+            "hex": "E5C8A2"
+          },
+          {
+            "name": "Beige",
+            "hex": "C6AD74"
+          },
+          {
+            "name": "Yellow",
+            "hex": "F3B400"
+          },
+          {
+            "name": "Lemon Yellow",
+            "hex": "F1D335"
+          },
+
+          {
+            "name": "Natural",
+            "hex": "E8E6D0"
+          },
+          {
+            "name": "Olive Green",
+            "hex": "857C00"
+          },
+          {
+            "name": "Lime Green",
+            "hex": "DEDE00"
+          },
+          {
+            "name": "Jungle Green",
+            "hex": "446B20"
+          },
+          {
+            "name": "Green",
+            "hex": "06924D"
+          },
+          {
+            "name": "Polymaker Teal",
+            "hex": "4CC0C7"
+          },
+          {
+            "name": "Aqua Blue",
+            "hex": "39B9DB"
+          },
+          {
+            "name": "Stone Blue",
+            "hex": "40719A"
+          },
+          {
+            "name": "Azure Blue",
+            "hex": "0066D9"
+          },
+          {
+            "name": "Blue",
+            "hex": "003776"
+          },
+          {
+            "name": "Dark Blue",
+            "hex": "041B3D"
+          }
+        ]
+      },
+      {
         "name": "Polymaker PC-ABS {color_name}",
         "material": "PC",
         "density": 1.1,


### PR DESCRIPTION
This PR contains the following changes:
- Add Polymaker PolyLite™ PLA (non-pro)
- Addition of FlashForge PLA and PLA Pro filaments
- Modification to Extrudr PETG Glowex entry as this is sold in a smaller spool and has slightly different characteristics to the normal PETG range