### PR TITLE
Fix Bambu Lab hex codes and add missing filaments

### DIFF
--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -836,8 +836,8 @@
                     "name": "Aurora Purple (Blue-Purple)",
                     "multi_color_direction": "longitudinal",
                     "hexes": [
-                        "1E63BF",
-                        "713D9C"
+                        "7F3696",
+                        "006EC9"
                     ]
                 }
             ]

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -982,7 +982,7 @@
                 },
                 {
                     "name": "Gray",
-                    "hex": "9EA2A2"
+                    "hex": "7F7E83"
                 },
                 {
                     "name": "Blue Gray",
@@ -1378,7 +1378,7 @@
                 },
                 {
                     "name": "Clear Black",
-                    "hex": "5A5161"
+                    "hex": "000000"
                 },
                 {
                     "name": "Black",

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -776,6 +776,13 @@
                         "F78F77",
                         "E4505A"
                     ]
+                },
+                {
+                    "name": "Dusk Glare",
+                    "hexes": [
+                        "ED9558",
+                        "CE4406"
+                    ]
                 }
             ]
         },
@@ -839,6 +846,96 @@
                         "7F3696",
                         "006EC9"
                     ]
+                },
+                {
+                    "name": "South Beach",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "F772A4",
+                        "00918B"
+                    ]
+                },
+                {
+                    "name": "Dawn Radiance",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "EC984C",
+                        "6CD4BC",
+                        "A66EB9",
+                        "D87694"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Lite {color_name}",
+            "material": "PLA",
+            "density": 1.4,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 35,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "999D9D"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Red",
+                    "hex": "C6001A"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "EFE255"
+                },
+                {
+                    "name": "Cyan",
+                    "hex": "4DAFDA"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "004EA8"
+                }
+            ]
+        },
+        {
+            "name": "Aero {color_name}",
+            "material": "PLA",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 235,
+            "bed_temp": 35,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
                 }
             ]
         },
@@ -1023,6 +1120,10 @@
                 {
                     "name": "Purple",
                     "hex": "9E007E"
+                },
+                {
+                    "name": "Dark Brown",
+                    "hex": "4F2C1D"
                 },
                 {
                     "name": "Black",


### PR DESCRIPTION
Fix Bambu Lab hex codes and add missing filaments

## Fixes

- PETG Basic Gray: `9EA2A2` -> `7F7E83`
- PC Clear Black: `5A5161` -> `000000`
- PLA Silk Multi-Color Aurora Purple: `1E63BF, 713D9C` -> `7F3696, 006EC9`

## Additions

- PLA Basic Gradient: Dusk Glare
- PLA Silk Multi-Color: South Beach, Dawn Radiance (4-color)
- PETG Basic: Dark Brown
- PLA Aero (new type): White, Black
- PLA Lite (new type): White, Gray, Black, Red, Yellow, Cyan, Blue

## Sources

Verified against Bambu Lab's official hex code PDFs and store page:
- PETG Basic : https://store.bblcdn.com/s1/default/1e4af3b3c12948ccb04433a8499c3264/PETG_Basic_Hex_Code_Table.pdf)
- PLA Silk Multi-Color : https://store.bblcdn.com/s1/default/7e3a5dec148b468d862d96593d01d624/PLA_Silk_Mutil-color_Hex_Code_Table.pdf
- PLA Basic Gradient (Dusk Glare) : https://eu.store.bambulab.com/fr/products/pla-basic-gradient

PLA Aero and PLA Lite values come from BambuStudio's [filaments_color_codes.json](https://github.com/bambulab/BambuStudio/blob/master/resources/profiles/BBL/filament/filaments_color_codes.json) (no standalone PDF available).
