### PR TITLE
Creality Rainbow CR & Ender-PLA

### DIFF
--- a/filaments/creality.json
+++ b/filaments/creality.json
@@ -74,56 +74,6 @@
                 {
                     "name": "Red",
                     "hex": "DE3530"
-                }
-            ]
-        },
-        {
-            "name": "{color_name}",
-            "material": "PLA",
-            "density": 1.24,
-            "weights": [
-                {
-                    "weight": 1000,
-                    "spool_weight": 120
-                }
-            ],
-            "diameters": [
-                1.75
-            ],
-            "extruder_temp": 210,
-            "bed_temp": 60,
-            "colors": [
-                {
-                    "name": "White",
-                    "hex": "FFFFFF"
-                },
-                {
-                    "name": "Silver",
-                    "hex": "ABB3B9"
-                },
-                {
-                    "name": "Grey",
-                    "hex": "666D78"
-                },
-                {
-                    "name": "Black",
-                    "hex": "000000"
-                },
-                {
-                    "name": "Yellow",
-                    "hex": "E5D660"
-                },
-                {
-                    "name": "Green",
-                    "hex": "5EEAAB"
-                },
-                {
-                    "name": "Blue",
-                    "hex": "2D8CD5"
-                },
-                {
-                    "name": "Red",
-                    "hex": "DE3530"
                 },
                 {
                     "name": "Raindow",

--- a/filaments/creality.json
+++ b/filaments/creality.json
@@ -76,6 +76,101 @@
                     "hex": "DE3530"
                 }
             ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 120
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "ABB3B9"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "666D78"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E5D660"
+                },
+                {
+                    "name": "Green",
+                    "hex": "5EEAAB"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2D8CD5"
+                },
+                {
+                    "name": "Red",
+                    "hex": "DE3530"
+                },
+                {
+                    "name": "Raindow",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "37c597",
+                        "fdff79",
+                        "e95f2a",
+                        "a15160",
+                        "84adcf"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Ender-PLA {color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 120
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2D8CD5"
+                },
+                {
+                    "name": "Red",
+                    "hex": "DE3530"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Rainbow CR 
https://store.creality.com/au/products/cr-1-75mm-pla-3d-printing-filament-1kg?spm=..product_95c043b9-c56e-4fec-a7fb-4c0d7194fe36.header_1.1&spm_prev=..product_57e00e12-39d8-4f32-8641-2e3247a963b0.header_1.1

The CR PLA is labelled as just PLA in the file - Creality sells lots of different sub-types with slightly different costs & profiles so this can be confusing. Didn't update it to avoid breaking things

Ender-PLA - Blue and red available occasionally, colours match CR PLA but are more matt (but it's not listed as matt)
https://store.creality.com/au/products/ender-pla-value-pack2-spools-pack?spm=..product_57e00e12-39d8-4f32-8641-2e3247a963b0.header_1.1

