### PR TITLE
Add Soleyin PLAs

### DIFF
--- a/filaments/soleyin.json
+++ b/filaments/soleyin.json
@@ -20,75 +20,75 @@
       "colors": [
         {
           "name": "Almond Purple",
-          "hex": "#D9B8F1"
+          "hex": "D9B8F1"
         },
         {
           "name": "Black",
-          "hex": "#000000"
+          "hex": "000000"
         },
         {
           "name": "Gray",
-          "hex": "#9EA2A2"
+          "hex": "9EA2A2"
         },
         {
           "name": "Greenery",
-          "hex": "#B2BA81"
+          "hex": "B2BA81"
         },
         {
           "name": "Light Green",
-          "hex": "#B8F1CC"
+          "hex": "B8F1CC"
         },
         {
           "name": "Ocean Blue",
-          "hex": "#B8F1ED"
+          "hex": "B8F1ED"
         },
         {
           "name": "Pineapple Yellow",
-          "hex": "#FFE543"
+          "hex": "FFE543"
         },
         {
           "name": "Rosehip",
-          "hex": "#FD7D36"
+          "hex": "FD7D36"
         },
         {
           "name": "Strawberry Milk",
-          "hex": "#F16D7A"
+          "hex": "F16D7A"
         },
         {
           "name": "White",
-          "hex": "#FFFFFF"
+          "hex": "FFFFFF"
         },
         {
           "name": "Matte Black",
-          "hex": "#000000",
+          "hex": "000000",
           "finish": "matte"
         },
         {
           "name": "Matte Fluorite",
           "hexes": [
-            "#69F793",
-            "#6DC1FD",
-            "#E290F9"
+            "69F793",
+            "6DC1FD",
+            "E290F9"
           ],
           "finish": "matte",
           "multi_color_direction": "coaxial"
         },
         {
           "name": "Matte Greenery",
-          "hex": "#6F907C",
+          "hex": "6F907C",
           "finish": "matte"
         },
         {
           "name": "Matte Grey",
-          "hex": "#929292",
+          "hex": "929292",
           "finish": "matte"
         },
         {
           "name": "Matte Moonstone",
           "hexes": [
-            "#DC8ADD",
-            "#99C1F1",
-            "#F9F06B"
+            "DC8ADD",
+            "99C1F1",
+            "F9F06B"
           ],
           "finish": "matte",
           "multi_color_direction": "coaxial"
@@ -96,16 +96,16 @@
         {
           "name": "Matte Rose Stone",
           "hexes": [
-            "#67B9F4",
-            "#F1A6F7",
-            "#B861FF"
+            "67B9F4",
+            "F1A6F7",
+            "B861FF"
           ],
           "finish": "matte",
           "multi_color_direction": "coaxial"
         },
         {
           "name": "Matte White",
-          "hex": "#FFFFFF",
+          "hex": "FFFFFF",
           "finish": "matte"
         }
       ]


### PR DESCRIPTION
Added Soleyin (Creality SubBrand) PLA Filaments
https://store.creality.com/de/products/soleyin-ultra-pla-1-75mm-1kg

Infos from Webpage ( Names, Hex Codes, Generic Infos) , Measured (Spool weight) + My Filament Profiles (Tri Color Hex Codes)