### PR TITLE
Add Prusament Carmine Red PETG

### DIFF
--- a/filaments/prusament.json
+++ b/filaments/prusament.json
@@ -101,6 +101,10 @@
                     "hex": "2B3B61"
                 },
                 {
+                    "name": "Carmine Red",
+                    "hex": "B54230"
+                },
+                {
                     "name": "Clear",
                     "hex": "dcdcdc"
                 }

--- a/filaments/prusament.json
+++ b/filaments/prusament.json
@@ -101,12 +101,39 @@
                     "hex": "2B3B61"
                 },
                 {
-                    "name": "Carmine Red",
-                    "hex": "B54230"
-                },
-                {
                     "name": "Clear",
                     "hex": "dcdcdc"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 193.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 250,
+            "extruder_temp_range": [
+                240,
+                260
+            ],
+            "bed_temp": 90,
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Carmine Red",
+                    "hex": "B54230"
                 }
             ]
         },


### PR DESCRIPTION
added missing PETG Garmine Red


[PETG Garmine Red](https://www.prusa3d.com/de/produkt/prusament-petg-carmine-red-1kg/)