### PR TITLE
Add Polymaker Marble PLA filaments & Geeetech PLA filaments Glow in the Dark

### DIFF
--- a/filaments/geeetech.json
+++ b/filaments/geeetech.json
@@ -61,6 +61,60 @@
             ]
         },
         {
+            "name": "Luminous {color_name}",
+            "material": "PLA",
+            "glow": true,
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Green",
+                    "hex": "00bc00"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "f0b200"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "f39f00"
+                },
+                {
+                    "name": "White",
+                    "hex": "97a2c2"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "01acf7"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "1429d2"
+                },
+                {
+                    "name": "Rose red",
+                    "hex": "d857df"
+                }
+            ]
+        },
+        {
             "name": "Matte {color_name}",
             "material": "PLA",
             "density": 1.31,

--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -330,7 +330,7 @@
           90,
           100
         ],
- 
+
         "colors": [
             {
                 "name": "Galaxy Dark Grey",
@@ -1028,7 +1028,7 @@
             ],
             "finish": "matte",
             "multi_color_direction": "coaxial"
-          }          
+          }
         ]
       },
       {
@@ -2006,6 +2006,52 @@
           {
             "name": "Wood Brown",
             "hex": "ad7441"
+          }
+        ]
+      },
+      {
+        "name": "Panchroma™ Marble (Formerly PolyTerra™ Marble) {color_name}",
+        "material": "PLA",
+        "pattern": "marble",
+        "density": 1.24,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "White",
+            "hex": "cfccd6"
+          },
+          {
+            "name": "Slate Grey",
+            "hex": "91c2cc"
+          },
+          {
+            "name": "Brick",
+            "hex": "cf6646"
+          },
+          {
+            "name": "Limestone",
+            "hex": "bfbfb3"
+          },
+          {
+            "name": "Sandstone",
+            "hex": "c6c781"
           }
         ]
       }


### PR DESCRIPTION
This pull request adds new filament entries to the `geeetech.json` and `polymaker.json` files, expanding the available options for 3D printing materials. The main changes are the addition of a luminous PLA filament for Geeetech and a marble-patterned PLA filament for Polymaker, each with detailed color and property definitions.

**New filament types and properties:**

*Geeetech:*
- Added a new luminous PLA filament entry (`Luminous {color_name}`) with glow properties and a range of color options, including Green, Yellow, Orange, White, Blue, Purple, and Rose red, _missing Multicolor_.

*Polymaker:*
- Added a new marble-patterned PLA filament entry (`Panchroma™ Marble (Formerly PolyTerra™ Marble) {color_name}`) with several color variants such as White, Slate Grey, Brick, Limestone, and Sandstone.

Color were chosen with color pipette when not directly given.