### PR TITLE
Add Sunlu PLA non-glow

### DIFF
--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -205,6 +205,22 @@
                     "name": "Black",
                     "hex": "2B2B2D"
                 },
+                {
+                    "name": "White",
+                    "hex": "C7CDD7"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "636767"
+                },
+                {
+                    "name": "Red",
+                    "hex": "AC3638"
+                },
+                {
+                    "name": "Sunny Orange",
+                    "hex": "D8631E"
+                }
             ]
         },
         {

--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -150,7 +150,7 @@
         {
             "name": "{color_name}",
             "material": "PLA",
-            "density": 1.24,
+            "density": 1.26,
             "weights": [
                 {
                     "weight": 1000.0,

--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -185,6 +185,30 @@
         },
         {
             "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 162.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 60,
+            "glow": false,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "2B2B2D"
+                },
+            ]
+        },
+        {
+            "name": "{color_name}",
             "material": "PETG",
             "density": 1.23,
             "weights": [


### PR DESCRIPTION
Hey there,

not sure if this is the correct way to add these. The other Sunlu PLAs where with glow: true. I did no merge them into one list because they have different densities (I checked in Sunlu's Filament Technical Data Sheet (TDS): https://3dsunlu.com/pages/materials).
These are the ones without glow. You can find them here: https://3dsunlu.com/products/sunlu-pla-filament?variant=51742515101987
I only added those that I could find on https://filamentcolors.xyz/library/?f=&mfr=sunlu&ft=pla where the name matched the one in the Sunlu website. The spool weight comes from https://www.reddit.com/r/BambuLab/comments/1f9241i/sunlu_pla_20_spool_weight/ as this is the spool that I got with the black PLA. They are reusable.