### PR TITLE
Use python3 to install pipx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
           python-version: "3.11"
       - name: Install pipx
         run: |
-          sudo apt update
-          sudo apt install pipx
-          pipx ensurepath
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+        shell: bash
       - name: Install jsonschema
         run: pipx install check-jsonschema
       - name: Validate Materials


### PR DESCRIPTION
Remove the need to update entire os of build host, in testing it drops about a minute off the build time.