### PR TITLE
Polymaker panchroma matte updates

### DIFF
--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -1835,179 +1835,179 @@
         ]
       },
       {
-            "name": "Panchroma™ Matte (Formerly PolyTerra™) {color_name}",
-            "material": "PLA",
-            "density": 1.24,
-            "weights": [
-                {
-                    "weight": 1000,
-                    "spool_weight": 140
-                },
-                {
-                    "weight": 3000,
-                    "spool_weight": 425
-                }
-            ],
-            "diameters": [
-                1.75,
-                2.85
-            ],
-            "extruder_temp": 210,
-            "bed_temp": 50,
-            "colors": [
-              {
-                "name": "Arctic Teal",
-                "hex": "5aabb1"
-              },
-              {
-                "name": "Army Beige",
-                "hex": "cca897"
-              },
-              {
-                "name": "Army Blue",
-                "hex": "062b4d"
-              },
-              {
-                "name": "Army Brown",
-                "hex": "724e3d"
-              },
-              {
-                "name": "Army Dark Green",
-                "hex": "515234"
-              },
-              {
-                "name": "Army Light Green",
-                "hex": "a78403"
-              },
-              {
-                "name": "Army Purple",
-                "hex": "292036"
-              },
-              {
-                "name": "Army Red",
-                "hex": "ac1a17"
-              },
-              {
-                "name": "Ash Grey",
-                "hex": "575e75"
-              },
-              {
-                "name": "Charcoal Black",
-                "hex": "1c1c1c"
-              },
-              {
-                "name": "Cotton White",
-                "hex": "e6dddb"
-              },
-              {
-                "name": "Earth Brown",
-                "hex": "7c594a"
-              },
-              {
-                "name": "Electric Indigo",
-                "hex": "764c99"
-              },
-              {
-                "name": "Forest Green",
-                "hex": "519f61"
-              },
-              {
-                "name": "Fossil Grey",
-                "hex": "6f727e"
-              },
-              {
-                "name": "Lavender Purple",
-                "hex": "8a68b5"
-              },
-              {
-                "name": "Lava Red",
-                "hex": "de1619"
-              },
-              {
-                "name": "Lime Green",
-                "hex": "d0e740"
-              },
-              {
-                "name": "Lotus Pink",
-                "hex": "f98289"
-              },
-              {
-                "name": "Muted Blue",
-                "hex": "4e6a84"
-              },
-              {
-                "name": "Muted Green",
-                "hex": "656d60"
-              },
-              {
-                "name": "Muted Purple",
-                "hex": "7c5577"
-              },
-              {
-                "name": "Muted Red",
-                "hex": "db3e14"
-              },
-              {
-                "name": "Muted White",
-                "hex": "afa198"
-              },
-              {
-                "name": "Pastel Banana",
-                "hex": "f5cf6f"
-              },
-              {
-                "name": "Pastel Candy",
-                "hex": "dabcc8"
-              },
-              {
-                "name": "Pastel Ice",
-                "hex": "95c5d3"
-              },
-              {
-                "name": "Pastel Mint",
-                "hex": "bec9a5"
-              },
-              {
-                "name": "Pastel Peach",
-                "hex": "f2b67a"
-              },
-              {
-                "name": "Pastel Peanut",
-                "hex": "c29572"
-              },
-              {
-                "name": "Pastel Periwinkle",
-                "hex": "bfb2e6"
-              },
-              {
-                "name": "Pastel Watermelon",
-                "hex": "e93a3f"
-              },
-              {
-                "name": "Sakura Pink",
-                "hex": "e0a8bb"
-              },
-              {
-                "name": "Sapphire Blue",
-                "hex": "005aa2"
-              },
-              {
-                "name": "Savannah Yellow",
-                "hex": "f0be02"
-              },
-              {
-                "name": "Sky Blue",
-                "hex": "87ceeb"
-              },
-              {
-                "name": "Sunrise Orange",
-                "hex": "f78e0e"
-              },
-              {
-                "name": "Wood Brown",
-                "hex": "ad7441"
-              }
-            ]
-        }
+        "name": "Panchroma™ Matte (Formerly PolyTerra™) {color_name}",
+        "material": "PLA",
+        "density": 1.24,
+        "weights": [
+            {
+                "weight": 1000,
+                "spool_weight": 140
+            },
+            {
+                "weight": 3000,
+                "spool_weight": 425
+            }
+        ],
+        "diameters": [
+            1.75,
+            2.85
+        ],
+        "extruder_temp": 210,
+        "bed_temp": 50,
+        "colors": [
+          {
+            "name": "Arctic Teal",
+            "hex": "5aabb1"
+          },
+          {
+            "name": "Army Beige",
+            "hex": "cca897"
+          },
+          {
+            "name": "Army Blue",
+            "hex": "062b4d"
+          },
+          {
+            "name": "Army Brown",
+            "hex": "724e3d"
+          },
+          {
+            "name": "Army Dark Green",
+            "hex": "515234"
+          },
+          {
+            "name": "Army Light Green",
+            "hex": "a78403"
+          },
+          {
+            "name": "Army Purple",
+            "hex": "292036"
+          },
+          {
+            "name": "Army Red",
+            "hex": "ac1a17"
+          },
+          {
+            "name": "Ash Grey",
+            "hex": "575e75"
+          },
+          {
+            "name": "Charcoal Black",
+            "hex": "1c1c1c"
+          },
+          {
+            "name": "Cotton White",
+            "hex": "e6dddb"
+          },
+          {
+            "name": "Earth Brown",
+            "hex": "7c594a"
+          },
+          {
+            "name": "Electric Indigo",
+            "hex": "764c99"
+          },
+          {
+            "name": "Forest Green",
+            "hex": "519f61"
+          },
+          {
+            "name": "Fossil Grey",
+            "hex": "6f727e"
+          },
+          {
+            "name": "Lavender Purple",
+            "hex": "8a68b5"
+          },
+          {
+            "name": "Lava Red",
+            "hex": "de1619"
+          },
+          {
+            "name": "Lime Green",
+            "hex": "d0e740"
+          },
+          {
+            "name": "Lotus Pink",
+            "hex": "f98289"
+          },
+          {
+            "name": "Muted Blue",
+            "hex": "4e6a84"
+          },
+          {
+            "name": "Muted Green",
+            "hex": "656d60"
+          },
+          {
+            "name": "Muted Purple",
+            "hex": "7c5577"
+          },
+          {
+            "name": "Muted Red",
+            "hex": "db3e14"
+          },
+          {
+            "name": "Muted White",
+            "hex": "afa198"
+          },
+          {
+            "name": "Pastel Banana",
+            "hex": "f5cf6f"
+          },
+          {
+            "name": "Pastel Candy",
+            "hex": "dabcc8"
+          },
+          {
+            "name": "Pastel Ice",
+            "hex": "95c5d3"
+          },
+          {
+            "name": "Pastel Mint",
+            "hex": "bec9a5"
+          },
+          {
+            "name": "Pastel Peach",
+            "hex": "f2b67a"
+          },
+          {
+            "name": "Pastel Peanut",
+            "hex": "c29572"
+          },
+          {
+            "name": "Pastel Periwinkle",
+            "hex": "bfb2e6"
+          },
+          {
+            "name": "Pastel Watermelon",
+            "hex": "e93a3f"
+          },
+          {
+            "name": "Sakura Pink",
+            "hex": "e0a8bb"
+          },
+          {
+            "name": "Sapphire Blue",
+            "hex": "005aa2"
+          },
+          {
+            "name": "Savannah Yellow",
+            "hex": "f0be02"
+          },
+          {
+            "name": "Sky Blue",
+            "hex": "87ceeb"
+          },
+          {
+            "name": "Sunrise Orange",
+            "hex": "f78e0e"
+          },
+          {
+            "name": "Wood Brown",
+            "hex": "ad7441"
+          }
+        ]
+      }
     ]
 }

