### PR TITLE
Add Bambu Lab Support Materials

### DIFF
--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -720,7 +720,7 @@
             ]
         },
         {
-            "name": "Support for ABS",
+            "name": "Support for {color_name}",
             "material": "ABS",
             "density": 1.16,
             "weights": [
@@ -736,13 +736,13 @@
             "bed_temp": 90,
             "colors": [
                 {
-                    "name": "White",
+                    "name": "ABS",
                     "hex": "FFFFFF"
                 }
             ]
         },
         {
-            "name": "Support for PA/PET",
+            "name": "Support for {color_name}",
             "material": "PA",
             "density": 1.17,
             "weights": [
@@ -758,7 +758,7 @@
             "bed_temp": 90,
             "colors": [
                 {
-                    "name": "Green",
+                    "name": "PA/PET",
                     "hex": "BECF00"
                 }
             ]

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -720,6 +720,102 @@
             ]
         },
         {
+            "name": "Support for ABS",
+            "material": "ABS",
+            "density": 1.16,
+            "weights": [
+                {
+                    "weight": 500,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 270,
+            "bed_temp": 90,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "Support for PA/PET",
+            "material": "PA",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 500,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 290,
+            "bed_temp": 90,
+            "colors": [
+                {
+                    "name": "Green",
+                    "hex": "BECF00"
+                }
+            ]
+        },
+        {
+            "name": "Support for PLA/PETG",
+            "material": "PLA",
+            "density": 1.28,
+            "weights": [
+                {
+                    "weight": 500,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Nature",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        },
+        {
+            "name": "Support for PLA",
+            "material": "PLA",
+            "density": 1.22,
+            "weights": [
+                {
+                    "weight": 500,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 225,
+            "bed_temp": 45,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        },
+        {
             "name": "{color_name}",
             "material": "PETG",
             "density": 1.25,

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -764,7 +764,7 @@
             ]
         },
         {
-            "name": "Support for PLA/PETG",
+            "name": "Support for PLA/PETG {color_name}",
             "material": "PLA",
             "density": 1.28,
             "weights": [
@@ -790,7 +790,7 @@
             ]
         },
         {
-            "name": "Support for PLA",
+            "name": "Support for PLA {color_name}",
             "material": "PLA",
             "density": 1.22,
             "weights": [


### PR DESCRIPTION
Add Bambu Lab:
- Support for PLA/PETG
- Support for PLA
- Support for ABS
- Support for PA/PET