### PR TITLE
Fix extruder_temp schema errors, add ASA-X/ABS-T variants and REDLINE FILAMENT

### DIFF
--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -29,9 +29,9 @@
                         "pattern": "\\{"
                     },
                     "material": {
-                        "$comment": "Valid materials must be uppercase letters and numbers, optionally separated by + or -. Optionally ends with -CF or -GF followed by a number. Examples: ABS, ABS-CF, PC+ABS, PC+ABS-CF10.",
+                        "$comment": "Valid materials must be uppercase letters and numbers, optionally separated by + or -. Optionally ends with -CF or -GF followed by a number, or a single-letter variant suffix (-X, -T). Examples: ABS, ABS-CF, ABS-T, ASA-X, PC+ABS, PC+ABS-CF10.",
                         "type": "string",
-                        "pattern": "^[A-Z0-9]+(\\+[A-Z0-9]+)*(-(CF\\d{0,2}|GF\\d{0,2}|\\d{2}[AD]))?\\+?$"
+                        "pattern": "^[A-Z0-9]+(\\+[A-Z0-9]+)*(-(CF\\d{0,2}|GF\\d{0,2}|\\d{2}[AD]|X|T))?\\+?$"
                     },
                     "density": {
                         "type": "number",

--- a/filaments/Numakers.json
+++ b/filaments/Numakers.json
@@ -330,7 +330,7 @@
             "diameters": [
                 1.75
             ],
-            "extruder_temp_Range": [
+            "extruder_temp_range": [
                 210,
                 240
             ],

--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -1070,7 +1070,7 @@
             "diameters": [
                 1.75
             ],
-            "extruder_temp_rang": [230, 270],
+            "extruder_temp_range": [230, 270],
             "bed_temp_range": [100, 115],
             "colors": [
                 {"name": "Black", "hex": "000000"},

--- a/filaments/ldo.json
+++ b/filaments/ldo.json
@@ -14,7 +14,7 @@
             "diameters": [
                 1.75
             ],
-			"extruder_temp ": 260,
+			"extruder_temp": 260,
 			"bed_temp_range": [
 				90,
 				110
@@ -74,7 +74,7 @@
             "diameters": [
                 1.75
             ],
-			"extruder_temp ": 260,
+			"extruder_temp": 260,
 			"bed_temp_range": [
 				90,
 				110

--- a/filaments/redlinefilament.json
+++ b/filaments/redlinefilament.json
@@ -3,6 +3,81 @@
     "filaments": [
         {
             "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 155,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                195,
+                215
+            ],
+            "bed_temp_range": [
+                0,
+                60
+            ],
+            "colors": [
+                {"name": "Beige", "hex": "c2b078"},
+                {"name": "Maisgelb", "hex": "e3a500"},
+                {"name": "Elfenbein", "hex": "e6d2b5"},
+                {"name": "Schwefelgelb", "hex": "f5d033"},
+                {"name": "Gelb", "hex": "fad201"},
+                {"name": "Goldbraun", "hex": "a38c15"},
+                {"name": "Bronzegold", "hex": "9f8932"},
+                {"name": "Gelborange", "hex": "f0a500"},
+                {"name": "Hellorange", "hex": "ed760e"},
+                {"name": "Orange", "hex": "f3752b"},
+                {"name": "Weinrot (Braunrot)", "hex": "412227"},
+                {"name": "Rot", "hex": "cc2529"},
+                {"name": "Orientrot", "hex": "763420"},
+                {"name": "Lila", "hex": "8d7598"},
+                {"name": "Magenta", "hex": "c63678"},
+                {"name": "Lavendel", "hex": "a5154a"},
+                {"name": "Dunkelblau", "hex": "20214f"},
+                {"name": "Kobaltblau", "hex": "1d1f5b"},
+                {"name": "Himmelblau", "hex": "2271b3"},
+                {"name": "Islandblau", "hex": "6daedd", "translucent": true},
+                {"name": "Taubenblau", "hex": "6d8099"},
+                {"name": "Wasserblau", "hex": "358698"},
+                {"name": "Blattgrün", "hex": "4d7c43"},
+                {"name": "Dunkelgrün", "hex": "1e6b4a"},
+                {"name": "Apfelgrün", "hex": "36b336"},
+                {"name": "Olivgrün", "hex": "3f4030"},
+                {"name": "Leichtes Grün", "hex": "a8d8cb"},
+                {"name": "Grau", "hex": "7e8b92"},
+                {"name": "Khaki", "hex": "6a5f31"},
+                {"name": "Eisengrau", "hex": "4e5965"},
+                {"name": "Hellgrau", "hex": "d7d7d7"},
+                {"name": "Kupferbraun", "hex": "8e402a"},
+                {"name": "Braun", "hex": "59351f"},
+                {"name": "Beigebraun", "hex": "7b5141"},
+                {"name": "Crem Weiß (Perlweiß)", "hex": "fdf4e3"},
+                {"name": "Weiß", "hex": "f4f4f4"},
+                {"name": "Silber", "hex": "a5a5a5"},
+                {"name": "Schwarz", "hex": "1e1e1e"},
+                {"name": "Neon Grün", "hex": "00b140", "translucent": true},
+                {"name": "Neon Pink", "hex": "fe17a2"},
+                {"name": "Neon Orange", "hex": "fe5000", "translucent": true},
+                {"name": "Leichtes Blau", "hex": "74b2dd"},
+                {"name": "Neon Gelb", "hex": "d4ed47", "translucent": true},
+                {"name": "Gelbgold", "hex": "c9a96e"},
+                {"name": "Neon Transparent", "hex": "b8d4e8", "translucent": true},
+                {"name": "Leichtes Pink", "hex": "f9c4ba"},
+                {"name": "Blau", "hex": "1b4f8a"},
+                {"name": "Natur Transparent", "hex": "e8e4d8", "translucent": true},
+                {"name": "Glow in the Dark (Grün)", "hex": "c8e04a", "glow": true},
+                {"name": "Glow in the Dark (Blau)", "hex": "5bb8f5", "glow": true}
+            ]
+        },
+        {
+            "name": "{color_name}",
             "material": "ASA-X",
             "density": 1.11,
             "weights": [
@@ -15,6 +90,7 @@
             "diameters": [
                 1.75
             ],
+            "extruder_temp": 255,
             "extruder_temp_range": [
                 235,
                 255
@@ -24,62 +100,20 @@
                 90
             ],
             "colors": [
-                {
-                    "name": "Schwarz",
-                    "hex": "1e1e1e"
-                },
-                {
-                    "name": "Weiß",
-                    "hex": "f4f4f4"
-                },
-                {
-                    "name": "Rot",
-                    "hex": "cc2529"
-                },
-                {
-                    "name": "Dunkelblau",
-                    "hex": "20214f"
-                },
-                {
-                    "name": "Eisengrau",
-                    "hex": "4e5965"
-                },
-                {
-                    "name": "Hellgrau",
-                    "hex": "d7d7d7"
-                },
-                {
-                    "name": "Verkehrsblau",
-                    "hex": "2271b3"
-                },
-                {
-                    "name": "Apfelgrün",
-                    "hex": "57a639"
-                },
-                {
-                    "name": "Blattgrün",
-                    "hex": "4d7c43"
-                },
-                {
-                    "name": "Dunkelsilber",
-                    "hex": "9a9697"
-                },
-                {
-                    "name": "Orange",
-                    "hex": "f3752b"
-                },
-                {
-                    "name": "Gelb",
-                    "hex": "fad201"
-                },
-                {
-                    "name": "Glitzer Eisengau",
-                    "hex": "535a5e"
-                },
-                {
-                    "name": "Glitzer Oxidrot",
-                    "hex": "911e1e"
-                }
+                {"name": "Schwarz", "hex": "1e1e1e"},
+                {"name": "Weiß", "hex": "f4f4f4"},
+                {"name": "Rot", "hex": "cc2529"},
+                {"name": "Dunkelblau", "hex": "20214f"},
+                {"name": "Eisengrau", "hex": "4e5965"},
+                {"name": "Hellgrau", "hex": "d7d7d7"},
+                {"name": "Verkehrsblau", "hex": "2271b3"},
+                {"name": "Apfelgrün", "hex": "57a639"},
+                {"name": "Blattgrün", "hex": "4d7c43"},
+                {"name": "Dunkelsilber", "hex": "9a9697"},
+                {"name": "Orange", "hex": "f3752b"},
+                {"name": "Gelb", "hex": "fad201"},
+                {"name": "Glitzer Eisengau", "hex": "535a5e", "pattern": "sparkle"},
+                {"name": "Glitzer Oxidrot", "hex": "911e1e", "pattern": "sparkle"}
             ]
         }
     ]

--- a/filaments/redlinefilament.json
+++ b/filaments/redlinefilament.json
@@ -4,7 +4,7 @@
         {
             "name": "{color_name}",
             "material": "PLA",
-            "density": 1.25,
+            "density": 1.24,
             "weights": [
                 {
                     "weight": 1000,

--- a/filaments/redlinefilament.json
+++ b/filaments/redlinefilament.json
@@ -1,0 +1,86 @@
+{
+    "manufacturer": "REDLINE FILAMENT",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "ASA-X",
+            "density": 1.11,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 155,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                235,
+                255
+            ],
+            "bed_temp_range": [
+                80,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Schwarz",
+                    "hex": "1e1e1e"
+                },
+                {
+                    "name": "Weiß",
+                    "hex": "f4f4f4"
+                },
+                {
+                    "name": "Rot",
+                    "hex": "cc2529"
+                },
+                {
+                    "name": "Dunkelblau",
+                    "hex": "20214f"
+                },
+                {
+                    "name": "Eisengrau",
+                    "hex": "4e5965"
+                },
+                {
+                    "name": "Hellgrau",
+                    "hex": "d7d7d7"
+                },
+                {
+                    "name": "Verkehrsblau",
+                    "hex": "2271b3"
+                },
+                {
+                    "name": "Apfelgrün",
+                    "hex": "57a639"
+                },
+                {
+                    "name": "Blattgrün",
+                    "hex": "4d7c43"
+                },
+                {
+                    "name": "Dunkelsilber",
+                    "hex": "9a9697"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "f3752b"
+                },
+                {
+                    "name": "Gelb",
+                    "hex": "fad201"
+                },
+                {
+                    "name": "Glitzer Eisengau",
+                    "hex": "535a5e"
+                },
+                {
+                    "name": "Glitzer Oxidrot",
+                    "hex": "911e1e"
+                }
+            ]
+        }
+    ]
+}

--- a/materials.json
+++ b/materials.json
@@ -64,6 +64,10 @@
         "density": 1.05
     },
     {
+        "material": "ASA-X",
+        "density": 1.11
+    },
+    {
         "material": "Polypropylene (PP)",
         "density": 0.9
     },


### PR DESCRIPTION
- Also fixes invalid `extruder_temp` key names in ldo, esun, and Numakers
- Adds ASA-X and ABS-T as valid material variants to the filaments schema
- Add new manufacturer REDLINE FILAMENT GmbH (Neuss, Germany)
- PLA filament with 50 colors
- ASA-X filament with 12 standard colors and 2 glitter variants