--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -1856,6 +1856,10 @@
             "bed_temp": 50,
             "colors": [
               {
+                "name": "Arctic Teal",
+                "hex": "5aabb1"
+              },
+              {
                 "name": "Army Beige",
                 "hex": "cca897"
               },
@@ -1877,19 +1881,15 @@
               },
               {
                 "name": "Army Purple",
-                "hex": "ffffff"
+                "hex": "292036"
               },
               {
                 "name": "Army Red",
                 "hex": "ac1a17"
               },
               {
-                "name": "Arctic Teal",
-                "hex": "5aabb1"
-              },
-              {
                 "name": "Ash Grey",
-                "hex": "ffffff"
+                "hex": "575e75"
               },
               {
                 "name": "Charcoal Black",
@@ -1901,11 +1901,11 @@
               },
               {
                 "name": "Earth Brown",
-                "hex": "623e2a"
+                "hex": "7c594a"
               },
               {
                 "name": "Electric Indigo",
-                "hex": "ffffff"
+                "hex": "764c99"
               },
               {
                 "name": "Forest Green",
@@ -1916,16 +1916,20 @@
                 "hex": "6f727e"
               },
               {
-                "name": "Lava Red",
-                "hex": "de1619"
-              },
-              {
                 "name": "Lavender Purple",
                 "hex": "8a68b5"
               },
               {
+                "name": "Lava Red",
+                "hex": "de1619"
+              },
+              {
                 "name": "Lime Green",
                 "hex": "d0e740"
+              },
+              {
+                "name": "Lotus Pink",
+                "hex": "f98289"
               },
               {
                 "name": "Muted Blue",
@@ -1960,6 +1964,10 @@
                 "hex": "95c5d3"
               },
               {
+                "name": "Pastel Mint",
+                "hex": "bec9a5"
+              },
+              {
                 "name": "Pastel Peach",
                 "hex": "f2b67a"
               },
