### PR TITLE
Update density for DasFilament

### DIFF
--- a/filaments/dasfilament.json
+++ b/filaments/dasfilament.json
@@ -4,7 +4,7 @@
         {
             "name": "{color_name}",
             "material": "PLA",
-            "density": 1.23,
+            "density": 1.24,
             "weights": [
                 {
                     "weight": 800,
@@ -140,7 +140,7 @@
         {
             "name": "{color_name} - Refill",
             "material": "PLA",
-            "density": 1.23,
+            "density": 1.24,
             "weights": [
                 {
                     "weight": 800,
@@ -276,7 +276,7 @@
         {
             "name": "{color_name}",
             "material": "PETG",
-            "density": 1.27,
+            "density": 1.29,
             "weights": [
                 {
                     "weight": 800,
@@ -424,7 +424,7 @@
         {
             "name": "{color_name} - Refill",
             "material": "PETG",
-            "density": 1.27,
+            "density": 1.29,
             "weights": [
                 {
                     "weight": 800,


### PR DESCRIPTION
The density values for both PETG and PLA in `dasfilament.json` were differing from the manufacturer's specs. According to Das Filament their PLA has a density of 1.24 g/cm³ and their PETG of 1.29 g/cm³.

Also, an unrelated FYI: Das Filament are in the process of changing their spool sizes from 800g  to 1 kg.