### PR TITLE
Remove - Support for PLA (Discontinued & Conflicts with PLA/PETG)

### DIFF
--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -781,37 +781,11 @@
             "colors": [
                 {
                     "name": "Nature",
-                    "hex": "FFFFFF"
+                    "hex": "000000"
                 },
                 {
                     "name": "Black",
-                    "hex": "000000"
-                }
-            ]
-        },
-        {
-            "name": "Support for PLA {color_name}",
-            "material": "PLA",
-            "density": 1.22,
-            "weights": [
-                {
-                    "weight": 500,
-                    "spool_weight": 250
-                }
-            ],
-            "diameters": [
-                1.75
-            ],
-            "extruder_temp": 225,
-            "bed_temp": 45,
-            "colors": [
-                {
-                    "name": "White",
                     "hex": "FFFFFF"
-                },
-                {
-                    "name": "Black",
-                    "hex": "000000"
                 }
             ]
         },

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -781,11 +781,11 @@
             "colors": [
                 {
                     "name": "Nature",
-                    "hex": "000000"
+                    "hex": "FFFFFF"
                 },
                 {
                     "name": "Black",
-                    "hex": "FFFFFF"
+                    "hex": "000000"
                 }
             ]
         },


### PR DESCRIPTION
This filament is discontinued, being replaced by "Support for PLA/PETG", however Bambu Lab is now encoding these new spools with the RFID data saying its 'Support for PLA' (i.e. not showing the /PETG). This is seeing the new Support PLA/PETG incorrectly identifying as 'Support for PLA'

Given Support for PLA is no longer sold, to avoid this issue, 'Support for PLA' is being removed. 

Additionally the new 'Support for PLA/PETG' is supposed to be available in "Nature" (Colour is a semi translucent White, so hex code = FFFFFF) and Black (hex code = 000000). However, it appears Bambu is shipping these spools with the RFID hex codes reversed. So for now, these hex codes are being swapped, IF/WHEN Bambu starts shipping these spools with the correctly matched hex codes, these can be reversed back (L784 and L788).