### PR TITLE
feat: add product identifier fields (code, ean, ean_refill)

### DIFF
--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -216,9 +216,11 @@
                                     "$comment": "Manufacturer product codes / SKUs for this color variant (e.g. Bambu Lab '10601' for PLA Basic Blue).",
                                     "type": "array",
                                     "items": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "minLength": 1
                                     },
-                                    "uniqueItems": true
+                                    "uniqueItems": true,
+                                    "minItems": 1
                                 },
                                 "eans": {
                                     "$comment": "EAN/GTIN barcodes for the spooled version of this color.",
@@ -227,7 +229,8 @@
                                         "type": "string",
                                         "pattern": "^[0-9]{8,14}$"
                                     },
-                                    "uniqueItems": true
+                                    "uniqueItems": true,
+                                    "minItems": 1
                                 },
                                 "eans_refill": {
                                     "$comment": "EAN/GTIN barcodes for the refill (no spool) version of this color.",
@@ -236,7 +239,8 @@
                                         "type": "string",
                                         "pattern": "^[0-9]{8,14}$"
                                     },
-                                    "uniqueItems": true
+                                    "uniqueItems": true,
+                                    "minItems": 1
                                 }
                             }
                         }

--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -211,6 +211,20 @@
                                 "glow": {
                                     "$comment": "True if this color has a glow-in-the-dark effect",
                                     "type": "boolean"
+                                },
+                                "code": {
+                                    "$comment": "Manufacturer product code / SKU for this color variant (e.g. Bambu Lab '10601' for PLA Basic Blue).",
+                                    "type": "string"
+                                },
+                                "ean": {
+                                    "$comment": "EAN/GTIN barcode for the spooled version of this color.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{8,14}$"
+                                },
+                                "ean_refill": {
+                                    "$comment": "EAN/GTIN barcode for the refill (no spool) version of this color.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{8,14}$"
                                 }
                             }
                         }

--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -212,19 +212,31 @@
                                     "$comment": "True if this color has a glow-in-the-dark effect",
                                     "type": "boolean"
                                 },
