### PR TITLE
Correction on ASA White

### DIFF
--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -1066,7 +1066,7 @@
             "colors": [
                 {
                     "name": "White",
-                    "hex": "FFFAF2"
+                    "hex": "FFFFFF"
                 },
                 {
                     "name": "Gray",


### PR DESCRIPTION
Looks like either Bambu Lab changed color code for white or there is something else going on.

This is what I got from my printer when listening to MQTT messages and looking at my ASA White

` {
              "bed_temp": "0",
              "bed_temp_type": "0",
              "cali_idx": -1,
              "cols": [
                "FFFFFFFF"
              ],
              "ctype": 0,
              "drying_temp": "80",
              "drying_time": "8",
              "id": "1",
              "nozzle_temp_max": "270",
              "nozzle_temp_min": "240",
              "remain": 91,
              "tag_uid": "9A21FAAF00000100",
              "tray_color": "FFFFFFFF",
              "tray_diameter": "1.75",
              "tray_id_name": "B01-W0",
              "tray_info_idx": "GFB01",
              "tray_sub_brands": "ASA",
              "tray_type": "ASA",
              "tray_uuid": "B008D3DA5F8B49A3AB8B5BF281536A74",
              "tray_weight": "1000",
              "xcam_info": "34218813E803E803CDCC0C3F"
            }`