### PR TITLE
add soleyin PLAs

### DIFF
--- a/filaments/soleyin.json
+++ b/filaments/soleyin.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "Soleyin Ultra PLA {color_name}",
+    "material": "PLA",
+    "density": 1.25,
+    "weights": [
+      {
+        "weight": 1.0,
+        "spool_weight": 0.13,
+        "spool_type": "plastic"
+      }
+    ],
+    "diameters": [
+      1.75
+    ],
+    "extruder_temp": 210,
+    "bed_temp": 53,
+    "colors": [
+      {
+        "name": "Black",
+        "hex": "#000000"
+      },
+      {
+        "name": "Gray",
+        "hex": "#9EA2A2"
+      },
+      {
+        "name": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "name": "Almond Purple",
+        "hex": "#D9B8F1"
+      },
+      {
+        "name": "Greenery",
+        "hex": "#B2BA81"
+      },
+      {
+        "name": "Light Green",
+        "hex": "#B8F1CC"
+      },
+      {
+        "name": "Ocean Blue",
+        "hex": "#B8F1ED"
+      },
+      {
+        "name": "Pineapple Yellow",
+        "hex": "#FFE543"
+      },
+      {
+        "name": "Rosehip",
+        "hex": "#FD7D36"
+      },
+      {
+        "name": "Strawberry Milk",
+        "hex": "#F16D7A"
+      },
+      {
+        "name": "Matte Black",
+        "hex": "#000000",
+        "finish": "matte"
+      },
+      {
+        "name": "Matte Gray",
+        "hex": "#929292",
+        "finish": "matte"
+      },
+      {
+        "name": "Matte White",
+        "hex": "#FFFFFF",
+        "finish": "matte",
+        "comment": "Using standard White hex code as the specific matte hex was not available."
+      },
+      {
+        "name": "Matte Fluonte (Tri-Color)",
+        "hexes": [
+          "#69F793",
+          "#6DC1FD",
+          "#E290F9"
+        ],
+        "finish": "matte",
+        "multi_color_direction": "coaxial"
+      },
+      {
+        "name": "Matte Moonstone (Tri-Color)",
+        "hexes": [
+          "#DC8ADD",
+          "#99C1F1",
+          "#F9F06B"
+        ],
+        "finish": "matte",
+        "multi_color_direction": "coaxial"
+      },
+      {
+        "name": "Matte Rose Stone (Tri-Color)",
+        "hexes": [
+          "#67B9F4",
+          "#F1A6F7",
+          "#B861FF"
+        ],
+        "finish": "matte",
+        "multi_color_direction": "coaxial"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Added Soleyin (Creality SubBrand) PLA Filaments
https://store.creality.com/de/products/soleyin-ultra-pla-1-75mm-1kg

Infos from Webpage ( Names, Hex Codes, Generic Infos) , Measured (Spool weight) + My Filament Profiles (Tri Color Hex Codes)