### PR TITLE
Overture ABS

### DIFF
--- a/filaments/overture.json
+++ b/filaments/overture.json
@@ -156,6 +156,78 @@
                     "translucent": true
                 }
             ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.15,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 150,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                245,
+                265
+            ],
+            "bed_temp_range": [
+                80,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },{
+                    "name": "Black",
+                    "hex": "000000"
+                },{
+                    "name": "Gray",
+                    "hex": "cacac9"
+                },{
+                    "name": "Blue",
+                    "hex": "00628f"
+                },{
+                    "name": "Slate Gray",
+                    "hex": "91a0b6"
+                },{
+                    "name": "Yellow",
+                    "hex": "ffff47"
+                },{
+                    "name": "Dark Red",
+                    "hex": "ff311f"
+                },{
+                    "name": "Natural",
+                    "hex": "f8f8ee"
+                },{
+                    "name": "Green",
+                    "hex": "3d9441"
+                },{
+                    "name": "Purple",
+                    "hex": "7142a3"
+                },{
+                    "name": "Glow Green",
+                    "hex": "ebefee",
+                    "glow": true
+                },{
+                    "name": "Diamond Purple",
+                    "hex": "a04ed0",
+                    "pattern": "sparkle"
+                },{
+                    "name": "Diamond Gray",
+                    "hex": "8c8c8c",
+                    "pattern": "sparkle"
+                },{
+                    "name": "Diamond Orange",
+                    "hex": "ff8133",
+                    "pattern": "sparkle"
+                }
+            ]
         }
     ]
 }

--- a/filaments/overture.json
+++ b/filaments/overture.json
@@ -164,7 +164,7 @@
             "weights": [
                 {
                     "weight": 1000.0,
-                    "spool_weight": 150,
+                    "spool_weight": 147,
                     "spool_type": "cardboard"
                 }
             ],


### PR DESCRIPTION
I added the Overture ABS filaments since they seemed to be missing. Everything aside from the spool weight was retrieved from Overture's website. The spool weight is based on the indicated weight of a real spool of Overture ABS that I recently purchased, I was unable to find any indication of the spool weight on Overture's website.