### PR TITLE
Update and add Overture PETG filaments

### DIFF
--- a/filaments/overture.json
+++ b/filaments/overture.json
@@ -166,7 +166,8 @@
             "weights": [
                 {
                     "weight": 1000.0,
-                    "spool_weight": 132
+                    "spool_weight": 132,
+                    "spool_type": "cardboard"
                 }
             ],
             "diameters": [


### PR DESCRIPTION
All and updated current Overture PETG filaments according to

https://overture3d.com/products/overture-petg

and

https://overture3d.com/cdn/shop/files/OVERTURE_PETG_TDS_EN_V5.1_dd9a50e3-8cc9-4067-b95b-870f56031a85.pdf?v=18084543551518595481

best regards
freakyDude