### PR TITLE
Added Amazon Basics Silk PLA filaments

### DIFF
--- a/filaments/AmazonBasics.json
+++ b/filaments/AmazonBasics.json
@@ -40,6 +40,44 @@
             ]
         },
         {
+            "name": "Silk {color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 266
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "F8CC6D"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "926043"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "1E90EC"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "A0AAB1"
+                },
+                {
+                    "name": "Cream",
+                    "hex": "FEFDFA"
+                }
+            ]
+        },
+        {
             "name": "{color_name}",
             "material": "PETG",
             "density": 1.29,


### PR DESCRIPTION
I updated the Amazon Basics filaments with silk PLA. 

I couldn't find details on the density so I measured a sample of my own and came up with a reasonable looking number so went with it.

The color hexes may not be perfect either. For blue and cream I had to use a color picker on a picture to get the value. No promises it's perfect. If anyone has a better source of info for these it would be appreciated.