-                                "code": {
-                                    "$comment": "Manufacturer product code / SKU for this color variant (e.g. Bambu Lab '10601' for PLA Basic Blue).",
-                                    "type": "string"
+                                "codes": {
+                                    "$comment": "Manufacturer product codes / SKUs for this color variant (e.g. Bambu Lab '10601' for PLA Basic Blue).",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "uniqueItems": true
                                 },
-                                "ean": {
-                                    "$comment": "EAN/GTIN barcode for the spooled version of this color.",
-                                    "type": "string",
-                                    "pattern": "^[0-9]{8,14}$"
+                                "eans": {
+                                    "$comment": "EAN/GTIN barcodes for the spooled version of this color.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "pattern": "^[0-9]{8,14}$"
+                                    },
+                                    "uniqueItems": true
                                 },
-                                "ean_refill": {
-                                    "$comment": "EAN/GTIN barcode for the refill (no spool) version of this color.",
-                                    "type": "string",
-                                    "pattern": "^[0-9]{8,14}$"
+                                "eans_refill": {
+                                    "$comment": "EAN/GTIN barcodes for the refill (no spool) version of this color.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "pattern": "^[0-9]{8,14}$"
+                                    },
+                                    "uniqueItems": true
                                 }
                             }
                         }

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -20,8 +20,12 @@
                 {
                     "name": "Jade White",
                     "hex": "FFFFFF",
-                    "code": "10100",
-                    "ean": "6975337031024"
+                    "codes": [
+                        "10100"
+                    ],
+                    "eans": [
+                        "6975337031024"
+                    ]
                 },
                 {
                     "name": "Beige",
@@ -50,8 +54,12 @@
                 {
                     "name": "Cocoa Brown",
                     "hex": "6F5034",
-                    "code": "10802",
-                    "ean": "6977252429108"
+                    "codes": [
+                        "10802"
+                    ],
+                    "eans": [
+                        "6977252429108"
+                    ]
                 },
                 {
                     "name": "Maroon Red",
@@ -72,7 +80,9 @@
                 {
                     "name": "Hot Pink",
                     "hex": "F5547C",
-                    "code": "10204"
+                    "codes": [
+                        "10204"
+                    ]
                 },
                 {
                     "name": "Orange",
@@ -81,13 +91,19 @@
                 {
                     "name": "Pumpkin Orange",
                     "hex": "FF9016",
-                    "code": "10301"
+                    "codes": [
+                        "10301"
+                    ]
                 },
                 {
                     "name": "Sunflower Yellow",
                     "hex": "FEC600",
-                    "code": "10402",
-                    "ean": "6977252429122"
+                    "codes": [
+                        "10402"
+                    ],
+                    "eans": [
+                        "6977252429122"
+                    ]
                 },
                 {
                     "name": "Yellow",
@@ -100,7 +116,9 @@
                 {
                     "name": "Bambu Green",
                     "hex": "00AE42",
-                    "ean_refill": "6975337035817"
+                    "eans_refill": [
+                        "6975337035817"
+                    ]
                 },
                 {
                     "name": "Mistletoe Green",
@@ -109,20 +127,32 @@
                 {
                     "name": "Turquoise",
                     "hex": "00B1B7",
-                    "code": "10503",
-                    "ean_refill": "6977252427210"
+                    "codes": [
+                        "10503"
+                    ],
+                    "eans_refill": [
+                        "6977252427210"
+                    ]
                 },
                 {
                     "name": "Cyan",
                     "hex": "0086D6",
-                    "code": "10603",
-                    "ean": "6975337032052"
+                    "codes": [
+                        "10603"
+                    ],
+                    "eans": [
+                        "6975337032052"
+                    ]
                 },
                 {
                     "name": "Blue",
                     "hex": "0A2989",
-                    "code": "10601",
-                    "ean": "3119780059485"
+                    "codes": [
+                        "10601"
+                    ],
+                    "eans": [
+                        "3119780059485"
+                    ]
                 },
                 {
                     "name": "Cobalt Blue",
@@ -135,8 +165,12 @@
                 {
                     "name": "Indigo Purple",
                     "hex": "482960",
-                    "code": "10701",
-                    "ean": "6977252429115"
+                    "codes": [
+                        "10701"
+                    ],
+                    "eans": [
+                        "6977252429115"
+                    ]
                 },
                 {
                     "name": "Blue Gray",
@@ -153,7 +187,9 @@
                 {
                     "name": "Black",
                     "hex": "000000",
-                    "code": "10101"
+                    "codes": [
+                        "10101"
+                    ]
                 }
             ]
         },
@@ -219,8 +255,12 @@
                 {
                     "name": "Ivory White",
                     "hex": "FFFFFF",
-                    "code": "11100",
-                    "ean": "6975337031345"
+                    "codes": [
+                        "11100"
+                    ],
+                    "eans": [
+                        "6975337031345"
+                    ]
                 },
                 {
                     "name": "Latte Brown",
@@ -233,8 +273,12 @@
                 {
                     "name": "Ash Gray",
                     "hex": "9B9EA0",
-                    "code": "11102",
-                    "ean": "6975337031352"
+                    "codes": [
+                        "11102"
+                    ],
+                    "eans": [
+                        "6975337031352"
+                    ]
                 },
                 {
                     "name": "Lilac Purple",
@@ -255,8 +299,12 @@
                 {
                     "name": "Scarlet Red",
                     "hex": "DE4343",
-                    "code": "11200",
-                    "ean": "6975337031338"
+                    "codes": [
+                        "11200"
+                    ],
+                    "eans": [
+                        "6975337031338"
+                    ]
                 },
                 {
                     "name": "Dark Red",
@@ -281,7 +329,9 @@
                 {
                     "name": "Marine Blue",
                     "hex": "0078BF",
-                    "code": "11600"
+                    "codes": [
+                        "11600"
+                    ]
                 },
                 {
                     "name": "Dark Blue",
@@ -290,8 +340,12 @@
                 {
                     "name": "Charcoal",
                     "hex": "000000",
-                    "code": "11101",
-                    "ean": "6975337031376"
+                    "codes": [
+                        "11101"
+                    ],
+                    "eans": [
+                        "6975337031376"
+                    ]
                 },
                 {
                     "name": "Bone White",
@@ -346,8 +400,12 @@
                 {
                     "name": "Yellow",
                     "hex": "F4D53F",
-                    "code": "12401",
-                    "ean": "6937285500670"
+                    "codes": [
+                        "12401"
+                    ],
+                    "eans": [
+                        "6937285500670"
+                    ]
                 },
                 {
                     "name": "White",
@@ -1083,8 +1141,12 @@
                 {
                     "name": "Translucent Light Blue",
                     "hex": "61B0FF",
-                    "code": "32600",
-                    "ean": "6975337035961"
+                    "codes": [
+                        "32600"
+                    ],
+                    "eans": [
+                        "6975337035961"
+                    ]
                 },
                 {
                     "name": "Translucent Olive",
@@ -1097,8 +1159,12 @@
                 {
                     "name": "Translucent Teal",
                     "hex": "77EDD7",
-                    "code": "32501",
-                    "ean": "6975337035992"
+                    "codes": [
+                        "32501"
+                    ],
+                    "eans": [
+                        "6975337035992"
+                    ]
                 },
                 {
                     "name": "Translucent Orange",
@@ -1115,7 +1181,9 @@
                 {
                     "name": "Clear",
                     "hex": "FFFFFF",
-                    "code": "32101"
+                    "codes": [
+                        "32101"
+                    ]
                 }
             ]
         },
@@ -1155,12 +1223,16 @@
                 {
                     "name": "Blue",
                     "hex": "002E96",
-                    "code": "33600"
+                    "codes": [
+                        "33600"
+                    ]
                 },
                 {
                     "name": "Black",
                     "hex": "000000",
-                    "code": "33102"
+                    "codes": [
+                        "33102"
+                    ]
                 },
                 {
                     "name": "White",
@@ -1169,8 +1241,12 @@
                 {
                     "name": "Cream",
                     "hex": "F9DFB9",
-                    "code": "33401",
-                    "ean": "6937285507990"
+                    "codes": [
+                        "33401"
+                    ],
+                    "eans": [
+                        "6937285507990"
+                    ]
                 },
                 {
                     "name": "Lime Green",
@@ -1179,8 +1255,12 @@
                 {
                     "name": "Forest Green",
                     "hex": "39541A",
-                    "code": "33502",
-                    "ean": "6937285508010"
+                    "codes": [
+                        "33502"
+                    ],
+                    "eans": [
+                        "6937285508010"
+                    ]
                 },
                 {
                     "name": "Lake Blue",
@@ -1189,8 +1269,12 @@
                 {
                     "name": "Peanut Brown",
                     "hex": "875718",
-                    "code": "33801",
-                    "ean": "6937285508041"
+                    "codes": [
+                        "33801"
+                    ],
+                    "eans": [
+                        "6937285508041"
+                    ]
                 },
                 {
                     "name": "Gray",

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -19,7 +19,9 @@
             "colors": [
                 {
                     "name": "Jade White",
-                    "hex": "FFFFFF"
+                    "hex": "FFFFFF",
+                    "code": "10100",
+                    "ean": "6975337031024"
                 },
                 {
                     "name": "Beige",
@@ -47,7 +49,9 @@
                 },
                 {
                     "name": "Cocoa Brown",
-                    "hex": "6F5034"
+                    "hex": "6F5034",
+                    "code": "10802",
+                    "ean": "6977252429108"
                 },
                 {
                     "name": "Maroon Red",
@@ -67,7 +71,8 @@
                 },
                 {
                     "name": "Hot Pink",
-                    "hex": "F5547C"
+                    "hex": "F5547C",
+                    "code": "10204"
                 },
                 {
                     "name": "Orange",
@@ -75,11 +80,14 @@
                 },
                 {
                     "name": "Pumpkin Orange",
-                    "hex": "FF9016"
+                    "hex": "FF9016",
+                    "code": "10301"
                 },
                 {
                     "name": "Sunflower Yellow",
-                    "hex": "FEC600"
+                    "hex": "FEC600",
+                    "code": "10402",
+                    "ean": "6977252429122"
                 },
                 {
                     "name": "Yellow",
@@ -91,7 +99,8 @@
                 },
                 {
                     "name": "Bambu Green",
-                    "hex": "00AE42"
+                    "hex": "00AE42",
+                    "ean_refill": "6975337035817"
                 },
                 {
                     "name": "Mistletoe Green",
@@ -99,15 +108,21 @@
                 },
                 {
                     "name": "Turquoise",
-                    "hex": "00B1B7"
+                    "hex": "00B1B7",
+                    "code": "10503",
+                    "ean_refill": "6977252427210"
                 },
                 {
                     "name": "Cyan",
-                    "hex": "0086D6"
+                    "hex": "0086D6",
+                    "code": "10603",
+                    "ean": "6975337032052"
                 },
                 {
                     "name": "Blue",
-                    "hex": "0A2989"
+                    "hex": "0A2989",
+                    "code": "10601",
+                    "ean": "3119780059485"
                 },
                 {
                     "name": "Cobalt Blue",
@@ -119,7 +134,9 @@
                 },
                 {
                     "name": "Indigo Purple",
-                    "hex": "482960"
+                    "hex": "482960",
+                    "code": "10701",
+                    "ean": "6977252429115"
                 },
                 {
                     "name": "Blue Gray",
@@ -135,7 +152,8 @@
                 },
                 {
                     "name": "Black",
-                    "hex": "000000"
+                    "hex": "000000",
+                    "code": "10101"
                 }
             ]
         },
@@ -200,7 +218,9 @@
             "colors": [
                 {
                     "name": "Ivory White",
-                    "hex": "FFFFFF"
+                    "hex": "FFFFFF",
+                    "code": "11100",
+                    "ean": "6975337031345"
                 },
                 {
                     "name": "Latte Brown",
@@ -212,7 +232,9 @@
                 },
                 {
                     "name": "Ash Gray",
-                    "hex": "9B9EA0"
+                    "hex": "9B9EA0",
+                    "code": "11102",
+                    "ean": "6975337031352"
                 },
                 {
                     "name": "Lilac Purple",
@@ -232,7 +254,9 @@
                 },
                 {
                     "name": "Scarlet Red",
-                    "hex": "DE4343"
+                    "hex": "DE4343",
+                    "code": "11200",
+                    "ean": "6975337031338"
                 },
                 {
                     "name": "Dark Red",
@@ -256,7 +280,8 @@
                 },
                 {
                     "name": "Marine Blue",
-                    "hex": "0078BF"
+                    "hex": "0078BF",
+                    "code": "11600"
                 },
                 {
                     "name": "Dark Blue",
@@ -264,7 +289,9 @@
                 },
                 {
                     "name": "Charcoal",
-                    "hex": "000000"
+                    "hex": "000000",
+                    "code": "11101",
+                    "ean": "6975337031376"
                 },
                 {
                     "name": "Bone White",
@@ -318,7 +345,9 @@
             "colors": [
                 {
                     "name": "Yellow",
-                    "hex": "F4D53F"
+                    "hex": "F4D53F",
+                    "code": "12401",
+                    "ean": "6937285500670"
                 },
                 {
                     "name": "White",
@@ -1053,7 +1082,9 @@
                 },
                 {
                     "name": "Translucent Light Blue",
-                    "hex": "61B0FF"
+                    "hex": "61B0FF",
+                    "code": "32600",
+                    "ean": "6975337035961"
                 },
                 {
                     "name": "Translucent Olive",
@@ -1065,7 +1096,9 @@
                 },
                 {
                     "name": "Translucent Teal",
-                    "hex": "77EDD7"
+                    "hex": "77EDD7",
+                    "code": "32501",
+                    "ean": "6975337035992"
                 },
                 {
                     "name": "Translucent Orange",
@@ -1081,7 +1114,8 @@
                 },
                 {
                     "name": "Clear",
-                    "hex": "FFFFFF"
+                    "hex": "FFFFFF",
+                    "code": "32101"
                 }
             ]
         },
@@ -1120,11 +1154,13 @@
                 },
                 {
                     "name": "Blue",
-                    "hex": "002E96"
+                    "hex": "002E96",
+                    "code": "33600"
                 },
                 {
                     "name": "Black",
-                    "hex": "000000"
+                    "hex": "000000",
+                    "code": "33102"
                 },
                 {
                     "name": "White",
@@ -1132,7 +1168,9 @@
                 },
                 {
                     "name": "Cream",
-                    "hex": "F9DFB9"
+                    "hex": "F9DFB9",
+                    "code": "33401",
+                    "ean": "6937285507990"
                 },
                 {
                     "name": "Lime Green",
@@ -1140,7 +1178,9 @@
                 },
                 {
                     "name": "Forest Green",
-                    "hex": "39541A"
+                    "hex": "39541A",
+                    "code": "33502",
+                    "ean": "6937285508010"
                 },
                 {
                     "name": "Lake Blue",
@@ -1148,7 +1188,9 @@
                 },
                 {
                     "name": "Peanut Brown",
-                    "hex": "875718"
+                    "hex": "875718",
+                    "code": "33801",
+                    "ean": "6937285508041"
                 },
                 {
                     "name": "Gray",

--- a/scripts/compile_filaments.py
+++ b/scripts/compile_filaments.py
@@ -43,6 +43,9 @@ class Color(TypedDict):
     pattern: NotRequired[Pattern | None]
     translucent: NotRequired[bool]
     glow: NotRequired[bool]
+    codes: NotRequired[list[str]]
+    eans: NotRequired[list[str]]
+    eans_refill: NotRequired[list[str]]
 
 
 class Filament(TypedDict):
@@ -126,6 +129,9 @@ def expand_filament_data(manufacturer: str, data: Filament) -> Iterator[dict]:
                 color_pattern = color_obj.get("pattern", None)
                 color_translucent = color_obj.get("translucent", None)
                 color_glow = color_obj.get("glow", None)
+                color_codes = color_obj.get("codes", None)
+                color_eans = color_obj.get("eans", None)
+                color_eans_refill = color_obj.get("eans_refill", None)
 
                 if color_finish is None:
                     color_finish = finish
@@ -192,6 +198,9 @@ def expand_filament_data(manufacturer: str, data: Filament) -> Iterator[dict]:
                     "pattern": color_pattern,
                     "translucent": color_translucent,
                     "glow": color_glow,
+                    "codes": color_codes,
+                    "eans": color_eans,
+                    "eans_refill": color_eans_refill,
                 }
 
 


### PR DESCRIPTION
## Summary

Adds three optional fields to the color object in `filaments.schema.json`:

- **`code`** — Manufacturer product code / SKU (e.g. Bambu Lab `10601` for PLA Basic Blue)
- **`ean`** — EAN/GTIN barcode for the spooled version
- **`ean_refill`** — EAN/GTIN barcode for the refill (no spool) version

This addresses the need discussed in #198 for product identification fields. The schema distinguishes between:

1. **Manufacturer codes** (`code`) — internal product IDs used by manufacturers (e.g. Bambu Lab's 5-digit codes)
2. **Barcodes** (`ean`, `ean_refill`) — physical EAN/GTIN codes found on packaging, separated by packaging type since many manufacturers sell both spooled and refill versions with different barcodes

### Data included

Verified identifiers for **25 Bambu Lab colors** across:
- PLA Basic (11 colors)
- PLA Matte (5 colors)
- PLA Tough+ (1 color)
- PETG HF (5 colors)
- PETG Translucent (3 colors)

All EAN codes were physically scanned from packaging. Product codes are from the Bambu Lab website.

### Example

```json
{
    "name": "Jade White",
    "hex": "FFFFFF",
    "code": "10100",
    "ean": "6975337031024"
}
```

### Schema additions

All fields are optional and backward-compatible:

```json
"code": { "type": "string" },
"ean": { "type": "string", "pattern": "^[0-9]{8,14}$" },
"ean_refill": { "type": "string", "pattern": "^[0-9]{8,14}$" }
```

Relates to #198