### PR TITLE
Update esun.json

### DIFF
--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -880,7 +880,18 @@
             "material": "PETG",
             "density": 1.27,
             "extruder_temp": 260,
+            "extruder_temp_range": [250, 265],
             "bed_temp": 70,
+            "bed_temp_range": [65, 80],
+
+            "fill": null,
+            "finish": null,
+            "multi_color_direction": null,
+            "pattern": null,
+
+            "translucent": true,
+            "glow": false,
+            
             "weights": [
                 {
                     "weight": 1000,

--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -354,7 +354,7 @@
                     "hex": "ebcfa7"
                 }
             ]
-        },        
+        },
         {
             "name": "ePLA+HS {color_name}",
             "material": "PLA+",
@@ -690,7 +690,7 @@
                 }
             ]
         },
-     {
+        {
             "name": "PLA-Matte {color_name}",
             "material": "PLA",
             "density": 1.329,
@@ -849,7 +849,6 @@
             "extruder_temp": 220,
             "bed_temp": 60,
             "colors": [
-
                 {
                     "name": "Cored Luminous Orange",
                     "hex": "ff977f"
@@ -873,6 +872,29 @@
                 {
                     "name": "Luminous Blue",
                     "hex": "2c95cc"
+                }
+            ]
+        },
+        {
+            "name": "PETG-Basic {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "extruder_temp": "250-265",
+            "bed_temp": "65-80",
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 160,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "colors": [
+                {
+                    "name": "Transparent Orange",
+                    "hex": "ff8126"
                 }
             ]
         },
@@ -1070,12 +1092,27 @@
             "diameters": [
                 1.75
             ],
-            "extruder_temp_rang": [230, 270],
-            "bed_temp_range": [100, 115],
+            "extruder_temp_rang": [
+                230,
+                270
+            ],
+            "bed_temp_range": [
+                100,
+                115
+            ],
             "colors": [
-                {"name": "Black", "hex": "000000"},
-                {"name": "White", "hex": "ffffff"},
-                {"name": "Natural", "hex": "beb8ac"}
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "beb8ac"
+                }
             ]
         },
         {

--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -879,8 +879,8 @@
             "name": "PETG-Basic {color_name}",
             "material": "PETG",
             "density": 1.27,
-            "extruder_temp": "260",
-            "bed_temp": "70",
+            "extruder_temp": 250-265,
+            "bed_temp": 65-80,
             "weights": [
                 {
                     "weight": 1000,

--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -879,8 +879,8 @@
             "name": "PETG-Basic {color_name}",
             "material": "PETG",
             "density": 1.27,
-            "extruder_temp": "250-265",
-            "bed_temp": "65-80",
+            "extruder_temp": "260",
+            "bed_temp": "70",
             "weights": [
                 {
                     "weight": 1000,
@@ -893,7 +893,7 @@
             ],
             "colors": [
                 {
-                    "name": "Transparent Orange",
+                    "name": "Translucent Orange",
                     "hex": "ff8126"
                 }
             ]

--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -879,8 +879,8 @@
             "name": "PETG-Basic {color_name}",
             "material": "PETG",
             "density": 1.27,
-            "extruder_temp": 250-265,
-            "bed_temp": 65-80,
+            "extruder_temp": 260,
+            "bed_temp": 70,
             "weights": [
                 {
                     "weight": 1000,


### PR DESCRIPTION
Added eSUN PETG-Basic Transparent Orange (1.75mm, 1kg).

- Density: 1.27 g/cm³
- Nozzle temp: 250–265°C (from spool label)
- Bed temp: 65–80°C (from spool label)
- Cardboard spool, empty weight 160g (measured)
- Diameter: 1.75mm

Color name and hex aligned with existing eSun entries.