@@ -1969,11 +1977,7 @@
               },
               {
                 "name": "Pastel Periwinkle",
-                "hex": "ffffff"
-              },
-              {
-                "name": "Pastel Mint",
-                "hex": "bec9a5"
+                "hex": "bfb2e6"
               },
               {
                 "name": "Pastel Watermelon",
@@ -1990,6 +1994,10 @@
               {
                 "name": "Savannah Yellow",
                 "hex": "f0be02"
+              },
+              {
+                "name": "Sky Blue",
+                "hex": "87ceeb"
               },
               {
                 "name": "Sunrise Orange",

--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -1855,150 +1855,150 @@
             "extruder_temp": 210,
             "bed_temp": 50,
             "colors": [
-                {
-                    "name": "Charcoal Black",
-                    "hex": "1c1c1c"
-                },
-                {
-                    "name": "Cotton White",
-                    "hex": "e6dddb"
-                },
-                {
-                    "name": "Army Beige",
-                    "hex": "cca897"
-                },
-                {
-                    "name": "Army Brown",
-                    "hex": "724e3d"
-                },
-                {
-                    "name": "Earth Brown",
-                    "hex": "623e2a"
-                },
-                {
-                    "name": "Muted White",
-                    "hex": "afa198"
-                },
-                {
-                    "name": "Pastel Peanut",
-                    "hex": "c29572"
-                },
-                {
-                    "name": "Wood Brown",
-                    "hex": "ad7441"
-                },
-                {
-                    "name": "Pastel Peach",
-                    "hex": "f2b67a"
-                },
-                {
-                    "name": "Sunrise Orange",
-                    "hex": "f78e0e"
-                },
-                {
-                    "name": "Pastel Banana",
-                    "hex": "f5cf6f"
-                },
-                {
-                    "name": "Army Light Green",
-                    "hex": "a78403"
-                },
-                {
-                    "name": "Savannah Yellow",
-                    "hex": "f0be02"
-                },
-                {
-                    "name": "Lime Green",
-                    "hex": "d0e740"
-                },
-                {
-                    "name": "Army Dark Green",
-                    "hex": "515234"
-                },
-                {
-                    "name": "Pastel Mint",
-                    "hex": "bec9a5"
-                },
-                {
-                    "name": "Muted Green",
-                    "hex": "656d60"
-                },
-                {
-                    "name": "Forest Green",
-                    "hex": "519f61"
-                },
-                {
-                    "name": "Arctic Teal",
-                    "hex": "5aabb1"
-                },
-                {
-                    "name": "Pastel Ice",
-                    "hex": "95c5d3"
-                },
-                {
-                    "name": "Sapphire Blue",
-                    "hex": "005aa2"
-                },
-                {
-                    "name": "Army Blue",
-                    "hex": "062b4d"
-                },
-                {
-                    "name": "Muted Blue",
-                    "hex": "4e6a84"
-                },
-                {
-                    "name": "Fossil Grey",
-                    "hex": "6f727e"
-                },
-                {
-                    "name": "Lavender Purple",
-                    "hex": "8a68b5"
-                },
-                {
-                    "name": "Muted Purple",
-                    "hex": "7c5577"
-                },
-                {
-                    "name": "Pastel Candy",
-                    "hex": "dabcc8"
-                },
-                {
-                    "name": "Sakura Pink",
-                    "hex": "e0a8bb"
-                },
-                {
-                    "name": "Pastel Watermelon",
-                    "hex": "e93a3f"
-                },
-                {
-                    "name": "Lava Red",
-                    "hex": "de1619"
-                },
-                {
-                    "name": "Army Red",
-                    "hex": "ac1a17"
-                },
-                {
-                    "name": "Muted Red",
-                    "hex": "db3e14"
-                },
-                {
-                    "name": "Army Purple",
-                    "hex": "ffffff"
-                },
-                {
-                    "name": "Ash Grey",
-                    "hex": "ffffff"
-                },
-                {
-                    "name": "Electric Indigo",
-                    "hex": "ffffff"
-                },
-                {
-                    "name": "Pastel Periwinkle",
-                    "hex": "ffffff"
-                }
+              {
+                "name": "Army Beige",
+                "hex": "cca897"
+              },
+              {
+                "name": "Army Blue",
+                "hex": "062b4d"
+              },
+              {
+                "name": "Army Brown",
+                "hex": "724e3d"
+              },
+              {
+                "name": "Army Dark Green",
+                "hex": "515234"
+              },
+              {
+                "name": "Army Light Green",
+                "hex": "a78403"
+              },
+              {
+                "name": "Army Purple",
+                "hex": "ffffff"
+              },
+              {
+                "name": "Army Red",
+                "hex": "ac1a17"
+              },
+              {
+                "name": "Arctic Teal",
+                "hex": "5aabb1"
+              },
+              {
+                "name": "Ash Grey",
+                "hex": "ffffff"
+              },
+              {
+                "name": "Charcoal Black",
+                "hex": "1c1c1c"
+              },
+              {
+                "name": "Cotton White",
+                "hex": "e6dddb"
+              },
+              {
+                "name": "Earth Brown",
+                "hex": "623e2a"
+              },
+              {
+                "name": "Electric Indigo",
+                "hex": "ffffff"
+              },
+              {
+                "name": "Forest Green",
+                "hex": "519f61"
+              },
+              {
+                "name": "Fossil Grey",
+                "hex": "6f727e"
+              },
+              {
+                "name": "Lava Red",
+                "hex": "de1619"
+              },
+              {
+                "name": "Lavender Purple",
+                "hex": "8a68b5"
+              },
+              {
+                "name": "Lime Green",
+                "hex": "d0e740"
+              },
+              {
+                "name": "Muted Blue",
+                "hex": "4e6a84"
+              },
+              {
+                "name": "Muted Green",
+                "hex": "656d60"
+              },
+              {
+                "name": "Muted Purple",
+                "hex": "7c5577"
+              },
+              {
+                "name": "Muted Red",
+                "hex": "db3e14"
+              },
+              {
+                "name": "Muted White",
+                "hex": "afa198"
+              },
+              {
+                "name": "Pastel Banana",
+                "hex": "f5cf6f"
+              },
+              {
+                "name": "Pastel Candy",
+                "hex": "dabcc8"
+              },
+              {
+                "name": "Pastel Ice",
+                "hex": "95c5d3"
+              },
+              {
+                "name": "Pastel Peach",
+                "hex": "f2b67a"
+              },
+              {
+                "name": "Pastel Peanut",
+                "hex": "c29572"
+              },
+              {
+                "name": "Pastel Periwinkle",
+                "hex": "ffffff"
+              },
+              {
+                "name": "Pastel Mint",
+                "hex": "bec9a5"
+              },
+              {
+                "name": "Pastel Watermelon",
+                "hex": "e93a3f"
+              },
+              {
+                "name": "Sakura Pink",
+                "hex": "e0a8bb"
+              },
+              {
+                "name": "Sapphire Blue",
+                "hex": "005aa2"
+              },
+              {
+                "name": "Savannah Yellow",
+                "hex": "f0be02"
+              },
+              {
+                "name": "Sunrise Orange",
+                "hex": "f78e0e"
+              },
+              {
+                "name": "Wood Brown",
+                "hex": "ad7441"
+              }
             ]
         }
     ]

--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -1835,7 +1835,7 @@
         ]
       },
       {
-            "name": "PolyTerra™ {color_name}",
+            "name": "Panchroma™ Matte (Formerly PolyTerra™) {color_name}",
             "material": "PLA",
             "density": 1.24,
             "weights": [


### PR DESCRIPTION
PolyTerra PLA is now Panchroma Matte PLA. https://us.polymaker.com/products/panchroma-matte

- adjusted the name to align with the polymaker 
- added colors that were not present
- updated hex codes to align with the stated hex codes from the polymaker specs
- updated hex codes that were set to white to the hex code used to represent the color on the polymaker site