### PR TITLE
Added new dual silk color Velvet Eclipse

### DIFF
--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -661,6 +661,13 @@
             "finish": "glossy",
             "colors": [
                 {
+                    "name": "Velvet Eclipse (Black-Red)",
+                    "hexes": [
+                        "000000",
+                        "A34342"
+                    ]
+                },
+                {
                     "name": "Midnight Blaze (Blue-Red)",
                     "hexes": [
                         "0047BB",


### PR DESCRIPTION
Just a simple update to support a new color Bambu offers. Color data from https://us.store.bambulab.com/collections/bambu-lab-3d-printer-filament/products/pla-silk-dual-color