### PR TITLE
remove illegal escape sequence

### DIFF
--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -31,7 +31,7 @@
                     "material": {
                         "$comment": "Valid materials must be uppercase letters and numbers, optionally separated by + or -. Optionally ends with -CF or -GF followed by a number. Examples: ABS, ABS-CF, PC+ABS, PC+ABS-CF10.",
                         "type": "string",
-                        "pattern": "^[A-Z0-9]+(\\+[A-Z0-9]+)*(\\-(CF\\d{0,2}|GF\\d{0,2}|\\d{2}[AD]))?\\+?$"
+                        "pattern": "^[A-Z0-9]+(\\+[A-Z0-9]+)*(-(CF\\d{0,2}|GF\\d{0,2}|\\d{2}[AD]))?\\+?$"
                     },
                     "density": {
                         "type": "number",


### PR DESCRIPTION
In release [0.31.0](https://github.com/python-jsonschema/check-jsonschema/releases/tag/0.31.0) of check-jsonschema regular expressions now use unicode mode by default. A summary of difference can be found [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#description). In SpoolmanDB's case that means that patterns in the schema file can no longer escape any character that is not an actual escape sequence like before. In unicode-aware-mode those would've been "identity escapes"
> An escape sequence that's not recognized becomes an ["identity escape"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape).

now they are just straight up forbidden. I removed the backslashes for the illegal `-` escape.