### PR TITLE
Add Bambu Lab PLA Tough+

### DIFF
--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -301,8 +301,8 @@
             ]
         },
         {
-            "name": "{color_name}",
-            "material": "PLA Tough+",
+            "name": "Tough+ {color_name}",
+            "material": "PLA",
             "density": 1.21,
             "weights": [
                 {

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -301,6 +301,52 @@
             ]
         },
         {
+            "name": "{color_name}",
+            "material": "PLA Tough+",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 245,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Yellow",
+                    "hex": "F4D53F"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "DC3A27"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "AFB1AE"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "959698"
+                },
+                {
+                    "name": "Cyan",
+                    "hex": "009BD8"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        },
+        {
             "name": "Silk {color_name}",
             "material": "PLA",
             "density": 1.32,


### PR DESCRIPTION
Information gathered from Bambu Lab store page for [PLA Tough+](https://eu.store.bambulab.com/products/pla-tough-upgrade). See "Filament TDS.pdf" (Filament Technical Data Sheet) under the Downloads section.