### PR TITLE
Added entry for  Sunlu Clear PLA.

### DIFF
--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -284,6 +284,11 @@
                 {
                     "name": "Sunny Orange",
                     "hex": "D8631E"
+                },
+                {
+                    "name": "Clear",
+                    "hex": "#ffffffaa",
+                    "translucent": true
                 }
             ]
         },

--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -287,7 +287,7 @@
                 },
                 {
                     "name": "Clear",
-                    "hex": "#ffffffaa",
+                    "hex": "ffffffaa",
                     "translucent": true
                 }
             ]


### PR DESCRIPTION
Entry for Sunlu Clear/Transparent PLA.  I can't find it on their website but i bought it from Amazon on 4/27/24.  [Amazon page here](https://www.amazon.com/dp/B07ZNG4L9P?th=1).