### PR TITLE
feat: add and update community filament definitions

### DIFF
--- a/filaments/1233d.json
+++ b/filaments/1233d.json
@@ -1,0 +1,764 @@
+{
+  "manufacturer": "123-3D",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        265
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Neutral",
+          "hex": "fdfdf5"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        245
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "000000"
+        },
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Aero {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "test",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        245
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Green - Blue",
+          "hex": "38a64d"
+        },
+        {
+          "name": "Paars-Roze",
+          "hex": "4c2e78"
+        },
+        {
+          "name": "Red / Yellow",
+          "hexes": [
+            "ff0000",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Yellow",
+          "hex": "dee10e"
+        }
+      ]
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "green",
+          "hex": "bfff00"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "aa9220",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Red",
+          "hex": "9c3c2f",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000a4"
+        },
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PCTG {color_name}",
+      "material": "PCTG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        275
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "White",
+          "hex": "fafafa"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        245
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "575757"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff9224"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0080ff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Yest",
+          "hex": "45c8d6"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "pink",
+          "hex": "e9a7b4"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        235
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Jupiter-Silver",
+          "hex": "747576"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Brown",
+          "hex": "422d00"
+        },
+        {
+          "name": "Crème Wit",
+          "hex": "f9f0dd"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "05158f"
+        },
+        {
+          "name": "Glow in the Dark Groen",
+          "hex": "e2deb1"
+        },
+        {
+          "name": "Green",
+          "hex": "14525f"
+        },
+        {
+          "name": "Grey",
+          "hex": "4f4f4f"
+        },
+        {
+          "name": "Groen",
+          "hex": "204a23"
+        },
+        {
+          "name": "Jupiter Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Leafy Green",
+          "hex": "325928"
+        },
+        {
+          "name": "Lichtgrijs",
+          "hex": "c7c7c7"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "fc8aec"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "a9f769"
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff"
+        },
+        {
+          "name": "Nude",
+          "hex": "fdc8a5"
+        },
+        {
+          "name": "Orange",
+          "hex": "f99201"
+        },
+        {
+          "name": "Pastel mint-green",
+          "hex": "d3f6ed"
+        },
+        {
+          "name": "Pastel Rose",
+          "hex": "ffbdbd"
+        },
+        {
+          "name": "Pastel Turquoise",
+          "hex": "87cec9"
+        },
+        {
+          "name": "Purple",
+          "hex": "4e028d"
+        },
+        {
+          "name": "Red",
+          "hex": "e02a25"
+        },
+        {
+          "name": "Satin",
+          "hex": "dfdfdf"
+        },
+        {
+          "name": "sky blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Snow white",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Sulfur Yellow",
+          "hex": "f9f568"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Rose red + sky blue + green",
+          "hexes": [
+            "00ffff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "f0f0f0"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        240
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Translucent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Traslucent PETG",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "000000"
+        },
+        {
+          "name": "red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PCTG",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        275
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent Red",
+          "hex": "b80011"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Bio Oak Wood",
+          "hex": "f9e59f"
+        },
+        {
+          "name": "Dennen",
+          "hex": "9d8568"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/22network.json
+++ b/filaments/22network.json
@@ -1,0 +1,241 @@
+{
+  "manufacturer": "22 Network",
+  "filaments": [
+    {
+      "name": "{color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 65],
+      "colors": [
+        {"name": "Cold White", "hex": "F5F5F5", "codes": ["33100"]},
+        {"name": "Warm White", "hex": "FAF0E6", "codes": ["10100"]},
+        {"name": "Black", "hex": "000000", "codes": ["10101"]},
+        {"name": "Light Grey", "hex": "D3D3D3", "codes": ["10104"]},
+        {"name": "Grey", "hex": "808080", "codes": ["10103"]},
+        {"name": "Grey Blue", "hex": "6699CC", "codes": ["10602"]},
+        {"name": "Dark Grey", "hex": "404040", "codes": ["10105"]},
+        {"name": "Red", "hex": "E30613", "codes": ["10200"]},
+        {"name": "Rouge Red", "hex": "A52A2A", "codes": ["10205"]},
+        {"name": "Sky Blue", "hex": "87CEEB", "codes": ["11601"]},
+        {"name": "Turquoise Green", "hex": "40E0D0", "codes": ["10605"]},
+        {"name": "Cyan", "hex": "00FFFF", "codes": ["10603"]},
+        {"name": "Cobalt Blue", "hex": "0047AB", "codes": ["10604"]},
+        {"name": "Blue Grey", "hex": "6699AA", "codes": ["2157C"]},
+        {"name": "Dark Blue", "hex": "00008B", "codes": ["10601"]},
+        {"name": "Army Blue", "hex": "002868", "codes": ["2140C"]},
+        {"name": "Dark Night Blue", "hex": "191970", "codes": ["11602"]},
+        {"name": "Apple Green", "hex": "8DB600", "codes": ["10503"]},
+        {"name": "Grass Green", "hex": "7CFC00", "codes": ["11500"]},
+        {"name": "Bambu Green", "hex": "228B22", "codes": ["10501"]},
+        {"name": "Christmas Green", "hex": "008000", "codes": ["10502"]},
+        {"name": "Dark Night Green", "hex": "013220", "codes": ["11501"]},
+        {"name": "Lilac Purple", "hex": "C8A2C8", "codes": ["11700"]},
+        {"name": "Purple", "hex": "800080", "codes": ["10700"]},
+        {"name": "Violet Purple", "hex": "4B0082", "codes": ["10701"]},
+        {"name": "Orange", "hex": "FF6600", "codes": ["10300"]},
+        {"name": "Pumpkin Orange", "hex": "FF7518", "codes": ["10301"]},
+        {"name": "Bronze", "hex": "CD7F32", "codes": ["10801"]},
+        {"name": "Brown", "hex": "8B4513", "codes": ["10800"]},
+        {"name": "Dark Night Brown", "hex": "3D2B1F", "codes": ["11801"]},
+        {"name": "Coco Brown", "hex": "6F4E37", "codes": ["10802"]},
+        {"name": "Dark Brown", "hex": "654321", "codes": ["11802"]},
+        {"name": "Pale Apricot", "hex": "FBE7B2", "codes": ["10201"]},
+        {"name": "Dessert Yellow", "hex": "F5DEB3", "codes": ["11401"]},
+        {"name": "Latte Brown", "hex": "C4A484", "codes": ["11800"]},
+        {"name": "Warm Yellow", "hex": "F5DEB3", "codes": ["10402"]},
+        {"name": "Yellow", "hex": "FFFF00", "codes": ["10400"]},
+        {"name": "Cherry Blossom", "hex": "FFB7C5", "codes": ["11201"]},
+        {"name": "Red Pink", "hex": "FF69B4", "codes": ["10204"]},
+        {"name": "Pink", "hex": "FFC0CB", "codes": ["10203"]},
+        {"name": "Magenta Red", "hex": "FF00FF", "codes": ["10202"]},
+        {"name": "Gold", "hex": "FFD700", "codes": ["10401"]},
+        {"name": "Silver", "hex": "C0C0C0", "codes": ["10102"]},
+        {"name": "Butter Yellow", "hex": "FFFACD", "codes": ["88101"]},
+        {"name": "Dusty Pink", "hex": "D8BFD8", "codes": ["88102"]},
+        {"name": "Azure Blue", "hex": "007FFF", "codes": ["88103"]},
+        {"name": "American Yellow", "hex": "FFAA1D", "codes": ["88104"]},
+        {"name": "Skin", "hex": "E8BEAC", "codes": ["88105"]},
+        {"name": "Forest Green", "hex": "228B22", "codes": ["88106"]},
+        {"name": "Fluorescent Green", "hex": "39FF14", "codes": ["88107"]},
+        {"name": "Fluorescent Orange", "hex": "FFBF00", "codes": ["88108"]},
+        {"name": "Rose Red", "hex": "C21E56", "codes": ["88109"]},
+        {"name": "Fluorescent Yellow", "hex": "CCFF00", "codes": ["88110"]}
+      ]
+    },
+    {
+      "name": "Luminous {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 65],
+      "glow": true,
+      "colors": [
+        {"name": "Green", "hex": "ADFF2F", "codes": ["Luminous Green"]},
+        {"name": "Blue", "hex": "00BFFF", "codes": ["Luminous Blue"]}
+      ]
+    },
+    {
+      "name": "Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 65],
+      "finish": "glossy",
+      "colors": [
+        {"name": "White", "hex": "FFFFFF", "codes": ["silk001"]},
+        {"name": "Yellow", "hex": "FFFF00", "codes": ["silk002"]},
+        {"name": "China Red", "hex": "E32636", "codes": ["silk003"]},
+        {"name": "Blue", "hex": "0000FF", "codes": ["silk004"]},
+        {"name": "Yellow-Gold", "hex": "FFD700", "codes": ["silk005"]},
+        {"name": "Silver", "hex": "C0C0C0", "codes": ["silk006"]},
+        {"name": "Purple", "hex": "800080", "codes": ["silk007"]},
+        {"name": "Black", "hex": "000000", "codes": ["silk008"]},
+        {"name": "Copper", "hex": "B87333", "codes": ["silk009"]},
+        {"name": "Bronze", "hex": "CD7F32", "codes": ["silk010"]},
+        {"name": "Christmas Green", "hex": "008000", "codes": ["silk011"]},
+        {"name": "Dark Gold", "hex": "B8860B", "codes": ["silk012"]},
+        {"name": "Pink", "hex": "FFC0CB", "codes": ["silk013"]},
+        {"name": "Cyan", "hex": "00FFFF", "codes": ["silk014"]}
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 65],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {"name": "Red/Green", "hexes": ["E30613", "008000"], "codes": ["Dual 01"]},
+        {"name": "Red/Blue", "hexes": ["E30613", "0000FF"], "codes": ["Dual 02"]},
+        {"name": "Blue/Green", "hexes": ["0000FF", "008000"], "codes": ["Dual 03"]},
+        {"name": "Red/Gold", "hexes": ["E30613", "FFD700"], "codes": ["Dual 04"]},
+        {"name": "Gold/Copper", "hexes": ["FFD700", "B87333"], "codes": ["Dual 05"]},
+        {"name": "Gold/Silver", "hexes": ["FFD700", "C0C0C0"], "codes": ["Dual 06"]},
+        {"name": "Purple/Gold", "hexes": ["800080", "FFD700"], "codes": ["Dual 07"]},
+        {"name": "Yellow/Green", "hexes": ["FFFF00", "008000"], "codes": ["Dual 08"]},
+        {"name": "Rose Red/Light Blue", "hexes": ["C21E56", "ADD8E6"], "codes": ["Dual 09"]},
+        {"name": "Rose Red/Black", "hexes": ["C21E56", "000000"], "codes": ["Dual 10"]},
+        {"name": "Emerald Green/Black", "hexes": ["046307", "000000"], "codes": ["Dual 11"]},
+        {"name": "Black/Gold", "hexes": ["000000", "FFD700"], "codes": ["Dual 12"]},
+        {"name": "Black/Purple", "hexes": ["000000", "800080"], "codes": ["Dual 13"]},
+        {"name": "Black/Red", "hexes": ["000000", "E30613"], "codes": ["Dual 14"]},
+        {"name": "Purple/Green", "hexes": ["800080", "008000"], "codes": ["Dual 15"]},
+        {"name": "Teal/Coral", "hexes": ["008080", "FF7F50"], "codes": ["Dual 16"]},
+        {"name": "Blue/Silver", "hexes": ["0000FF", "C0C0C0"], "codes": ["Dual 17"]},
+        {"name": "Blue/Gold", "hexes": ["0000FF", "FFD700"], "codes": ["Dual 18"]},
+        {"name": "Coral/Purple", "hexes": ["FF7F50", "800080"], "codes": ["Dual 19"]},
+        {"name": "Blue/Purple", "hexes": ["0000FF", "800080"], "codes": ["Dual 20"]},
+        {"name": "Teal/Dark Violet", "hexes": ["008080", "9400D3"], "codes": ["Dual 21"]}
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 65],
+      "fill": "wood",
+      "colors": [
+        {"name": "Classic Birch", "hex": "F5F5DC", "codes": ["13505"]},
+        {"name": "Clay Brown", "hex": "D2691E", "codes": ["13801"]},
+        {"name": "Black Walnut", "hex": "3D2B1F", "codes": ["13107"]},
+        {"name": "Rosewood", "hex": "65000B", "codes": ["13204"]},
+        {"name": "White Oak", "hex": "E8DCC8", "codes": ["13106"]},
+        {"name": "Ochre Yellow", "hex": "CC7722", "codes": ["13403"]}
+      ]
+    },
+    {
+      "name": "{color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [215, 230],
+      "bed_temp_range": [70, 90],
+      "colors": [
+        {"name": "Green", "hex": "008000", "codes": ["33500"]},
+        {"name": "Red", "hex": "E30613", "codes": ["33200"]},
+        {"name": "Yellow", "hex": "FFFF00", "codes": ["33400"]},
+        {"name": "Warm Yellow", "hex": "F5DEB3", "codes": ["10402"]},
+        {"name": "Black", "hex": "000000", "codes": ["33102"]},
+        {"name": "Grey", "hex": "808080", "codes": ["33101"]},
+        {"name": "White", "hex": "FFFFFF", "codes": ["33100"]},
+        {"name": "Orange", "hex": "FF6600", "codes": ["33300"]},
+        {"name": "Dark Blue", "hex": "00008B", "codes": ["33600"]},
+        {"name": "Dark Grey", "hex": "404040", "codes": ["33103"]},
+        {"name": "Lake Blue", "hex": "0066CC", "codes": ["33601"]},
+        {"name": "Forest Green", "hex": "228B22", "codes": ["33502"]},
+        {"name": "Lemon Green", "hex": "ADFF2F", "codes": ["33501"]},
+        {"name": "Cream White", "hex": "FFFDD0", "codes": ["33401"]},
+        {"name": "Peanut Brown", "hex": "D2B48C", "codes": ["33801"]},
+        {"name": "Transparent", "hex": "FFFFFF", "translucent": true, "codes": ["99100"]},
+        {"name": "Silver", "hex": "C0C0C0", "codes": ["10102"]},
+        {"name": "Transparent Blue", "hex": "ADD8E6", "translucent": true, "codes": ["99101"]},
+        {"name": "Transparent Yellow", "hex": "FFFFE0", "translucent": true, "codes": ["99102"]},
+        {"name": "Transparent Orange", "hex": "FFDAB9", "translucent": true, "codes": ["99103"]},
+        {"name": "Transparent Green", "hex": "90EE90", "translucent": true, "codes": ["99104"]},
+        {"name": "Purple", "hex": "800080", "codes": ["10700"]},
+        {"name": "Cherry Blossom", "hex": "FFB7C5", "codes": ["11201"]},
+        {"name": "Pink", "hex": "FFC0CB", "codes": ["10203"]},
+        {"name": "Magenta", "hex": "FF00FF", "codes": ["10202"]},
+        {"name": "Brown", "hex": "8B4513", "codes": ["10800"]},
+        {"name": "Sky Blue", "hex": "87CEEB", "codes": ["11601"]}
+      ]
+    }
+  ]
+}

--- a/filaments/3d4makers.json
+++ b/filaments/3d4makers.json
@@ -1,0 +1,1585 @@
+{
+  "manufacturer": "3D4Makers",
+  "filaments": [
+    {
+      "name": "ABS Filament {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Blue (RAL 5002)",
+          "hex": "1e3a8a",
+          "codes": [
+            "ABSXX-5002-175-750-3D4M",
+            "ABSXX-5002-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Green (RAL 6029)",
+          "hex": "2e7d32",
+          "codes": [
+            "ABSXX-6029-175-750-3D4M",
+            "ABSXX-6029-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Black (RAL 9011)",
+          "hex": "1a1a1a",
+          "codes": [
+            "ABSXX-9011-175-750-3D4M",
+            "ABSXX-9011-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "White (RAL 9016)",
+          "hex": "f5f5f5",
+          "codes": [
+            "ABSXX-9016-175-750-3D4M",
+            "ABSXX-9016-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Red (RAL 3020)",
+          "hex": "c41e2a",
+          "codes": [
+            "ABSXX-3020-175-750-3D4M",
+            "ABSXX-3020-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "ABSXX-0000-175-750-3D4M",
+            "ABSXX-0000-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    },
+    {
+      "name": "ABS Kevlar Filament {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "ABSKF-0000-175-500-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "ABS-ESD Filament {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "ABSES-BK-175-500-3D4M"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "ABSES-0000-175-500-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        260
+      ]
+    },
+    {
+      "name": "Hemp PLA Filament {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "HEMP-0000-175-750-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ]
+    },
+    {
+      "name": "ASA Filament {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "ASAXX-0000-175-750-3D4M",
+            "ASAXX-0000-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "ASAXX-9011-175-750-3D4M",
+            "ASAXX-9011-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PAHT 9825 NT Filament {color_name}",
+      "material": "PAHT",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Nt",
+          "hex": "f5f5f5",
+          "codes": [
+            "LPAHT-0000-175-500-3D4M",
+            "LPAHT-0000-175-750-3D4M",
+            "LPAHT-0000-175-2300-3D4M",
+            "LPAHT-0000-175-1000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        285
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PAHT 9936 BK Filament {color_name}",
+      "material": "PAHT",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Bk",
+          "hex": "1a1a1a",
+          "codes": [
+            "LPAHT-9936-175-500-3D4M",
+            "LPAHT-9936-175-750-3D4M",
+            "LPAHT-9936-175-1000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PAHT KK 50056 BK FR Filament {color_name}",
+      "material": "PAHT",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Bk",
+          "hex": "1a1a1a",
+          "codes": [
+            "LPAFR-0000-175-500-3D4M",
+            "LPAFR-0000-175-750-3D4M",
+            "LPAFR-0000-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        265,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        90
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PAHT CF 9742 BK Filament {color_name}",
+      "material": "PAHT-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Bk",
+          "hex": "1a1a1a",
+          "codes": [
+            "PAHTC-9742-175-500-3D4M",
+            "PAHTC-9742-175-750-3D4M",
+            "PAHTC-9742-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte"
+    },
+    {
+      "name": "Luvocom® 3F PAHT CF 9891 BK Filament {color_name}",
+      "material": "PAHT-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Bk",
+          "hex": "1a1a1a",
+          "codes": [
+            "PAHTC-0000-175-500-3D4M",
+            "PAHTC-0000-175-750-3D4M",
+            "PAHTC-0000-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte"
+    },
+    {
+      "name": "Facilan™ C8 Filament {color_name}",
+      "material": "PCL",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 4500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "FC8XX-0000-175-750-3D4M",
+            "FC8XX-0000-175-2300-3D4M",
+            "FC8XX-0000-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "FC8XX-BLCK-175-750-3D4M",
+            "FC8XX-BLCK-175-2300-3D4M",
+            "FC8XX-BLCK-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32",
+          "codes": [
+            "FC8XX-GREN-175-750-3D4M",
+            "FC8XX-GREN-175-2300-3D4M",
+            "FC8XX-GREN-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a",
+          "codes": [
+            "FC8XX-RED-175-750-3D4M",
+            "FC8XX-RED-175-2300-3D4M",
+            "FC8XX-RED-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "1e3a8a",
+          "codes": [
+            "FC8XX-BLUE-175-750-3D4M",
+            "FC8XX-BLUE-175-2300-3D4M",
+            "FC8XX-BLUE-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "808080",
+          "codes": [
+            "FC8XX-DAGR-175-750-3D4M",
+            "FC8XX-DAGR-175-2300-3D4M",
+            "FC8XX-DAGR-175-4500-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "Facilan™ HT Filament {color_name}",
+      "material": "PCL",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "FCHT-0000-175-750-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ]
+    },
+    {
+      "name": "Facilan™ Ortho Filament {color_name}",
+      "material": "PCL",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "FORTO-0000-175-500-3D4M",
+            "FORTO-0000-175-750-3D4M",
+            "FORTO-0000-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        130,
+        170
+      ],
+      "bed_temp_range": [
+        30,
+        45
+      ]
+    },
+    {
+      "name": "Facilan™ PCL 100 Filament {color_name}",
+      "material": "PCL",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "FPCL1-0000-175-750-3D4M",
+            "FPCL1-0000-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        130,
+        170
+      ],
+      "bed_temp_range": [
+        30,
+        45
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PEEK 9581 NT Filament {color_name}",
+      "material": "PEEK",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "LPEEK-0000-175-500-3D4M",
+            "LPEEK-0000-175-750-3D4M",
+            "LPEEK-0000-175-200-3D4M",
+            "LPEEK-0000-175-1000-3D4M",
+            "LPEEK-0000-175-2000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        390,
+        440
+      ],
+      "bed_temp_range": [
+        120,
+        120
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PEKK 50082 NT Filament {color_name}",
+      "material": "PEEK",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "LPEKK-0000-175-200-3D4M",
+            "LPEKK-0000-175-500-3D4M",
+            "LPEKK-0000-175-750-3D4M",
+            "LPEKK-0000-175-1000-3D4M",
+            "LPEKK-0000-175-2000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        340,
+        380
+      ],
+      "bed_temp_range": [
+        120,
+        150
+      ]
+    },
+    {
+      "name": "PEEK Filament {color_name}",
+      "material": "PEEK",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PEEKX-0000-175-500-3D4M",
+            "PEEKX-0000-175-750-3D4M",
+            "PEEKX-0000-175-200-3D4M",
+            "PEEKX-0000-175-1000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        370,
+        420
+      ],
+      "bed_temp_range": [
+        120,
+        150
+      ]
+    },
+    {
+      "name": "R PEEK Filament {color_name}",
+      "material": "PEEK",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "RPEEK-0000-175-500-3D4M",
+            "RPEEK-0000-175-750-3D4M",
+            "RPEEK-0000-175-200-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        400,
+        450
+      ],
+      "bed_temp_range": [
+        120,
+        160
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PEEK CF 9676 BK Filament {color_name}",
+      "material": "PEEK-CF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Bk",
+          "hex": "1a1a1a",
+          "codes": [
+            "PEEKC-0000-175-200-3D4M",
+            "PEEKC-0000-175-500-3D4M",
+            "PEEKC-0000-175-750-3D4M",
+            "PEEKC-0000-175-2000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        400,
+        450
+      ],
+      "bed_temp_range": [
+        110,
+        150
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte"
+    },
+    {
+      "name": "Luvocom® 3F PEI 50236 GY Filament {color_name}",
+      "material": "PEI",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Gy",
+          "hex": "808080",
+          "codes": [
+            "LPEI-0000-175-200-3D4M",
+            "LPEI-0000-175-750-3D4M",
+            "LPEI-0000-175-500-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        400,
+        450
+      ]
+    },
+    {
+      "name": "PEI Ultem 1000 Filament {color_name}",
+      "material": "PEI",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PEI10-0000-175-750-3D4M",
+            "PEI10-0000-175-200-3D4M",
+            "PEI10-0000-175-500-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        355,
+        390
+      ],
+      "bed_temp_range": [
+        120,
+        160
+      ]
+    },
+    {
+      "name": "PEI Ultem 1010 Filament {color_name}",
+      "material": "PEI",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PEI11-0000-175-500-3D4M",
+            "PEI11-0000-175-750-3D4M",
+            "PEI11-0000-175-200-3D4M",
+            "PEI11-0000-175-1000-3D4M",
+            "PEI11-0000-175-2000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        360,
+        400
+      ],
+      "bed_temp_range": [
+        120,
+        160
+      ]
+    },
+    {
+      "name": "PEI Ultem 9085 Filament {color_name}",
+      "material": "PEI",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PEI90-0000-175-500-3D4M",
+            "PEI90-0000-175-750-3D4M",
+            "PEI90-0000-175-200-3D4M",
+            "PEI90-0000-175-1000-3D4M",
+            "PEI90-0000-175-2000-3D4M"
+          ]
+        },
+        {
+          "name": "Light grey",
+          "hex": "808080",
+          "codes": [
+            "PEI90-LGRY-175-500-3D4M",
+            "PEI90-LGRY-175-750-3D4M",
+            "PEI90-LGRY-175-200-3D4M",
+            "PEI90-LGRY-175-1000-3D4M",
+            "PEI90-LGRY-175-2000-3D4M"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "PEI90-BLCK-175-500-3D4M",
+            "PEI90-BLCK-175-750-3D4M",
+            "PEI90-BLCK-175-200-3D4M",
+            "PEI90-BLCK-175-1000-3D4M",
+            "PEI90-BLCK-175-2000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        350,
+        380
+      ],
+      "bed_temp_range": [
+        120,
+        160
+      ]
+    },
+    {
+      "name": "PEKK-A Filament {color_name}",
+      "material": "PEKK",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PEKKA-0000-175-500-3D4M",
+            "PEKKA-0000-175-200-3D4M",
+            "PEKKA-0000-175-750-3D4M",
+            "PEKKA-0000-175-1000-3D4M",
+            "PEKKA-0000-175-2000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        340,
+        380
+      ],
+      "bed_temp_range": [
+        120,
+        150
+      ]
+    },
+    {
+      "name": "PETG Filament {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 4500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Titanium",
+          "hex": "808080",
+          "codes": [
+            "PETGX-TITA-175-750-3D4M",
+            "PETGX-TITA-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Orange (RAL2008)",
+          "hex": "808080",
+          "codes": [
+            "PETGX-2008-175-750-3D4M"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "codes": [
+            "PETGX-0000-175-750-3D4M"
+          ]
+        },
+        {
+          "name": "Green (RAL6029)",
+          "hex": "2e7d32",
+          "codes": [
+            "PETGX-6029-175-750-3D4M",
+            "PETGX-6029-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Blue (RAL5002)",
+          "hex": "1e3a8a",
+          "codes": [
+            "PETGX-5002-175-750-3D4M"
+          ]
+        },
+        {
+          "name": "Red (RAL3020)",
+          "hex": "c41e2a",
+          "codes": [
+            "PETGX-3020-175-750-3D4M",
+            "PETGX-3020-175-2300-3D4M",
+            "PETGX-3020-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "White (RAL9003)",
+          "hex": "f5f5f5",
+          "codes": [
+            "PETGX-9003-175-750-3D4M",
+            "PETGX-9003-175-2300-3D4M",
+            "PETGX-9003-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Black (RAL9011)",
+          "hex": "1a1a1a",
+          "codes": [
+            "PETGX-9011-175-750-3D4M",
+            "PETGX-9011-175-1000-3D4M",
+            "PETGX-9011-175-2300-3D4M",
+            "PETGX-9011-175-4500-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ]
+    },
+    {
+      "name": "PETG Carbon Filament {color_name}",
+      "material": "PETG-CF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 3000
+        },
+        {
+          "weight": 4500
+        },
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "PETCF-0000-175-500-3D4M",
+            "PETCF-0000-175-750-3D4M",
+            "PETCF-0000-175-1000-3D4M",
+            "PETCF-0000-175-2300-3D4M",
+            "PETCF-0000-175-4500-3D4M",
+            "PETCF-0000-175-8000-3D4M",
+            "PETCF-0000-175-3000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte"
+    },
+    {
+      "name": "PI Z2 Filament {color_name}",
+      "material": "PI",
+      "density": 1.38,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PIZ2Z-NT-175-750-3D4M",
+            "PIZ2Z-NT-175-500-3D4M",
+            "PIZ2Z-NT-175-200-3D4M"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "PIZ2Z-BK-175-750-3D4M",
+            "PIZ2Z-BK-175-500-3D4M",
+            "PIZ2Z-BK-175-200-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        390,
+        410
+      ],
+      "bed_temp_range": [
+        120,
+        160
+      ]
+    },
+    {
+      "name": "Luvocom® 3F PPS CF 9938 BK Filament {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Bk",
+          "hex": "1a1a1a",
+          "codes": [
+            "PPSCF-0000-175-500-3D4M",
+            "PPSCF-0000-175-750-3D4M",
+            "PPSCF-0000-175-1000-3D4M",
+            "PPSCF-0000-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        310,
+        340
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ]
+    },
+    {
+      "name": "PLA Filament {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 4500
+        },
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Orange (RAL 2008)",
+          "hex": "808080",
+          "codes": [
+            "PLAXX-2008-175-750-3D4M",
+            "PLAXX-2008-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Blue (RAL 5002)",
+          "hex": "1e3a8a",
+          "codes": [
+            "PLAXX-5002-175-750-3D4M",
+            "PLAXX-5002-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Red (RAL 3020)",
+          "hex": "c41e2a",
+          "codes": [
+            "PLAXX-3020-175-750-3D4M",
+            "PLAXX-3020-175-2300-3D4M",
+            "PLAXX-3020-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Green (RAL 6029)",
+          "hex": "2e7d32",
+          "codes": [
+            "PLAXX-6029-175-750-3D4M",
+            "PLAXX-6029-175-2300-3D4M",
+            "PLAXX-6029-175-4500-3D4M"
+          ]
+        },
+        {
+          "name": "Black (RAL 9011)",
+          "hex": "1a1a1a",
+          "codes": [
+            "PLAXX-9011-175-750-3D4M",
+            "PLAXX-9011-175-2300-3D4M",
+            "PLAXX-9011-175-4500-3D4M",
+            "PLAXX-9011-175-8000-3D4M"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PLAXX-0000-175-750-3D4M",
+            "PLAXX-0000-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "White (RAL 9003)",
+          "hex": "f5f5f5",
+          "codes": [
+            "PLAXX-9003-175-750-3D4M",
+            "PLAXX-9003-175-2300-3D4M",
+            "PLAXX-9003-175-4500-3D4M",
+            "PLAXX-9003-175-8000-3D4M"
+          ]
+        },
+        {
+          "name": "Yellow (RAL 1023)",
+          "hex": "808080",
+          "codes": [
+            "PLAXX-1023-175-750-3D4M",
+            "PLAXX-1023-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Apple Green (RAL 6018)",
+          "hex": "2e7d32",
+          "codes": [
+            "PLAXX-6018-175-750-3D4M",
+            "PLAXX-6018-175-1000-3D4M",
+            "PLAXX-6018-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Sky Blue (RAL 5015)",
+          "hex": "1e3a8a",
+          "codes": [
+            "PLAXX-5015-175-750-3D4M",
+            "PLAXX-5015-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Light Grey (RAL 7035)",
+          "hex": "808080",
+          "codes": [
+            "PLAXX-7035-175-750-3D4M",
+            "PLAXX-7035-175-2300-3D4M",
+            "PLAXX-7035-175-8000-3D4M"
+          ]
+        },
+        {
+          "name": "Silver (RAL 9006)",
+          "hex": "808080",
+          "codes": [
+            "PLAXX-9006-175-750-3D4M",
+            "PLAXX-9006-175-2300-3D4M",
+            "PLAXX-9006-175-8000-3D4M"
+          ]
+        },
+        {
+          "name": "Gold (RAL 1036)",
+          "hex": "808080",
+          "codes": [
+            "PLAXX-1036-175-750-3D4M",
+            "PLAXX-1036-175-2300-3D4M"
+          ]
+        },
+        {
+          "name": "Iron Grey (RAL 7011)",
+          "hex": "808080",
+          "codes": [
+            "PLAXX-7011-175-750-3D4M",
+            "PLAXX-7011-175-1000-3D4M",
+            "PLAXX-7011-175-2300-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        60
+      ]
+    },
+    {
+      "name": "PLLA Filament {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PLLAX-0000-175-750-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "r-UltraMarathon PP GF {color_name}",
+      "material": "PP-GF",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2000
+        },
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PPGF-0000-175-700-3D4M",
+            "PPGF-0000-175-2000-3D4M",
+            "PPGF-0000-175-4000-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "fill": "glass fiber",
+      "finish": "matte"
+    },
+    {
+      "name": "PPSU Filament {color_name}",
+      "material": "PPSU",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 200
+        },
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "PPSUX-0000-175-500-3D4M",
+            "PPSUX-0000-175-750-3D4M",
+            "PPSUX-0000-175-200-3D4M"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        390,
+        410
+      ],
+      "bed_temp_range": [
+        120,
+        220
+      ]
+    }
+  ]
+}

--- a/filaments/3dactive.json
+++ b/filaments/3dactive.json
@@ -1,0 +1,237 @@
+{
+  "manufacturer": "3DACTIVE",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "002395"
+        },
+        {
+          "name": "Emerald",
+          "hex": "00573f"
+        },
+        {
+          "name": "Silver",
+          "hex": "a5a5a8"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Biege",
+          "hex": "ffe9b3",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        245
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "000000"
+        },
+        {
+          "name": "brown",
+          "hex": "551b1b"
+        },
+        {
+          "name": "dark green",
+          "hex": "088000"
+        },
+        {
+          "name": "light green",
+          "hex": "11ff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff5e29"
+        },
+        {
+          "name": "pink",
+          "hex": "e100ff"
+        },
+        {
+          "name": "purple",
+          "hex": "741281"
+        },
+        {
+          "name": "red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "silver",
+          "hex": "545454"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fcff52"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        215
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Burgund",
+          "hex": "800040"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "3d3d3b"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "6bc1f5"
+        },
+        {
+          "name": "Lime",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "No-color",
+          "hex": "adadad"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f8e730"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dc.json
+++ b/filaments/3dc.json
@@ -1,0 +1,180 @@
+{
+  "manufacturer": "3DC",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Silk",
+          "hex": "232425"
+        },
+        {
+          "name": "Purple",
+          "hex": "52017e"
+        },
+        {
+          "name": "Rainbow Forest Series",
+          "hex": "00942c"
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Deep Blue",
+          "hex": "072a6c"
+        },
+        {
+          "name": "Grey",
+          "hex": "d9d9d9"
+        },
+        {
+          "name": "Indigo Purple",
+          "hex": "3d006c"
+        },
+        {
+          "name": "Magenta",
+          "hex": "e600e6"
+        },
+        {
+          "name": "Mistletoe Green",
+          "hex": "2e7759"
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "fb7d07"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Blue/Silver",
+          "hexes": [
+            "0000ff",
+            "2d82d7"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Moon Palace",
+          "hex": "faffad"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3de.json
+++ b/filaments/3de.json
@@ -1,0 +1,3612 @@
+{
+    "manufacturer": "3DE",
+    "filaments": [
+        {
+            "name": "Premium ABS {color_name}",
+            "material": "ABS",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                80,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Choclate Brown",
+                    "hex": "7a5c3e",
+                    "codes": [
+                        "201115"
+                    ]
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "0033a0",
+                    "codes": [
+                        "201110"
+                    ]
+                },
+                {
+                    "name": "Emerald Green",
+                    "hex": "2e8b57",
+                    "codes": [
+                        "210022"
+                    ]
+                },
+                {
+                    "name": "Flame Orange",
+                    "hex": "ff6900",
+                    "codes": [
+                        "201105"
+                    ]
+                },
+                {
+                    "name": "Gecko Green",
+                    "hex": "44d62c",
+                    "codes": [
+                        "201106"
+                    ]
+                },
+                {
+                    "name": "Leaf Green",
+                    "hex": "228b22",
+                    "codes": [
+                        "201107"
+                    ]
+                },
+                {
+                    "name": "Leather Brown",
+                    "hex": "8b5a2b",
+                    "codes": [
+                        "201116",
+                        "251116"
+                    ]
+                },
+                {
+                    "name": "Mailbox Red",
+                    "hex": "c8102e",
+                    "codes": [
+                        "201108"
+                    ]
+                },
+                {
+                    "name": "Nature",
+                    "hex": "f5f5dc",
+                    "codes": [
+                        "201113"
+                    ]
+                },
+                {
+                    "name": "Normal Blue",
+                    "hex": "005eb8",
+                    "codes": [
+                        "201109"
+                    ]
+                },
+                {
+                    "name": "Pirate Black",
+                    "hex": "25282a",
+                    "codes": [
+                        "201101"
+                    ]
+                },
+                {
+                    "name": "Signal Yellow",
+                    "hex": "fedd00",
+                    "codes": [
+                        "201114"
+                    ]
+                },
+                {
+                    "name": "Slate Grey",
+                    "hex": "4f5358",
+                    "codes": [
+                        "201104"
+                    ]
+                },
+                {
+                    "name": "Snow White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "201102"
+                    ]
+                },
+                {
+                    "name": "Terminator Grey",
+                    "hex": "97999b",
+                    "codes": [
+                        "201103"
+                    ]
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "808080",
+                    "codes": [
+                        "201112"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium ASA {color_name}",
+            "material": "ASA",
+            "density": 1.07,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                230,
+                250
+            ],
+            "bed_temp_range": [
+                90,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "101820",
+                    "codes": [
+                        "200601"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "b1b3b3",
+                    "codes": [
+                        "200603",
+                        "250603"
+                    ]
+                },
+                {
+                    "name": "Slate Grey",
+                    "hex": "4f5358",
+                    "codes": [
+                        "200604"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "250602",
+                        "200602"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium NYLON {color_name}",
+            "material": "NYLON",
+            "density": 1.14,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                240,
+                260
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "25282a",
+                    "codes": [
+                        "201051",
+                        "251053",
+                        "251051",
+                        "201053"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "251052",
+                        "201052",
+                        "207077"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PBT {color_name}",
+            "material": "PBT",
+            "density": 1.31,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 5000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                235,
+                235
+            ],
+            "bed_temp_range": [
+                65,
+                65
+            ],
+            "colors": [
+                {
+                    "name": "Avocado Green",
+                    "hex": "808080",
+                    "codes": [
+                        "201612"
+                    ]
+                },
+                {
+                    "name": "Blue Fish",
+                    "hex": "808080",
+                    "codes": [
+                        "201611"
+                    ]
+                },
+                {
+                    "name": "Carbon Black",
+                    "hex": "808080",
+                    "codes": [
+                        "201608"
+                    ]
+                },
+                {
+                    "name": "Cyber Yellow",
+                    "hex": "808080",
+                    "codes": [
+                        "201609"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "201603",
+                        "251603"
+                    ]
+                },
+                {
+                    "name": "Hot Red",
+                    "hex": "808080",
+                    "codes": [
+                        "201610"
+                    ]
+                },
+                {
+                    "name": "Pirate Black",
+                    "hex": "25282a",
+                    "codes": [
+                        "201601",
+                        "251601",
+                        "201615",
+                        "251613",
+                        "251615",
+                        "201613"
+                    ]
+                },
+                {
+                    "name": "Snow White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "201602",
+                        "251602"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "201614",
+                        "251614"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Tough PBT {color_name}",
+            "material": "PBT",
+            "density": 1.31,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                235,
+                235
+            ],
+            "bed_temp_range": [
+                65,
+                65
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "201001"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PBT {color_name}",
+            "material": "PC",
+            "density": 1.181,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                260,
+                270
+            ],
+            "bed_temp_range": [
+                100,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "PC-PBT - Black",
+                    "hex": "808080",
+                    "codes": [
+                        "207109"
+                    ]
+                },
+                {
+                    "name": "PC-PBT - White",
+                    "hex": "808080",
+                    "codes": [
+                        "207110"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PC {color_name}",
+            "material": "PC",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                260,
+                300
+            ],
+            "bed_temp_range": [
+                80,
+                120
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "250901",
+                        "200901"
+                    ]
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "808080",
+                    "codes": [
+                        "200903",
+                        "250903"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "200902",
+                        "250902"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PCTG {color_name}",
+            "material": "PCTG",
+            "density": 1.237,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                250
+            ],
+            "bed_temp_range": [
+                75,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Fully Black",
+                    "hex": "808080",
+                    "codes": [
+                        "210038"
+                    ],
+                    "eans": [
+                        "5744008200035"
+                    ]
+                },
+                {
+                    "name": "Fully White",
+                    "hex": "808080",
+                    "codes": [
+                        "210039"
+                    ],
+                    "eans": [
+                        "5744008200042"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PET {color_name}",
+            "material": "PET",
+            "density": 1.29,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                225,
+                245
+            ],
+            "bed_temp_range": [
+                0,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "High Speed PET - Black Diamond",
+                    "hex": "808080",
+                    "codes": [
+                        "207048"
+                    ],
+                    "eans": [
+                        "5745001109240"
+                    ]
+                },
+                {
+                    "name": "High Speed PET - White Agat",
+                    "hex": "808080",
+                    "codes": [
+                        "207049"
+                    ],
+                    "eans": [
+                        "5745001109257"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Carbon Fiber PETG {color_name}",
+            "material": "PETG",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                255
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Carbon Fiber Black",
+                    "hex": "1a1a1a",
+                    "codes": [
+                        "200723"
+                    ]
+                },
+                {
+                    "name": "Carbon Fiber Indigo Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "210020"
+                    ]
+                }
+            ],
+            "fill": "carbon fiber"
+        },
+        {
+            "name": "Premium Glow PLA {color_name}",
+            "material": "PETG",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                255
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Green",
+                    "hex": "008000",
+                    "glow": true,
+                    "codes": [
+                        "200453"
+                    ]
+                }
+            ],
+            "glow": true
+        },
+        {
+            "name": "Premium Opaque PETG {color_name}",
+            "material": "PETG",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                255
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "9002025"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PETG {color_name}",
+            "material": "PETG",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 5000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                230,
+                255
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Alien Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200717"
+                    ]
+                },
+                {
+                    "name": "Black in Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "210035"
+                    ],
+                    "eans": [
+                        "5745001109776"
+                    ]
+                },
+                {
+                    "name": "Budget Black",
+                    "hex": "808080",
+                    "codes": [
+                        "207122"
+                    ]
+                },
+                {
+                    "name": "Budget White",
+                    "hex": "808080",
+                    "codes": [
+                        "207123"
+                    ]
+                },
+                {
+                    "name": "Dark Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200715"
+                    ]
+                },
+                {
+                    "name": "Dark Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "200714"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Green - Semi-transparent",
+                    "hex": "808080",
+                    "codes": [
+                        "200712"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Orange - Semi-transparent",
+                    "hex": "808080",
+                    "codes": [
+                        "200710"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Yellow - Semi-transparent",
+                    "hex": "808080",
+                    "codes": [
+                        "200711"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Yellow - Solid Color",
+                    "hex": "808080",
+                    "codes": [
+                        "200716"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Black",
+                    "hex": "808080",
+                    "codes": [
+                        "207111"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "207116"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Dark Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "207113"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Green",
+                    "hex": "808080",
+                    "codes": [
+                        "207117"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Light Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "207114"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Orange",
+                    "hex": "808080",
+                    "codes": [
+                        "207119"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Red",
+                    "hex": "808080",
+                    "codes": [
+                        "207115"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - White",
+                    "hex": "808080",
+                    "codes": [
+                        "207112"
+                    ]
+                },
+                {
+                    "name": "High Speed PETG - Yellow",
+                    "hex": "808080",
+                    "codes": [
+                        "207118"
+                    ]
+                },
+                {
+                    "name": "PETG Magic - Blue, Green and Gold",
+                    "hex": "808080",
+                    "codes": [
+                        "207108"
+                    ],
+                    "eans": [
+                        "5745001109646"
+                    ]
+                },
+                {
+                    "name": "PETG Magic - Gold, Red and Purple",
+                    "hex": "808080",
+                    "codes": [
+                        "207103"
+                    ],
+                    "eans": [
+                        "5745001109592"
+                    ]
+                },
+                {
+                    "name": "PETG Magic - Red, Purple and Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "207102"
+                    ],
+                    "eans": [
+                        "5745001109585"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "8031a7",
+                    "codes": [
+                        "200706"
+                    ]
+                },
+                {
+                    "name": "Solid Black",
+                    "hex": "101820",
+                    "codes": [
+                        "200795",
+                        "200790",
+                        "200701"
+                    ]
+                },
+                {
+                    "name": "Solid Blue",
+                    "hex": "005eb8",
+                    "codes": [
+                        "200713"
+                    ]
+                },
+                {
+                    "name": "Solid Green",
+                    "hex": "2e8b57",
+                    "codes": [
+                        "200709"
+                    ]
+                },
+                {
+                    "name": "Solid Orange",
+                    "hex": "808080",
+                    "codes": [
+                        "200705"
+                    ]
+                },
+                {
+                    "name": "Solid Red",
+                    "hex": "c8102e",
+                    "codes": [
+                        "200708"
+                    ]
+                },
+                {
+                    "name": "Solid Tool Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200719"
+                    ]
+                },
+                {
+                    "name": "Solid Warm Yellow",
+                    "hex": "808080",
+                    "codes": [
+                        "200718"
+                    ]
+                },
+                {
+                    "name": "Solid Water Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "200721"
+                    ]
+                },
+                {
+                    "name": "Solid White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "250702",
+                        "200796",
+                        "200702",
+                        "200791"
+                    ]
+                },
+                {
+                    "name": "Solid Yellow",
+                    "hex": "f3d03e",
+                    "codes": [
+                        "200722"
+                    ]
+                },
+                {
+                    "name": "Sort",
+                    "hex": "808080",
+                    "codes": [
+                        "210006"
+                    ],
+                    "eans": [
+                        "5745001109356"
+                    ]
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "808080",
+                    "codes": [
+                        "200792",
+                        "200704"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "201802"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PRO PETG {color_name}",
+            "material": "PETG",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                255
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "200814",
+                        "200801"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "200803"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "200802"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "MAX PLA {color_name}",
+            "material": "PLA",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 5000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Barbados Cherry",
+                    "hex": "808080",
+                    "codes": [
+                        "207094"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "200141"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000ff",
+                    "codes": [
+                        "200147"
+                    ]
+                },
+                {
+                    "name": "Bone",
+                    "hex": "808080",
+                    "codes": [
+                        "200125"
+                    ]
+                },
+                {
+                    "name": "Cappucino",
+                    "hex": "808080",
+                    "codes": [
+                        "207095"
+                    ]
+                },
+                {
+                    "name": "Chili Red",
+                    "hex": "ce0037",
+                    "codes": [
+                        "200106",
+                        "250110"
+                    ]
+                },
+                {
+                    "name": "Coffee Brown",
+                    "hex": "808080",
+                    "codes": [
+                        "200114"
+                    ]
+                },
+                {
+                    "name": "Cold White",
+                    "hex": "808080",
+                    "codes": [
+                        "200103"
+                    ]
+                },
+                {
+                    "name": "Dark Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "200143"
+                    ]
+                },
+                {
+                    "name": "Desert Beige",
+                    "hex": "808080",
+                    "codes": [
+                        "200122"
+                    ]
+                },
+                {
+                    "name": "Dusty Rose",
+                    "hex": "808080",
+                    "codes": [
+                        "207092"
+                    ]
+                },
+                {
+                    "name": "Evening Sand",
+                    "hex": "808080",
+                    "codes": [
+                        "200124"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Green",
+                    "hex": "78d64b",
+                    "codes": [
+                        "200115"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Orange",
+                    "hex": "808080",
+                    "codes": [
+                        "200117"
+                    ]
+                },
+                {
+                    "name": "Fluorescent Yellow",
+                    "hex": "e1e000",
+                    "codes": [
+                        "200116"
+                    ]
+                },
+                {
+                    "name": "Grass Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200109",
+                        "250112"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000",
+                    "codes": [
+                        "200148"
+                    ]
+                },
+                {
+                    "name": "Green Gin Fruit",
+                    "hex": "808080",
+                    "codes": [
+                        "207090"
+                    ]
+                },
+                {
+                    "name": "Green-Blue Slate",
+                    "hex": "808080",
+                    "codes": [
+                        "207091"
+                    ]
+                },
+                {
+                    "name": "Greige",
+                    "hex": "808080",
+                    "codes": [
+                        "207089"
+                    ]
+                },
+                {
+                    "name": "Gun Metal",
+                    "hex": "808080",
+                    "codes": [
+                        "200107",
+                        "250107"
+                    ]
+                },
+                {
+                    "name": "Jade Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200119"
+                    ]
+                },
+                {
+                    "name": "Lemon Yellow",
+                    "hex": "808080",
+                    "codes": [
+                        "200113",
+                        "250114"
+                    ]
+                },
+                {
+                    "name": "Light Grey",
+                    "hex": "97999b",
+                    "codes": [
+                        "200144"
+                    ]
+                },
+                {
+                    "name": "Ocean Blue",
+                    "hex": "005eb8",
+                    "codes": [
+                        "200108"
+                    ]
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200121"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "ffa500",
+                    "codes": [
+                        "200149"
+                    ]
+                },
+                {
+                    "name": "Pacific Turquoise",
+                    "hex": "808080",
+                    "codes": [
+                        "200127"
+                    ]
+                },
+                {
+                    "name": "Popular Green",
+                    "hex": "808080",
+                    "codes": [
+                        "207088"
+                    ]
+                },
+                {
+                    "name": "Pure Black",
+                    "hex": "25282a",
+                    "codes": [
+                        "200101",
+                        "250101",
+                        "250195",
+                        "200190",
+                        "207056",
+                        "200084"
+                    ]
+                },
+                {
+                    "name": "Pure Gold",
+                    "hex": "808080",
+                    "codes": [
+                        "200120"
+                    ]
+                },
+                {
+                    "name": "Pure White",
+                    "hex": "25282a",
+                    "codes": [
+                        "250196"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "ff0000",
+                    "codes": [
+                        "200145"
+                    ]
+                },
+                {
+                    "name": "Royal Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "200128"
+                    ]
+                },
+                {
+                    "name": "Shadow Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "200104",
+                        "250108",
+                        "200192"
+                    ]
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "05c3de",
+                    "codes": [
+                        "200110"
+                    ]
+                },
+                {
+                    "name": "Solid Deep Purple",
+                    "hex": "512d6d",
+                    "codes": [
+                        "200111"
+                    ]
+                },
+                {
+                    "name": "Summer Sky Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "207093"
+                    ]
+                },
+                {
+                    "name": "Thunder Grey",
+                    "hex": "97999b",
+                    "codes": [
+                        "200105",
+                        "250109",
+                        "200193"
+                    ]
+                },
+                {
+                    "name": "True Orange",
+                    "hex": "ff6900",
+                    "codes": [
+                        "200112",
+                        "250113"
+                    ]
+                },
+                {
+                    "name": "Walnut Brown",
+                    "hex": "808080",
+                    "codes": [
+                        "200118"
+                    ]
+                },
+                {
+                    "name": "Warm White",
+                    "hex": "808080",
+                    "codes": [
+                        "200102",
+                        "207084"
+                    ]
+                },
+                {
+                    "name": "Warm Yellow",
+                    "hex": "808080",
+                    "codes": [
+                        "200126"
+                    ],
+                    "eans": [
+                        "7426934815276"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "200142"
+                    ]
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "ffff00",
+                    "codes": [
+                        "200146"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Carbon Fiber PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Carbon Fiber Black",
+                    "hex": "1a1a1a",
+                    "codes": [
+                        "200470"
+                    ]
+                }
+            ],
+            "fill": "carbon fiber"
+        },
+        {
+            "name": "Premium Flexible PLA {color_name}",
+            "material": "PLA",
+            "density": 1.16,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                195,
+                230
+            ],
+            "bed_temp_range": [
+                35,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "54D - All Black",
+                    "hex": "808080",
+                    "codes": [
+                        "207045"
+                    ],
+                    "eans": [
+                        "5745001109219"
+                    ]
+                },
+                {
+                    "name": "54D - All Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "207047"
+                    ],
+                    "eans": [
+                        "5745001109233"
+                    ]
+                },
+                {
+                    "name": "54D - All White",
+                    "hex": "808080",
+                    "codes": [
+                        "207046"
+                    ],
+                    "eans": [
+                        "5745001109226"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Fluorescent PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Neon Yellow - Fluorescent",
+                    "hex": "e1e000",
+                    "codes": [
+                        "200010"
+                    ]
+                },
+                {
+                    "name": "Nuclear Green",
+                    "hex": "78d64b",
+                    "codes": [
+                        "200011"
+                    ]
+                },
+                {
+                    "name": "Safety Orange",
+                    "hex": "808080",
+                    "codes": [
+                        "200012",
+                        "250012"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Glow PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Glow'n'Glitter Blue",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207039"
+                    ]
+                },
+                {
+                    "name": "Glow'n'Glitter Green",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207038"
+                    ]
+                },
+                {
+                    "name": "Glowing Blue",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207034"
+                    ]
+                },
+                {
+                    "name": "Glowing BluePurple",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207036"
+                    ]
+                },
+                {
+                    "name": "Glowing Green",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207035"
+                    ]
+                },
+                {
+                    "name": "Glowing Orange",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207037"
+                    ]
+                },
+                {
+                    "name": "Glowing Rainbow",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "glow": true,
+                    "codes": [
+                        "207030"
+                    ]
+                },
+                {
+                    "name": "Glowing Red",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207031"
+                    ]
+                },
+                {
+                    "name": "Glowing White",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207032"
+                    ]
+                },
+                {
+                    "name": "Glowing Yellow",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "207033"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000",
+                    "glow": true,
+                    "codes": [
+                        "200451"
+                    ]
+                },
+                {
+                    "name": "Green-Purple",
+                    "hex": "808080",
+                    "glow": true,
+                    "codes": [
+                        "200452"
+                    ]
+                },
+                {
+                    "name": "Multi Glow Rainbow",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "glow": true,
+                    "codes": [
+                        "210019"
+                    ]
+                }
+            ],
+            "glow": true
+        },
+        {
+            "name": "Premium High Speed PLA {color_name}",
+            "material": "PLA",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Silky Bronze",
+                    "hex": "808080",
+                    "codes": [
+                        "1000438"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Matt PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Cool Grey",
+                    "hex": "808080",
+                    "finish": "matte",
+                    "codes": [
+                        "200305"
+                    ]
+                },
+                {
+                    "name": "Ghost White",
+                    "hex": "f8f8ff",
+                    "finish": "matte",
+                    "codes": [
+                        "200302"
+                    ]
+                },
+                {
+                    "name": "Marine Blue",
+                    "hex": "808080",
+                    "finish": "matte",
+                    "codes": [
+                        "200306"
+                    ]
+                },
+                {
+                    "name": "Matte Rainbow Macaron",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "matte",
+                    "codes": [
+                        "210007"
+                    ],
+                    "eans": [
+                        "5745001109363"
+                    ]
+                },
+                {
+                    "name": "Matte Rainbow Ocean Wave",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "matte",
+                    "codes": [
+                        "210012"
+                    ],
+                    "eans": [
+                        "5745001109417"
+                    ]
+                },
+                {
+                    "name": "Matte Rainbow Paddy Fields",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "matte",
+                    "codes": [
+                        "210014"
+                    ],
+                    "eans": [
+                        "5745001109431"
+                    ]
+                },
+                {
+                    "name": "Matte Rainbow Purple Rain",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "matte",
+                    "codes": [
+                        "210011"
+                    ],
+                    "eans": [
+                        "5745001109400"
+                    ]
+                },
+                {
+                    "name": "Matte Rainbow Sunrise",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "matte",
+                    "codes": [
+                        "210013"
+                    ],
+                    "eans": [
+                        "5745001109424"
+                    ]
+                },
+                {
+                    "name": "Midnight Black",
+                    "hex": "101820",
+                    "finish": "matte",
+                    "codes": [
+                        "200301"
+                    ]
+                },
+                {
+                    "name": "Moss Green",
+                    "hex": "808080",
+                    "finish": "matte",
+                    "codes": [
+                        "200303"
+                    ]
+                },
+                {
+                    "name": "Ruby Red",
+                    "hex": "808080",
+                    "finish": "matte",
+                    "codes": [
+                        "200304"
+                    ]
+                },
+                {
+                    "name": "Sun Yellow",
+                    "hex": "808080",
+                    "finish": "matte",
+                    "codes": [
+                        "200307"
+                    ]
+                }
+            ],
+            "finish": "matte"
+        },
+        {
+            "name": "Premium Opaque PETG {color_name}",
+            "material": "PLA",
+            "density": 1.17,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                2.85
+            ],
+            "extruder_temp_range": [
+                230,
+                255
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "251802"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Opaque PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "201901"
+                    ]
+                },
+                {
+                    "name": "Off White",
+                    "hex": "808080",
+                    "codes": [
+                        "201902"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 5000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Aqua Blue",
+                    "hex": "40c1ac",
+                    "codes": [
+                        "200025"
+                    ]
+                },
+                {
+                    "name": "Army Green",
+                    "hex": "4b5320",
+                    "codes": [
+                        "200013"
+                    ]
+                },
+                {
+                    "name": "Army Green Camouflage",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "codes": [
+                        "200469"
+                    ]
+                },
+                {
+                    "name": "Black in Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "210023"
+                    ],
+                    "eans": [
+                        "5745001109653"
+                    ]
+                },
+                {
+                    "name": "Camel Beige",
+                    "hex": "d3bc8d",
+                    "codes": [
+                        "200027"
+                    ]
+                },
+                {
+                    "name": "Chameleon Blue",
+                    "hex": "808080",
+                    "codes": [
+                        "207082"
+                    ]
+                },
+                {
+                    "name": "Chameleon Purple",
+                    "hex": "808080",
+                    "codes": [
+                        "207083"
+                    ]
+                },
+                {
+                    "name": "Cherry Red",
+                    "hex": "93272c",
+                    "codes": [
+                        "200006"
+                    ]
+                },
+                {
+                    "name": "Chocolate Brown",
+                    "hex": "5b3427",
+                    "codes": [
+                        "200032"
+                    ]
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "0033a0",
+                    "codes": [
+                        "200022"
+                    ]
+                },
+                {
+                    "name": "Dark Stone",
+                    "hex": "b2b4b2",
+                    "codes": [
+                        "200466"
+                    ]
+                },
+                {
+                    "name": "Emerald Green",
+                    "hex": "2e8b57",
+                    "codes": [
+                        "210021"
+                    ]
+                },
+                {
+                    "name": "Flame Orange",
+                    "hex": "ff6900",
+                    "codes": [
+                        "200030"
+                    ]
+                },
+                {
+                    "name": "Flourish Rainbow",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "codes": [
+                        "200471",
+                        "250471"
+                    ]
+                },
+                {
+                    "name": "Frosted Bronze",
+                    "hex": "808080",
+                    "codes": [
+                        "200460"
+                    ]
+                },
+                {
+                    "name": "Gecko Green",
+                    "hex": "44d62c",
+                    "codes": [
+                        "200029"
+                    ]
+                },
+                {
+                    "name": "Hot Pink",
+                    "hex": "ff69b4",
+                    "codes": [
+                        "200018"
+                    ]
+                },
+                {
+                    "name": "Ice Blue",
+                    "hex": "a5d8ff",
+                    "codes": [
+                        "200024"
+                    ]
+                },
+                {
+                    "name": "Kaki Camouflage",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "codes": [
+                        "200468"
+                    ]
+                },
+                {
+                    "name": "Leaf Green",
+                    "hex": "228b22",
+                    "codes": [
+                        "200028"
+                    ]
+                },
+                {
+                    "name": "Leather Brown",
+                    "hex": "8b5a2b",
+                    "codes": [
+                        "200031"
+                    ]
+                },
+                {
+                    "name": "Light Stone",
+                    "hex": "b0b0b0",
+                    "codes": [
+                        "200467"
+                    ]
+                },
+                {
+                    "name": "Magenta",
+                    "hex": "ce0f69",
+                    "codes": [
+                        "200026"
+                    ]
+                },
+                {
+                    "name": "Magic Green Forest",
+                    "hex": "808080",
+                    "codes": [
+                        "210002"
+                    ],
+                    "eans": [
+                        "5745001109318"
+                    ]
+                },
+                {
+                    "name": "Mailbox Red",
+                    "hex": "c8102e",
+                    "codes": [
+                        "200005",
+                        "210027"
+                    ],
+                    "eans_refill": [
+                        "5745001109691"
+                    ]
+                },
+                {
+                    "name": "Mystic Blue",
+                    "hex": "4b0082",
+                    "codes": [
+                        "200050"
+                    ]
+                },
+                {
+                    "name": "Normal Blue",
+                    "hex": "005eb8",
+                    "codes": [
+                        "200023"
+                    ]
+                },
+                {
+                    "name": "Nude Color",
+                    "hex": "e8beac",
+                    "codes": [
+                        "200020"
+                    ]
+                },
+                {
+                    "name": "Pearl Copper",
+                    "hex": "808080",
+                    "codes": [
+                        "200411"
+                    ]
+                },
+                {
+                    "name": "Pearl Nature",
+                    "hex": "808080",
+                    "codes": [
+                        "200019",
+                        "207055"
+                    ]
+                },
+                {
+                    "name": "Pearl Purplish Red",
+                    "hex": "808080",
+                    "codes": [
+                        "200412"
+                    ]
+                },
+                {
+                    "name": "Pearl Red Brown",
+                    "hex": "808080",
+                    "codes": [
+                        "200410"
+                    ]
+                },
+                {
+                    "name": "Pirate Black",
+                    "hex": "25282a",
+                    "codes": [
+                        "200080",
+                        "200001",
+                        "200090",
+                        "210024"
+                    ],
+                    "eans": [
+                        "5711336017895"
+                    ],
+                    "eans_refill": [
+                        "5745001109660"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "8031a7",
+                    "codes": [
+                        "200009"
+                    ]
+                },
+                {
+                    "name": "Rainbow",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "codes": [
+                        "207060",
+                        "207061",
+                        "207062",
+                        "207064",
+                        "207065",
+                        "207066",
+                        "207067",
+                        "207068",
+                        "207069",
+                        "207070",
+                        "207071",
+                        "207072",
+                        "207073",
+                        "207074",
+                        "207063"
+                    ]
+                },
+                {
+                    "name": "Signal Yellow",
+                    "hex": "fedd00",
+                    "codes": [
+                        "200007"
+                    ]
+                },
+                {
+                    "name": "Silk Rainbow Universe",
+                    "hex": "808080",
+                    "codes": [
+                        "210016"
+                    ],
+                    "eans": [
+                        "5745001109295"
+                    ]
+                },
+                {
+                    "name": "Slate Grey",
+                    "hex": "4f5358",
+                    "codes": [
+                        "200003",
+                        "200092",
+                        "250092",
+                        "200082",
+                        "210026"
+                    ],
+                    "eans_refill": [
+                        "5745001109684"
+                    ]
+                },
+                {
+                    "name": "Snow White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "200002",
+                        "200091",
+                        "200081",
+                        "210025"
+                    ],
+                    "eans": [
+                        "5711336017888"
+                    ],
+                    "eans_refill": [
+                        "5745001109677"
+                    ]
+                },
+                {
+                    "name": "Terminator Grey",
+                    "hex": "97999b",
+                    "codes": [
+                        "200004",
+                        "200093",
+                        "200083",
+                        "210034"
+                    ],
+                    "eans_refill": [
+                        "5745001109769"
+                    ]
+                },
+                {
+                    "name": "Water Blue",
+                    "hex": "0077be",
+                    "codes": [
+                        "200040"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Pastel PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Dino Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200008"
+                    ]
+                },
+                {
+                    "name": "Lavender Purple - Pastel",
+                    "hex": "808080",
+                    "codes": [
+                        "200016"
+                    ]
+                },
+                {
+                    "name": "Steel Blue - Pastel",
+                    "hex": "808080",
+                    "codes": [
+                        "200015"
+                    ]
+                },
+                {
+                    "name": "Sunrise Yellow - Pastel",
+                    "hex": "808080",
+                    "codes": [
+                        "200014"
+                    ]
+                },
+                {
+                    "name": "Unicorn Pink - Pastel",
+                    "hex": "808080",
+                    "codes": [
+                        "200017"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Shimmer PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "25282a",
+                    "codes": [
+                        "200505"
+                    ]
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "003366",
+                    "codes": [
+                        "200502"
+                    ]
+                },
+                {
+                    "name": "Dark Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200508"
+                    ]
+                },
+                {
+                    "name": "Gold",
+                    "hex": "ffd700",
+                    "codes": [
+                        "200509"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "200504"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "ff0000",
+                    "codes": [
+                        "200507"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "c0c0c0",
+                    "codes": [
+                        "200501"
+                    ]
+                },
+                {
+                    "name": "Transparent Red",
+                    "hex": "c8102e",
+                    "codes": [
+                        "200503"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Silky PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "BiColor - Yellow&Blue",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207005"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "3f4444",
+                    "finish": "glossy",
+                    "codes": [
+                        "200206"
+                    ]
+                },
+                {
+                    "name": "Black & Gold",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207044"
+                    ]
+                },
+                {
+                    "name": "Black & Green",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207043"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "71c5e8",
+                    "finish": "glossy",
+                    "codes": [
+                        "200212"
+                    ]
+                },
+                {
+                    "name": "Blue & Green",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207041"
+                    ]
+                },
+                {
+                    "name": "Blue Purple",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200216"
+                    ]
+                },
+                {
+                    "name": "Bronze",
+                    "hex": "635939",
+                    "finish": "glossy",
+                    "codes": [
+                        "200202",
+                        "250202"
+                    ]
+                },
+                {
+                    "name": "Candy Pink",
+                    "hex": "dc8699",
+                    "finish": "glossy",
+                    "codes": [
+                        "200218"
+                    ]
+                },
+                {
+                    "name": "Copper",
+                    "hex": "83412c",
+                    "finish": "glossy",
+                    "codes": [
+                        "200203"
+                    ]
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "003366",
+                    "finish": "glossy",
+                    "codes": [
+                        "200213"
+                    ]
+                },
+                {
+                    "name": "Dark Blue & Gold",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207002"
+                    ]
+                },
+                {
+                    "name": "Deep Cyan",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200225"
+                    ]
+                },
+                {
+                    "name": "Elixir Blue",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200214",
+                        "250214"
+                    ]
+                },
+                {
+                    "name": "Gecko Green",
+                    "hex": "78d64b",
+                    "finish": "glossy",
+                    "codes": [
+                        "200209"
+                    ]
+                },
+                {
+                    "name": "Gold",
+                    "hex": "d19000",
+                    "finish": "glossy",
+                    "codes": [
+                        "200204"
+                    ]
+                },
+                {
+                    "name": "Golden Yellow",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200227"
+                    ]
+                },
+                {
+                    "name": "Goldfish Orange",
+                    "hex": "d45d00",
+                    "finish": "glossy",
+                    "codes": [
+                        "200220",
+                        "200620"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000",
+                    "finish": "glossy",
+                    "codes": [
+                        "200210",
+                        "250210"
+                    ]
+                },
+                {
+                    "name": "Green & Yellow",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207042"
+                    ]
+                },
+                {
+                    "name": "Iron Grey",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200230"
+                    ]
+                },
+                {
+                    "name": "Lagoon Blue",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200224"
+                    ]
+                },
+                {
+                    "name": "Mix Red-Sapphire Blue",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200222"
+                    ]
+                },
+                {
+                    "name": "Mocha Brown",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200226"
+                    ]
+                },
+                {
+                    "name": "Pink & Gold",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207001"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "8031a7",
+                    "finish": "glossy",
+                    "codes": [
+                        "200215"
+                    ]
+                },
+                {
+                    "name": "Rainbow",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "200472",
+                        "250472"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "ba0c2f",
+                    "finish": "glossy",
+                    "codes": [
+                        "200219"
+                    ]
+                },
+                {
+                    "name": "Red & Black",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207040"
+                    ]
+                },
+                {
+                    "name": "Red & Blue",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207003"
+                    ]
+                },
+                {
+                    "name": "Red & Gold",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207004"
+                    ]
+                },
+                {
+                    "name": "Red & Light Green",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "207006"
+                    ]
+                },
+                {
+                    "name": "Red Copper",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200201"
+                    ]
+                },
+                {
+                    "name": "Rose Gold",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200229"
+                    ]
+                },
+                {
+                    "name": "Sage Green",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "200221"
+                    ]
+                },
+                {
+                    "name": "Silky Rainbow Blue Violet",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "210008"
+                    ],
+                    "eans": [
+                        "5745001109370"
+                    ]
+                },
+                {
+                    "name": "Silky Rainbow Candy",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "210009"
+                    ],
+                    "eans": [
+                        "5745001109387"
+                    ]
+                },
+                {
+                    "name": "Silky Rainbow Flower",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "210005"
+                    ],
+                    "eans": [
+                        "5745001109349"
+                    ]
+                },
+                {
+                    "name": "Silky Rainbow Forest",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "210010"
+                    ],
+                    "eans": [
+                        "5745001109394"
+                    ]
+                },
+                {
+                    "name": "Silky Rainbow Macaron",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "210003"
+                    ],
+                    "eans": [
+                        "5745001109325"
+                    ]
+                },
+                {
+                    "name": "Silky Rainbow Pastel",
+                    "hex": "808080",
+                    "finish": "glossy",
+                    "codes": [
+                        "210004"
+                    ],
+                    "eans": [
+                        "5745001109332"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "7c878e",
+                    "finish": "glossy",
+                    "codes": [
+                        "200205"
+                    ]
+                },
+                {
+                    "name": "Sparkly Rainbow",
+                    "hexes": [
+                        "ff0000",
+                        "ff8800",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "200473"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Blue and Fuchsia",
+                    "hexes": [
+                        "ffd700",
+                        "0000ff",
+                        "808080"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207012"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Blue and Red",
+                    "hexes": [
+                        "ffd700",
+                        "0000ff",
+                        "ff0000"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207008"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Fuchsia and Black",
+                    "hexes": [
+                        "ffd700",
+                        "808080",
+                        "000000"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207011"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Green and Blue",
+                    "hexes": [
+                        "ffd700",
+                        "008000",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207010"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Green and Fuchsia",
+                    "hexes": [
+                        "ffd700",
+                        "008000",
+                        "808080"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207017"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Green and Pinkish",
+                    "hexes": [
+                        "ffd700",
+                        "008000",
+                        "808080"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207013"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Green and Purple",
+                    "hexes": [
+                        "ffd700",
+                        "008000",
+                        "8031a7"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207009"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Green and Red",
+                    "hexes": [
+                        "ffd700",
+                        "008000",
+                        "ff0000"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207014"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Red and Black",
+                    "hexes": [
+                        "ffd700",
+                        "ff0000",
+                        "000000"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207016"
+                    ]
+                },
+                {
+                    "name": "Tricolor Gold, Silver and Copper",
+                    "hexes": [
+                        "ffd700",
+                        "c0c0c0",
+                        "b87333"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207007"
+                    ]
+                },
+                {
+                    "name": "Tricolor Red, Green and Blue",
+                    "hexes": [
+                        "ff0000",
+                        "008000",
+                        "0000ff"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy",
+                    "codes": [
+                        "207015"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "finish": "glossy",
+                    "codes": [
+                        "200207"
+                    ]
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "ffff00",
+                    "finish": "glossy",
+                    "codes": [
+                        "200208",
+                        "250208"
+                    ]
+                }
+            ],
+            "finish": "glossy"
+        },
+        {
+            "name": "Premium Transparent PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "332f21",
+                    "translucent": true,
+                    "codes": [
+                        "200037"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000ff",
+                    "translucent": true,
+                    "codes": [
+                        "200035"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "009b77",
+                    "translucent": true,
+                    "codes": [
+                        "200036"
+                    ]
+                },
+                {
+                    "name": "Light Grey",
+                    "hex": "97999b",
+                    "translucent": true,
+                    "codes": [
+                        "200038"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "ffa500",
+                    "translucent": true,
+                    "codes": [
+                        "200034"
+                    ]
+                },
+                {
+                    "name": "PLA Transparent Rainbow - Glacier Blue",
+                    "hex": "808080",
+                    "translucent": true,
+                    "codes": [
+                        "207096"
+                    ]
+                },
+                {
+                    "name": "PLA Transparent Rainbow - Lotus Pink",
+                    "hex": "808080",
+                    "translucent": true,
+                    "codes": [
+                        "207098"
+                    ]
+                },
+                {
+                    "name": "PLA Transparent Rainbow - Mint Green",
+                    "hex": "808080",
+                    "translucent": true,
+                    "codes": [
+                        "207097"
+                    ]
+                },
+                {
+                    "name": "PLA Transparent Rainbow - Phantom Blue",
+                    "hex": "808080",
+                    "translucent": true,
+                    "codes": [
+                        "207099"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "c63527",
+                    "translucent": true,
+                    "codes": [
+                        "200039"
+                    ]
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "808080",
+                    "translucent": true,
+                    "codes": [
+                        "200094",
+                        "200021"
+                    ]
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "f3e500",
+                    "translucent": true,
+                    "codes": [
+                        "200033"
+                    ]
+                }
+            ],
+            "translucent": true
+        },
+        {
+            "name": "Premium Woodfill PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Dark Wood",
+                    "hex": "bf9474",
+                    "pattern": null,
+                    "codes": [
+                        "200481"
+                    ]
+                },
+                {
+                    "name": "Light Wood",
+                    "hex": "c4a484",
+                    "pattern": null,
+                    "codes": [
+                        "200480"
+                    ]
+                },
+                {
+                    "name": "Wood",
+                    "hex": "808080",
+                    "pattern": null,
+                    "codes": [
+                        "200483",
+                        "200482"
+                    ]
+                }
+            ],
+            "fill": "wood"
+        },
+        {
+            "name": "Premium X-Strong PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "201501"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "201505"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "201502"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                35,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "202650"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium 4D PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Nature",
+                    "hex": "f5f5dc",
+                    "codes": [
+                        "205000"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Antibacterial PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "200491"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Antistatic PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "202651"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium High Temp PLA {color_name}",
+            "material": "PLAHIGHTEMP",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "200351",
+                        "250351"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080",
+                    "codes": [
+                        "200353"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "200352",
+                        "250352"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Magic PLA {color_name}",
+            "material": "PLAMAGIC",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "0000ff",
+                    "codes": [
+                        "207051"
+                    ]
+                },
+                {
+                    "name": "Gold",
+                    "hex": "ffd700",
+                    "codes": [
+                        "207050"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000",
+                    "codes": [
+                        "207052"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "8031a7",
+                    "codes": [
+                        "207053"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Seaweed PLA {color_name}",
+            "material": "PLASEAWEED",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Yellow/Green",
+                    "hex": "808080",
+                    "codes": [
+                        "200454"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium PP {color_name}",
+            "material": "PP",
+            "density": 0.9,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                230,
+                260
+            ],
+            "bed_temp_range": [
+                45,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "200851",
+                        "250852"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Premium Ceramic {color_name}",
+            "material": "PVB",
+            "density": 1.16,
+            "weights": [
+                {
+                    "weight": 500,
+                    "spool_weight": 200,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                195,
+                215
+            ],
+            "bed_temp_range": [
+                60,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Jade Nature",
+                    "hex": "00a86b",
+                    "codes": [
+                        "10009115"
+                    ],
+                    "eans": [
+                        "7426934809503"
+                    ]
+                },
+                {
+                    "name": "Snow White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "10009110"
+                    ],
+                    "eans": [
+                        "7426934809497"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/3dea.json
+++ b/filaments/3dea.json
@@ -1,0 +1,312 @@
+{
+  "manufacturer": "3DEA",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff4f4f"
+        }
+      ]
+    },
+    {
+      "name": "Blend {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.252,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "202020"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Luminous Blue",
+          "hex": "d2d2ff"
+        }
+      ]
+    },
+    {
+      "name": "PA6 {color_name}",
+      "material": "PA6",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Brown",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Military Olive",
+          "hex": "404000"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Walnut Wood",
+          "hex": "98633b"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "Graphite",
+          "hex": "53565b"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold & Blue & Red",
+          "hex": "f1ec1d"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "clear",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dfila.json
+++ b/filaments/3dfila.json
@@ -1,0 +1,298 @@
+{
+  "manufacturer": "3DFila",
+  "filaments": [
+    {
+      "name": "90A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ABS Premium {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Branco Gesso",
+          "hex": "dadfe5"
+        },
+        {
+          "name": "Branco Odonto",
+          "hex": "c3c8c5"
+        },
+        {
+          "name": "Marrom Imperador",
+          "hex": "75563e"
+        },
+        {
+          "name": "Preto Ebony",
+          "hex": "000000"
+        },
+        {
+          "name": "Preto Sépia",
+          "hex": "000000"
+        },
+        {
+          "name": "Rosa Choque",
+          "hex": "d82c7c"
+        },
+        {
+          "name": "Roxo Titânio",
+          "hex": "523b71"
+        },
+        {
+          "name": "Vermelho Aranha",
+          "hex": "b93c39"
+        }
+      ]
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Fosforecente",
+          "hex": "c2d8c8"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PCTG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Tritan Preto Black Petroleum",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Amarelo Neon",
+          "hex": "d4ff00"
+        },
+        {
+          "name": "Vermelho Neon",
+          "hex": "ff0040"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        0,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Gold Metal",
+          "hex": "96804f"
+        },
+        {
+          "name": "XT Azul Blue Metal",
+          "hex": "21607a"
+        },
+        {
+          "name": "XT Cinza Gray Storm",
+          "hex": "65696a"
+        },
+        {
+          "name": "XT Preto Black Night",
+          "hex": "000000"
+        },
+        {
+          "name": "XT Transparente Glass",
+          "hex": "ff00f7"
+        },
+        {
+          "name": "XT Verde Green Metal",
+          "hex": "336054"
+        },
+        {
+          "name": "XT Vermelho Red Metal",
+          "hex": "a30008"
+        },
+        {
+          "name": "Green metal",
+          "hex": "263e0f"
+        },
+        {
+          "name": "XT Branco Snow White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Azul Caneta",
+          "hex": "1404fb"
+        },
+        {
+          "name": "Azul Claro",
+          "hex": "00a3c2"
+        },
+        {
+          "name": "Branco Gesso",
+          "hex": "e2e8ee"
+        },
+        {
+          "name": "Caucasiano",
+          "hex": "c9a992"
+        },
+        {
+          "name": "Cinza Prime",
+          "hex": "a6a6a6"
+        },
+        {
+          "name": "Dourado",
+          "hex": "8e7829"
+        },
+        {
+          "name": "Laranja",
+          "hex": "e16f24"
+        },
+        {
+          "name": "Natural Transparente",
+          "hex": "aaa69a"
+        },
+        {
+          "name": "Preto",
+          "hex": "242322"
+        },
+        {
+          "name": "Rosa",
+          "hex": "c832a0"
+        },
+        {
+          "name": "vermelho",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dfilament.json
+++ b/filaments/3dfilament.json
@@ -1,0 +1,398 @@
+{
+  "manufacturer": "3D Filament",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Carbon",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green to Neon-Yellow",
+          "hex": "1c3c31"
+        },
+        {
+          "name": "Temp. 33-45 C Black Red Yellow",
+          "hex": "302d0d"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Glowing Natural",
+          "hex": "ebebeb"
+        },
+        {
+          "name": "Glowing Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red Yellow Green",
+          "hex": "f55183"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Pink",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Weiss",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blau",
+          "hex": "004b9e"
+        },
+        {
+          "name": "Goldgelb",
+          "hex": "feb43f"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Carbon",
+          "hex": "030000"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "795038"
+        },
+        {
+          "name": "Gelb neon",
+          "hex": "e9ff1c"
+        },
+        {
+          "name": "Luminous Starry Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Oro (GOLD)",
+          "hex": "b48907"
+        },
+        {
+          "name": "Red",
+          "hex": "fa0025"
+        },
+        {
+          "name": "Rosso",
+          "hex": "d21414"
+        },
+        {
+          "name": "Skin",
+          "hex": "9fab9a"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold Plated Black",
+          "hex": "938e06"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "c37752"
+        },
+        {
+          "name": "silver/copper",
+          "hex": "4c4d4d"
+        }
+      ]
+    },
+    {
+      "name": "Silk Multi Color {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Green Black",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dragon Rainbow",
+          "hex": "032945"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Azur trans",
+          "hex": "00736c"
+        },
+        {
+          "name": "Orange",
+          "hex": "bcd453"
+        },
+        {
+          "name": "Rot",
+          "hex": "9b001a"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dfillies.json
+++ b/filaments/3dfillies.json
@@ -1,0 +1,204 @@
+{
+  "manufacturer": "3DFillies",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Chromatic - Twilight",
+          "hex": "a100e2"
+        },
+        {
+          "name": "MultiColor - Blue/Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "f5c555"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "0b3d95"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "051386"
+        },
+        {
+          "name": "Green",
+          "hex": "079140"
+        },
+        {
+          "name": "Lithophane White",
+          "hex": "e0e0e0"
+        },
+        {
+          "name": "Orange",
+          "hex": "ee6d2f"
+        },
+        {
+          "name": "Pastel Purple",
+          "hex": "bcabe5"
+        },
+        {
+          "name": "Pink",
+          "hex": "bc43aa"
+        },
+        {
+          "name": "Purple",
+          "hex": "8000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Skin",
+          "hex": "e9c3a4"
+        },
+        {
+          "name": "Transparent",
+          "hex": "afa796"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "e1c726"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        10,
+        10
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dfils.json
+++ b/filaments/3dfils.json
@@ -1,0 +1,265 @@
+{
+  "manufacturer": "3DFILS",
+  "filaments": [
+    {
+      "name": "60D {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "85A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "c30913"
+        }
+      ]
+    },
+    {
+      "name": "90A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Galactic Clear",
+          "hex": "c6c7c1",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galactic Gray",
+          "hex": "4f4f4f",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galactic Red",
+          "hex": "da152d",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Max {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Banana Yellow",
+          "hex": "e9e093"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "7cf8f0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Graphite Grey",
+          "hex": "474747"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "aa7941"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Electric blue",
+          "hex": "0040ff"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dgenius.json
+++ b/filaments/3dgenius.json
@@ -1,0 +1,324 @@
+{
+  "manufacturer": "3Dgenius",
+  "filaments": [
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Silk Gradient Silver Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Matte Gradient",
+          "hex": "9cf0b1"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "56aca7"
+        },
+        {
+          "name": "Rose Red + Sky Blue + Green",
+          "hexes": [
+            "c15add",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "4d9de2"
+        },
+        {
+          "name": "Brown",
+          "hex": "583300"
+        },
+        {
+          "name": "Purple",
+          "hex": "7f18af"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Candy Series",
+          "hex": "c43dc7"
+        },
+        {
+          "name": "Rose Red / Sky Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        45,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Dark Blue + Green",
+          "hexes": [
+            "000080",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold Red Orange",
+          "hex": "ff4b33"
+        },
+        {
+          "name": "Purple Sky Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Red + Black",
+          "hexes": [
+            "ff0000",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose Red + Yellow + Sky Blue",
+          "hexes": [
+            "aa5046",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Skyblue/Green",
+          "hexes": [
+            "107ae5",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Orange - Red",
+          "hex": "fe612c"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gradient Candy",
+          "hex": "4cdee6"
+        },
+        {
+          "name": "Gradient Macaron",
+          "hex": "808080"
+        },
+        {
+          "name": "Universe",
+          "hex": "460074"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Red Gold Purple",
+          "hex": "c49921"
+        },
+        {
+          "name": "Rose Red Dark Blue Green",
+          "hex": "0c5fe1"
+        },
+        {
+          "name": "Rose Red/Sky Blue/Green",
+          "hexes": [
+            "3a88fe",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dhojor.json
+++ b/filaments/3dhojor.json
@@ -1,0 +1,1374 @@
+{
+  "manufacturer": "3DHoJor",
+  "filaments": [
+    {
+      "name": "Basic PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Basic Black",
+          "codes": [
+            "HJ-Hyper PLA-175B1-DE",
+            "HJ-Hyper PLA-175B1-US"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Basic Blue",
+          "codes": [
+            "HJ-Hyper PLA-175U1-DE",
+            "HJ-Hyper PLA-175U1-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "Basic Cold White",
+          "codes": [
+            "HJ-Hyper PLA-175CW1-DE",
+            "HJ-Hyper PLA-175CW1-US"
+          ],
+          "hex": "f0f4f8"
+        },
+        {
+          "name": "Basic Fire Engine Red",
+          "codes": [
+            "HJ-Hyper PLA-175FR1-DE",
+            "HJ-Hyper PLA-175FR1-US"
+          ],
+          "hex": "ce2029"
+        },
+        {
+          "name": "Basic Green",
+          "codes": [
+            "HJ-Hyper PLA-175G1-DE",
+            "HJ-Hyper PLA-175G1-US"
+          ],
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Basic Grey",
+          "codes": [
+            "HJ-Hyper PLA-175H1-DE",
+            "HJ-Hyper PLA-175H1-US"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Basic Light Blue",
+          "codes": [
+            "HJ-Hyper PLA-175LU1-DE",
+            "HJ-Hyper PLA-175LU1-US"
+          ],
+          "hex": "87ceeb"
+        },
+        {
+          "name": "Basic Light Gray",
+          "codes": [
+            "HJ-Hyper PLA-175LH1-DE",
+            "HJ-Hyper PLA-175LH1-US"
+          ],
+          "hex": "b0b0b0"
+        },
+        {
+          "name": "Basic Orange",
+          "codes": [
+            "HJ-Hyper PLA-175O1-DE",
+            "HJ-Hyper PLA-175O1-US"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Basic Pink",
+          "codes": [
+            "HJ-Hyper PLA-175P1-DE",
+            "HJ-Hyper PLA-175P1-US"
+          ],
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Basic Purple",
+          "codes": [
+            "HJ-Hyper PLA-175Z1-DE",
+            "HJ-Hyper PLA-175Z1-US"
+          ],
+          "hex": "800080"
+        },
+        {
+          "name": "Basic Silver",
+          "codes": [
+            "HJ-Hyper PLA-175S1-DE",
+            "HJ-Hyper PLA-175S1-US"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Basic White",
+          "codes": [
+            "HJ-Hyper PLA-175W1-DE",
+            "HJ-Hyper PLA-175W1-US"
+          ],
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "Crystal Rainbow PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Crystal Rainbow Flame",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175FL1-US"
+          ],
+          "hexes": [
+            "ff4500",
+            "ff6b35",
+            "ffd700",
+            "ff8c00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Galaxy",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175GA1-US"
+          ],
+          "hexes": [
+            "1a1a2e",
+            "4a148c",
+            "1565c0",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Glacier",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175TBW1-US"
+          ],
+          "hexes": [
+            "a8d8ea",
+            "81d4fa",
+            "b3e5fc",
+            "e1f5fe"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Late Autumn",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175LA1-US"
+          ],
+          "hexes": [
+            "d35400",
+            "e67e22",
+            "f1c40f",
+            "8b4513"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Maple Leaf",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175MF1-US"
+          ],
+          "hexes": [
+            "c0392b",
+            "e74c3c",
+            "f39c12",
+            "d35400"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Nebulae",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175TBP1-US"
+          ],
+          "hexes": [
+            "4b0082",
+            "8e24aa",
+            "3949ab",
+            "e040fb"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Prairie",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175TBG1-US"
+          ],
+          "hexes": [
+            "7cb342",
+            "aed581",
+            "fff176",
+            "81c784"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Crystal Rainbow Wheat Field",
+          "codes": [
+            "HJ-PLA-CrystalRainbow-175WF1-US"
+          ],
+          "hexes": [
+            "f4d03f",
+            "f9e79f",
+            "f5b041",
+            "d4ac0d"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "longitudinal"
+    },
+    {
+      "name": "Matte PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Matte Almond Yellow",
+          "codes": [
+            "HJ-Matte PLA-175Y1KG-DE",
+            "HJ-Matte PLA-175Y1KG-US"
+          ],
+          "hex": "efdecd"
+        },
+        {
+          "name": "Matte Dark Grey",
+          "codes": [
+            "HJ-Matte PLA-175DH1KG-DE",
+            "HJ-Matte PLA-175DH1KG-US"
+          ],
+          "hex": "4a4a4a"
+        },
+        {
+          "name": "Matte Deep Black",
+          "codes": [
+            "HJ-Matte PLA-175DP1KG-DE",
+            "HJ-Matte PLA-175DP1KG-US"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Matte Light Blue",
+          "codes": [
+            "HJ-Matte PLA-175LU1KG-DE",
+            "HJ-Matte PLA-175LU1KG-US"
+          ],
+          "hex": "87ceeb"
+        },
+        {
+          "name": "Matte Light Khaki",
+          "codes": [
+            "HJ-Matte PLA-175LK1KG-DE",
+            "HJ-Matte PLA-175LK1KG-US"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Matte Milky White",
+          "codes": [
+            "HJ-Matte PLA-175NW1KG-DE",
+            "HJ-Matte PLA-175NW1KG-US"
+          ],
+          "hex": "faf8f5"
+        },
+        {
+          "name": "Matte Mint Green",
+          "codes": [
+            "HJ-Matte PLA-175MG1KG-DE",
+            "HJ-Matte PLA-175MG1KG-US"
+          ],
+          "hex": "98ff98"
+        },
+        {
+          "name": "Matte Morandi Purple",
+          "codes": [
+            "HJ-Matte PLA-175Z1KG-DE",
+            "HJ-Matte PLA-175Z1KG-US"
+          ],
+          "hex": "9b8ec4"
+        },
+        {
+          "name": "Matte Peach Pink",
+          "codes": [
+            "HJ-Matte PLA-175P1KG-DE",
+            "HJ-Matte PLA-175P1KG-US"
+          ],
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Matte Tangerine",
+          "codes": [
+            "HJ-Matte PLA-175O1KG-DE",
+            "HJ-Matte PLA-175O1KG-US"
+          ],
+          "hex": "808080"
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "PETG Blue",
+          "codes": [
+            "HJ-PETG-175SU1KG-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "PETG Green",
+          "codes": [
+            "HJ-PETG-175G1KG-US"
+          ],
+          "hex": "2e7d32"
+        },
+        {
+          "name": "PETG Natural",
+          "codes": [
+            "HJ-PETG-175SN1KG-US"
+          ],
+          "hex": "d4c4a8"
+        },
+        {
+          "name": "PETG Orange",
+          "codes": [
+            "HJ-PETG-175SO1KG-US"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "PETG Solid Black",
+          "codes": [
+            "HJ-PETG-175SB1KG-US-001"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "PETG Solid Blue",
+          "codes": [
+            "HJ-PETG-175U1KG-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "PETG Solid Grey",
+          "codes": [
+            "HJ-PETG-175SH1KG-US-001"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "PETG Solid Red",
+          "codes": [
+            "HJ-PETG-175SR1KG-US"
+          ],
+          "hex": "c41e2a"
+        },
+        {
+          "name": "PETG Solid Silver",
+          "codes": [
+            "HJ-PETG-175SS1KG-US"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "PETG Solid White",
+          "codes": [
+            "HJ-PETG-175SW1KG-US-001"
+          ],
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "PLA Lite {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "PLA Blue",
+          "codes": [
+            "HJ-PLA Lite-175U1KG-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "PLA Fire Engine Red",
+          "codes": [
+            "HJ-PLA Lite-175FR1KG-US"
+          ],
+          "hex": "ce2029"
+        },
+        {
+          "name": "PLA Green",
+          "codes": [
+            "HJ-PLA Lite-175G1KG-US"
+          ],
+          "hex": "2e7d32"
+        },
+        {
+          "name": "PLA Lite Black",
+          "codes": [
+            "HJ-PLA Lite-175B1KG-US"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "PLA Lite Cold White",
+          "codes": [
+            "HJ-PLA Lite-175CW1KG-US"
+          ],
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "PLA Lite Grey",
+          "codes": [
+            "HJ-PLA Lite-175H1KG-US"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "PLA Red",
+          "codes": [
+            "HJ-PLA Lite-175R1KG-US"
+          ],
+          "hex": "c41e2a"
+        },
+        {
+          "name": "PLA Very Peri",
+          "codes": [
+            "HJ-PLA Lite-175F1KG-US"
+          ],
+          "hex": "6667ab"
+        },
+        {
+          "name": "PLA White",
+          "codes": [
+            "HJ-PLA Lite-175W1KG-US"
+          ],
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "PLA Yellow",
+          "codes": [
+            "HJ-PLA Lite-175Y1KG-US"
+          ],
+          "hex": "ffd700"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "PLA Pro Beige",
+          "codes": [
+            "HJ-PLA Pro-175BG1-US"
+          ],
+          "hex": "d4b896"
+        },
+        {
+          "name": "PLA Pro Black",
+          "codes": [
+            "HJ-PLA Pro-175B1KG -DE",
+            "HJ-PLA Pro-175B1KG -US"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "PLA Pro Blue",
+          "codes": [
+            "HJ-PLA Pro-175U1KG -DE",
+            "HJ-PLA Pro-175U1KG -US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "PLA Pro Bone White",
+          "codes": [
+            "HJ-PLA Pro-175BW1"
+          ],
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "PLA Pro Brown",
+          "codes": [
+            "HJ-PLA Pro-175C1",
+            "HJ-PLA Pro-175C1-DE"
+          ],
+          "hex": "8b4513"
+        },
+        {
+          "name": "PLA Pro Cold White",
+          "codes": [
+            "HJ-PLA Pro-175W1KG -DE",
+            "HJ-PLA Pro-175W1KG -US"
+          ],
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "PLA Pro Green",
+          "codes": [
+            "HJ-PLA Pro-175G1-US"
+          ],
+          "hex": "2e7d32"
+        },
+        {
+          "name": "PLA Pro Grey",
+          "codes": [
+            "HJ-PLA Pro-175H1KG -DE",
+            "HJ-PLA Pro-175H1KG -US"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "PLA Pro Light Blue",
+          "codes": [
+            "HJ-PLA Pro-175D1-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "PLA Pro Orange",
+          "codes": [
+            "HJ-PLA Pro-175O1-DE",
+            "HJ-PLA Pro-175O1-US"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "PLA Pro Peak Green",
+          "codes": [
+            "HJ-PLA Pro-175V1"
+          ],
+          "hex": "2e7d32"
+        },
+        {
+          "name": "PLA Pro Pink",
+          "codes": [
+            "HJ-PLA Pro-175P1-DE",
+            "HJ-PLA Pro-175P1-US"
+          ],
+          "hex": "ff69b4"
+        },
+        {
+          "name": "PLA Pro Purple",
+          "codes": [
+            "HJ-PLA Pro-175Z1-US"
+          ],
+          "hex": "800080"
+        },
+        {
+          "name": "PLA Pro Red",
+          "codes": [
+            "HJ-PLA Pro-175R1KG -DE",
+            "HJ-PLA Pro-175R1KG -US"
+          ],
+          "hex": "c41e2a"
+        },
+        {
+          "name": "PLA Pro Silver",
+          "codes": [
+            "HJ-PLA Pro-175S1-US",
+            "HJ-PLA Pro-175S1KG -US"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "PLA Pro Yellow",
+          "codes": [
+            "HJ-PLA Pro-175Y1-DE",
+            "HJ-PLA Pro-175Y1-US"
+          ],
+          "hex": "ffd700"
+        }
+      ]
+    },
+    {
+      "name": "Rapid PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Rapid Black",
+          "codes": [
+            "HJ-PLA HS-175B1KG-US"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Rapid Blue",
+          "codes": [
+            "HJ-PLA HS-175U1KG-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "Rapid Grey",
+          "codes": [
+            "HJ-PLA HS-175H1KG-US"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Rapid Orange",
+          "codes": [
+            "HJ-PLA HS-175O1KG-US"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Rapid Red",
+          "codes": [
+            "HJ-PLA HS-175R1KG-US"
+          ],
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Rapid White",
+          "codes": [
+            "HJ-PLA HS-175W1KG-US"
+          ],
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Rapid Yellow",
+          "codes": [
+            "HJ-PLA HS-175Y1KG-US"
+          ],
+          "hex": "ffd700"
+        }
+      ]
+    },
+    {
+      "name": "Silk Magic Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black & Gold",
+          "codes": [
+            "HJ-PLA-SilkMagic-175BG1-US"
+          ],
+          "hexes": [
+            "1a1a1a",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Black & Green",
+          "codes": [
+            "HJ-PLA-SilkMagic-175BE1-US"
+          ],
+          "hexes": [
+            "1a1a1a",
+            "2e7d32"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Black & Purple",
+          "codes": [
+            "HJ-PLA-SilkMagic-175BP1-US"
+          ],
+          "hexes": [
+            "1a1a1a",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Black & Red",
+          "codes": [
+            "HJ-PLA-SilkMagic-175BR1-US"
+          ],
+          "hexes": [
+            "1a1a1a",
+            "c41e2a"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Blue & Green",
+          "codes": [
+            "HJ-PLA-SilkMagic-175LG1-US"
+          ],
+          "hexes": [
+            "1e3a8a",
+            "2e7d32"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Blue & Purple",
+          "codes": [
+            "HJ-PLA-SilkMagic-175LP1-US"
+          ],
+          "hexes": [
+            "1e3a8a",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Blue & Silver",
+          "codes": [
+            "HJ-PLA-SilkMagic-175LS1-US"
+          ],
+          "hexes": [
+            "1e3a8a",
+            "c0c0c0"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Gold & Silver",
+          "codes": [
+            "HJ-PLA-SilkMagic-175GS1-US"
+          ],
+          "hexes": [
+            "ffd700",
+            "c0c0c0"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Purple & Gold",
+          "codes": [
+            "HJ-PLA-SilkMagic-175PD1-US"
+          ],
+          "hexes": [
+            "800080",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Purple & Green",
+          "codes": [
+            "HJ-PLA-SilkMagic-175PG1-US"
+          ],
+          "hexes": [
+            "800080",
+            "2e7d32"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Red & Blue",
+          "codes": [
+            "HJ-PLA-SilkMagic-175RL1-US"
+          ],
+          "hexes": [
+            "c41e2a",
+            "1e3a8a"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Red & Gold",
+          "codes": [
+            "HJ-PLA-SilkMagic-175RG1-US"
+          ],
+          "hexes": [
+            "c41e2a",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Red & Green",
+          "codes": [
+            "HJ-PLA-SilkMagic-175RE1-US"
+          ],
+          "hexes": [
+            "c41e2a",
+            "2e7d32"
+          ],
+          "multi_color_direction": "coaxial"
+        }
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial"
+    },
+    {
+      "name": "Silk Mystic Tri {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black-Red-Gold",
+          "codes": [
+            "HJ-PLA-SilkMystic-175BRG1-US"
+          ],
+          "hexes": [
+            "1a1a1a",
+            "c41e2a",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Blue-Green-Orange",
+          "codes": [
+            "HJ-PLA-SilkMystic-175LOG1-US"
+          ],
+          "hexes": [
+            "1e3a8a",
+            "2e7d32",
+            "ff8c00"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Blue-Purple-Red",
+          "codes": [
+            "HJ-PLA-SilkMystic-175LPR1-US"
+          ],
+          "hexes": [
+            "1e3a8a",
+            "800080",
+            "c41e2a"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Gold-Silver-Copper",
+          "codes": [
+            "HJ-PLA-SilkMystic-175GSO1-US"
+          ],
+          "hexes": [
+            "ffd700",
+            "c0c0c0",
+            "b87333"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Red-Gold-Purple",
+          "codes": [
+            "HJ-PLA-SilkMystic-175RGP1-US"
+          ],
+          "hexes": [
+            "c41e2a",
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Red-Green-Blue",
+          "codes": [
+            "HJ-PLA-SilkMystic-175RGL1-US"
+          ],
+          "hexes": [
+            "c41e2a",
+            "2e7d32",
+            "1e3a8a"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Red-Yellow-Blue",
+          "codes": [
+            "HJ-PLA-SilkMystic-175RYB1-US"
+          ],
+          "hexes": [
+            "c41e2a",
+            "ffd700",
+            "1e3a8a"
+          ],
+          "multi_color_direction": "coaxial"
+        }
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial"
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Silk Blue",
+          "codes": [
+            "HJ-Silk PLA-175U1-DE",
+            "HJ-Silk PLA-175U1-US"
+          ],
+          "hex": "1e3a8a"
+        },
+        {
+          "name": "Silk Bronze",
+          "codes": [
+            "HJ-Silk PLA-175BR1-DE",
+            "HJ-Silk PLA-175BR1-US"
+          ],
+          "hex": "cd7f32"
+        },
+        {
+          "name": "Silk Copper",
+          "codes": [
+            "HJ-Silk PLA-175CO1KG-DE-001",
+            "HJ-Silk PLA-175CO1KG-US-001"
+          ],
+          "hex": "b87333"
+        },
+        {
+          "name": "Silk Gold",
+          "codes": [
+            "HJ-Silk PLA-175J1KG-US-001"
+          ],
+          "hex": "ffd700"
+        },
+        {
+          "name": "Silk Green",
+          "codes": [
+            "HJ-Silk PLA-175G1-DE",
+            "HJ-Silk PLA-175G1-US"
+          ],
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Silk Pink",
+          "codes": [
+            "HJ-Silk PLA-175P1-US"
+          ],
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Silk Purple",
+          "codes": [
+            "HJ-Silk PLA-175Z1-US"
+          ],
+          "hex": "800080"
+        },
+        {
+          "name": "Silk Red",
+          "codes": [
+            "HJ-Silk PLA-175R1-US"
+          ],
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Silk Silver",
+          "codes": [
+            "HJ-Silk PLA-175S1KG-DE-001",
+            "HJ-Silk PLA-175S1KG-US-001"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Silk White",
+          "codes": [
+            "HJ-Silk PLA-175W1-US"
+          ],
+          "hex": "f5f5f5"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Silk Rainbow PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Silk Rainbow Blood Orange",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175BN1-US"
+          ],
+          "hexes": [
+            "ff4500",
+            "ff6347",
+            "ff8c00",
+            "dc143c"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Rainbow Coral Reef",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175CF1-US"
+          ],
+          "hexes": [
+            "ff7f50",
+            "ff6347",
+            "ffa07a",
+            "20b2aa"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Rainbow Fiery Rose",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175LS1-US"
+          ],
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Rainbow Ivy",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175IV1-US"
+          ],
+          "hexes": [
+            "228b22",
+            "32cd32",
+            "90ee90",
+            "006400"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Rainbow Lavender",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175LD1-US"
+          ],
+          "hexes": [
+            "e6e6fa",
+            "d8bfd8",
+            "b19cd9",
+            "9370db"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Rainbow Macaron",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175RBA1-US"
+          ],
+          "hexes": [
+            "ffb7c5",
+            "b5ead7",
+            "c7ceea",
+            "ffdac1"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Rainbow Tulipa",
+          "codes": [
+            "HJ-PLA-SilkRainbow-175TU1-US"
+          ],
+          "hexes": [
+            "ff6b8a",
+            "ff1493",
+            "ff69b4",
+            "db7093"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "longitudinal"
+    },
+    {
+      "name": "TPU 95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "HJ-TPU-95A175B1"
+          ],
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Clear",
+          "codes": [
+            "HJ-TPU-95A175N1"
+          ],
+          "hex": "ffffff",
+          "translucent": true
+        },
+        {
+          "name": "Grey",
+          "codes": [
+            "HJ-TPU-95A175H1"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent Blue",
+          "codes": [
+            "HJ-TPU-95A175GU1"
+          ],
+          "hex": "6eb5ff",
+          "translucent": true
+        },
+        {
+          "name": "Transparent Red",
+          "codes": [
+            "HJ-TPU-95A175GR1"
+          ],
+          "hex": "ff6b6b",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "codes": [
+            "HJ-TPU-95A175W1"
+          ],
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "Wood PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Wood PLA Natural",
+          "codes": [
+            "HJ-Wood PLA-175N1"
+          ],
+          "hex": "c4a574"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/3dkordo.json
+++ b/filaments/3dkordo.json
@@ -1,0 +1,344 @@
+{
+  "manufacturer": "3DKordo",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PA12-CF",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Everfil {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Aluminium",
+          "hex": "a5a5a5"
+        },
+        {
+          "name": "azure blue silver",
+          "hex": "4b9cd3"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue Pantone 3005c",
+          "hex": "002e7a"
+        },
+        {
+          "name": "brown beige",
+          "hex": "af804f"
+        },
+        {
+          "name": "brown Pantone 478c",
+          "hex": "583400"
+        },
+        {
+          "name": "Carmine Red",
+          "hex": "831100"
+        },
+        {
+          "name": "copper metallic",
+          "hex": "b87333"
+        },
+        {
+          "name": "dark green",
+          "hex": "004d00"
+        },
+        {
+          "name": "dark green brocade",
+          "hex": "2c4f32"
+        },
+        {
+          "name": "Dark grey",
+          "hex": "444444"
+        },
+        {
+          "name": "glitter black",
+          "hex": "000000"
+        },
+        {
+          "name": "golden yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "gray ral 7005",
+          "hex": "606060"
+        },
+        {
+          "name": "green",
+          "hex": "00a859"
+        },
+        {
+          "name": "iron grey",
+          "hex": "464a4d"
+        },
+        {
+          "name": "light blue",
+          "hex": "0061ff"
+        },
+        {
+          "name": "lime green (roybi)",
+          "hex": "e4ef65"
+        },
+        {
+          "name": "Mint Green Ral 6029",
+          "hex": "20603d"
+        },
+        {
+          "name": "olive",
+          "hex": "263e0f"
+        },
+        {
+          "name": "orange",
+          "hex": "f05a28"
+        },
+        {
+          "name": "Orange Ral 2009",
+          "hex": "f54021"
+        },
+        {
+          "name": "perl blue",
+          "hex": "7293b5"
+        },
+        {
+          "name": "Perl Light Green",
+          "hex": "669c35"
+        },
+        {
+          "name": "pink",
+          "hex": "ff3eb5"
+        },
+        {
+          "name": "reafific red ral3020",
+          "hex": "b51a00"
+        },
+        {
+          "name": "Signal Yellow",
+          "hex": "f4a900"
+        },
+        {
+          "name": "Silk venetain rose",
+          "hex": "7b219f"
+        },
+        {
+          "name": "trafik red",
+          "hex": "e32400"
+        },
+        {
+          "name": "Transparent Glitter Red",
+          "hex": "e32400"
+        },
+        {
+          "name": "violet",
+          "hex": "6638b6"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow Ral 1003",
+          "hex": "e5be01"
+        }
+      ]
+    },
+    {
+      "name": "Everfil {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "27292b"
+        },
+        {
+          "name": "Green",
+          "hex": "368e55"
+        },
+        {
+          "name": "silver",
+          "hex": "878892"
+        }
+      ]
+    },
+    {
+      "name": "Everfil {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Everfil {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "black Matt",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "burgundy",
+          "hex": "a52a2a"
+        },
+        {
+          "name": "Natural",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Silver",
+          "hex": "a5a5a5"
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "b51a00"
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "002e7a"
+        },
+        {
+          "name": "Transparent Red",
+          "hex": "b3002d"
+        },
+        {
+          "name": "violet transparant",
+          "hex": "61177c"
+        },
+        {
+          "name": "water blue Matt",
+          "hex": "007577"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Everfil {color_name}",
+      "material": "PCTG",
+      "density": 1.26,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dlab.json
+++ b/filaments/3dlab.json
@@ -1,0 +1,157 @@
+{
+  "manufacturer": "3DLAB",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Areia",
+          "hex": "c1aa95"
+        },
+        {
+          "name": "Cinza",
+          "hex": "666666"
+        },
+        {
+          "name": "Rosê Gold",
+          "hex": "c96d7f"
+        },
+        {
+          "name": "Roxo",
+          "hex": "590c97"
+        },
+        {
+          "name": "Speed Premium Alumínio",
+          "hex": "636b74"
+        },
+        {
+          "name": "Speed Premium Amarelo",
+          "hex": "f2ec36"
+        },
+        {
+          "name": "Speed Premium Azul",
+          "hex": "000a99"
+        },
+        {
+          "name": "Speed Premium Azul Claro",
+          "hex": "327dc8"
+        },
+        {
+          "name": "Speed Premium Laranaja",
+          "hex": "ff5900"
+        },
+        {
+          "name": "Speed Premium Marmore",
+          "hex": "c5cace"
+        },
+        {
+          "name": "Speed Premium Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Speed Premium Transparente",
+          "hex": "e8e8e8"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marrom",
+          "hex": "271111"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Speed Premium Preto",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dmaliang.json
+++ b/filaments/3dmaliang.json
@@ -1,0 +1,332 @@
+{
+  "manufacturer": "3D Maliang",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "green to yellow",
+          "hex": "358500"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow Glitter transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        80
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "808080"
+        },
+        {
+          "name": "Black Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Black Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Bronze",
+          "hex": "808080"
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "DarkBlue",
+          "hex": "808080"
+        },
+        {
+          "name": "Gold",
+          "hex": "fff76b"
+        },
+        {
+          "name": "red",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "808080"
+        },
+        {
+          "name": "Rose Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Silk gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Silver",
+          "hex": "929292"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Flashpoint Forest",
+          "hex": "efaeed"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black Gold",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2457c7"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Flash Rainbow Candy",
+          "hex": "d6ecf2"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        160,
+        200
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Ebony",
+          "hex": "5f493c"
+        },
+        {
+          "name": "light wood",
+          "hex": "b89782"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/3do.json
+++ b/filaments/3do.json
@@ -1,0 +1,678 @@
+{
+    "manufacturer": "3DO",
+    "filaments": [
+        {
+            "name": "PLA 2.0 Tough {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Anthracite",
+                    "hex": "383e42",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Army Green",
+                    "hex": "4b5320",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000ff",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Brown",
+                    "hex": "964b00",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Grass Green",
+                    "hex": "00ff00",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "d3d3d3",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Makita Blue",
+                    "hex": "016c78",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "ffa500"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "ffc0cb"
+                },
+                {
+                    "name": "Red",
+                    "hex": "ff0000",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Sand White",
+                    "hex": "fae4d5",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "c0c0c0"
+                },
+                {
+                    "name": "Steel Blue",
+                    "hex": "32527b",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "ffff00"
+                }
+            ],
+            "finish": "matte",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "cfb53b",
+                    "codes": [
+                        "50509"
+                    ]
+                }
+            ],
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PETG 2.0 Matt {color_name}",
+            "material": "PETG",
+            "density": 1.41,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                60,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Army Green",
+                    "hex": "4b5320",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000ff"
+                },
+                {
+                    "name": "Grass Green",
+                    "hex": "00ff00",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "d3d3d3",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Makita Blue",
+                    "hex": "016c78",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "ffa500"
+                },
+                {
+                    "name": "RatRig Green",
+                    "hex": "7ec620"
+                },
+                {
+                    "name": "Red",
+                    "hex": "ff0000",
+                    "codes": [
+                        "50497"
+                    ]
+                },
+                {
+                    "name": "Steel Blue",
+                    "hex": "32527b"
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff"
+                }
+            ],
+            "finish": "matte",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PETG {color_name}",
+            "material": "PETG",
+            "density": 1.29,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                225,
+                245
+            ],
+            "bed_temp_range": [
+                60,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Glow In Dark",
+                    "hex": "befdb7",
+                    "codes": [
+                        "51650"
+                    ],
+                    "glow": true
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "ffffff80",
+                    "codes": [
+                        "51505"
+                    ],
+                    "translucent": true
+                }
+            ],
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "ASA {color_name}",
+            "material": "ASA",
+            "density": 1.05,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                100,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Anthracite",
+                    "hex": "383e42",
+                    "codes": [
+                        "52581"
+                    ]
+                },
+                {
+                    "name": "Army Green",
+                    "hex": "4b5320"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "codes": [
+                        "52502"
+                    ]
+                },
+                {
+                    "name": "Grey",
+                    "hex": "d3d3d3",
+                    "codes": [
+                        "52580"
+                    ]
+                },
+                {
+                    "name": "Light Blue",
+                    "hex": "7389f7",
+                    "codes": [
+                        "52688"
+                    ]
+                },
+                {
+                    "name": "Makita Blue",
+                    "hex": "016c78",
+                    "codes": [
+                        "52627"
+                    ]
+                },
+                {
+                    "name": "Neon Pink",
+                    "hex": "fb48c4",
+                    "codes": [
+                        "52688"
+                    ]
+                },
+                {
+                    "name": "Neon Yellow",
+                    "hex": "fff01f",
+                    "codes": [
+                        "52649"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "ffa500",
+                    "codes": [
+                        "52648"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "ff00ff",
+                    "codes": [
+                        "52647"
+                    ]
+                },
+                {
+                    "name": "RatRig Green",
+                    "hex": "7ec620",
+                    "codes": [
+                        "52599"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "ff0000",
+                    "codes": [
+                        "52501"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "c0c0c0",
+                    "codes": [
+                        "52580"
+                    ]
+                },
+                {
+                    "name": "Steel Blue",
+                    "hex": "32527b",
+                    "codes": [
+                        "52628"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "ffffff",
+                    "codes": [
+                        "52500"
+                    ]
+                }
+            ],
+            "finish": "matte",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "ASA-CF {color_name}",
+            "material": "ASA-CF",
+            "density": 1.14,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                240,
+                260
+            ],
+            "bed_temp_range": [
+                110,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "0000ff"
+                },
+                {
+                    "name": "Carbon Black",
+                    "hex": "232323",
+                    "codes": [
+                        "52631"
+                    ]
+                },
+                {
+                    "name": "Gold",
+                    "hex": "cfb53b"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "d3d3d3",
+                    "codes": [
+                        "52666"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "ff00ff"
+                }
+            ],
+            "finish": "matte",
+            "fill": "carbon fiber",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "ASA-GF {color_name}",
+            "material": "ASA-GF",
+            "density": 1.1,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                270
+            ],
+            "bed_temp_range": [
+                110,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Magenta",
+                    "hex": "ff0090",
+                    "codes": [
+                        "52631"
+                    ]
+                },
+                {
+                    "name": "Makita Blue",
+                    "hex": "016c78"
+                },
+                {
+                    "name": "RatRig Green",
+                    "hex": "7ec620",
+                    "codes": [
+                        "52631"
+                    ]
+                }
+            ],
+            "finish": "matte",
+            "fill": "glass fiber",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PC-PBT {color_name}",
+            "material": "PC+PBT",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                260,
+                290
+            ],
+            "bed_temp_range": [
+                110,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ],
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PC-PBT-CF {color_name}",
+            "material": "PC+PBT-CF",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                260,
+                290
+            ],
+            "bed_temp_range": [
+                110,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ],
+            "fill": "carbon fiber",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "TPU-CF {color_name}",
+            "material": "TPU-CF",
+            "density": 1.22,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 500,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                250
+            ],
+            "bed_temp_range": [
+                50,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ],
+            "fill": "carbon fiber",
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PA12 {color_name}",
+            "material": "PA12",
+            "density": 1.01,
+            "weights": [
+                {
+                    "weight": 800,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                260,
+                290
+            ],
+            "bed_temp_range": [
+                110,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ],
+            "country_of_origin": "Denmark"
+        },
+        {
+            "name": "PA12-CF {color_name}",
+            "material": "PA12-CF",
+            "density": 1.03,
+            "weights": [
+                {
+                    "weight": 800,
+                    "spool_weight": 400,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                260,
+                290
+            ],
+            "bed_temp_range": [
+                110,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ],
+            "fill": "carbon fiber",
+            "country_of_origin": "Denmark"
+        }
+    ]
+}

--- a/filaments/3dplast.json
+++ b/filaments/3dplast.json
@@ -1,0 +1,159 @@
+{
+  "manufacturer": "3D Plast",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 850
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Burgundy",
+          "hex": "58002e"
+        },
+        {
+          "name": "Grass green",
+          "hex": "00f201"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff56cc"
+        },
+        {
+          "name": "Purple",
+          "hex": "5e30eb"
+        },
+        {
+          "name": "Sky blue",
+          "hex": "00a9e7"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "0098bb"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffcc02"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 850
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Asphalt",
+          "hex": "333333"
+        },
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "5bb8fb"
+        },
+        {
+          "name": "Red",
+          "hex": "c60101"
+        },
+        {
+          "name": "Warm tangerine",
+          "hex": "f36435"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dpower.json
+++ b/filaments/3dpower.json
@@ -1,0 +1,304 @@
+{
+  "manufacturer": "3DPower",
+  "filaments": [
+    {
+      "name": "Basic PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d3d3d3"
+        },
+        {
+          "name": "Telegrey",
+          "hex": "708090"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Amber Yellow",
+          "hex": "ffbf00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Papaya Orange",
+          "hex": "e55b3c"
+        },
+        {
+          "name": "Flame Red",
+          "hex": "e2583e"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Cherry",
+          "hex": "9b111e"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        },
+        {
+          "name": "Violet",
+          "hex": "8f00ff"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513"
+        },
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "add8e6"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "40e0d0"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "7cfc00"
+        },
+        {
+          "name": "Light Green",
+          "hex": "90ee90"
+        },
+        {
+          "name": "Mint",
+          "hex": "98ff98"
+        },
+        {
+          "name": "Military Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Natural",
+          "hex": "fdf5e6"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ],
+      "country_of_origin": "Poland"
+    },
+    {
+      "name": "Basic PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d3d3d3"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "add8e6"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Flame Red",
+          "hex": "e2583e"
+        },
+        {
+          "name": "Cherry",
+          "hex": "9b111e"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Papaya Orange",
+          "hex": "e55b3c"
+        },
+        {
+          "name": "Light Green",
+          "hex": "90ee90"
+        },
+        {
+          "name": "Military Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Mint",
+          "hex": "98ff98"
+        },
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "Poland"
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "fafada"
+        }
+      ],
+      "country_of_origin": "Poland"
+    }
+  ]
+}

--- a/filaments/3dprimabasic.json
+++ b/filaments/3dprimabasic.json
@@ -1,0 +1,89 @@
+{
+  "manufacturer": "3D Prima Basic",
+  "filaments": [
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 207,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 404,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [75, 90],
+      "colors": [
+        {"name": "Black", "hex": "000000", "eans": ["7340002119472"], "codes": ["PV24-PLA-175-1000-BK"]},
+        {"name": "White", "hex": "FFFFFF", "eans": ["7340002119526"], "codes": ["PV24-PLA-175-1000-WH"]},
+        {"name": "Dark Grey", "hex": "545454", "eans": ["7340002119496"], "codes": ["PV24-PLA-175-1000-DG"]},
+        {"name": "Light Grey", "hex": "B0B0B0", "eans": ["7340002119564"], "codes": ["PV24-PLA-175-1000-LG"]},
+        {"name": "Matte Black", "hex": "1A1A1A", "finish": "matte", "eans": ["7340002119601"], "codes": ["PV24-PLA-175-1000-MB"]},
+        {"name": "Blue", "hex": "1565C0", "eans": ["7340002119489"], "codes": ["PV24-PLA-175-1000-BL"]},
+        {"name": "Red", "hex": "D32F2F", "eans": ["7340002119519"], "codes": ["PV24-PLA-175-1000-RD"]},
+        {"name": "Green", "hex": "2E7D32", "eans": ["7340002119502"], "codes": ["PV24-PLA-175-1000-GR"]},
+        {"name": "Yellow", "hex": "FDD835", "eans": ["7340002119540"], "codes": ["PV24-PLA-175-1000-YL"]},
+        {"name": "Orange", "hex": "F57C00", "eans": ["7340002119557"], "codes": ["PV24-PLA-175-1000-OR"]},
+        {"name": "Silver", "hex": "A8A9AD", "eans": ["7340002119533"], "codes": ["PV24-PLA-175-1000-SV"]},
+        {"name": "Marble", "hex": "F5F5F0", "pattern": "marble", "eans": ["7340002124612"], "codes": ["PV24-PLA-175-1000-MR"]}
+      ],
+      "country_of_origin": "Sweden"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 207,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 250],
+      "bed_temp_range": [75, 90],
+      "colors": [
+        {"name": "Black", "hex": "000000", "eans": ["7340002119717"], "codes": ["PV24-PETG-175-1000-BK"]},
+        {"name": "White", "hex": "FFFFFF", "eans": ["7340002119724"], "codes": ["PV24-PETG-175-1000-WH"]},
+        {"name": "Grey", "hex": "808080", "eans": ["7340002119731"], "codes": ["PV24-PETG-175-1000-GY"]}
+      ],
+      "country_of_origin": "Sweden"
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 207,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2500,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [240, 270],
+      "bed_temp_range": [90, 110],
+      "colors": [
+        {"name": "Black", "hex": "000000", "eans": ["7340002119380"], "codes": ["PV24-ABS-175-1000-BK"]},
+        {"name": "White", "hex": "FFFFFF", "eans": ["7340002119434"], "codes": ["PV24-ABS-175-1000-WH"]},
+        {"name": "Dark Grey", "hex": "545454", "eans": ["7340002119403"], "codes": ["PV24-ABS-175-1000-DG"]},
+        {"name": "Blue", "hex": "1565C0", "eans": ["7340002119397"], "codes": ["PV24-ABS-175-1000-BL"]},
+        {"name": "Red", "hex": "D32F2F", "eans": ["7340002119427"], "codes": ["PV24-ABS-175-1000-RD"]},
+        {"name": "Green", "hex": "2E7D32", "eans": ["7340002119410"], "codes": ["PV24-ABS-175-1000-GR"]}
+      ],
+      "country_of_origin": "Sweden"
+    }
+  ]
+}

--- a/filaments/3dprinterfilament.json
+++ b/filaments/3dprinterfilament.json
@@ -1,0 +1,263 @@
+{
+  "manufacturer": "3D Printer Filament",
+  "filaments": [
+    {
+      "name": "Light Blue {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Light Blue - glitter",
+          "hex": "009796"
+        }
+      ]
+    },
+    {
+      "name": "Meta {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Meta Grey",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent Multicolor",
+          "hex": "a0faf5"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8040"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0414f6"
+        },
+        {
+          "name": "Braun",
+          "hex": "850532"
+        },
+        {
+          "name": "Bronze",
+          "hex": "95986c"
+        },
+        {
+          "name": "Cyan",
+          "hex": "027af2"
+        },
+        {
+          "name": "Gray",
+          "hex": "5f6163"
+        },
+        {
+          "name": "Hellgoldenes Gold",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Military Rainbow",
+          "hex": "94bf7c"
+        },
+        {
+          "name": "Pink",
+          "hex": "f7089f"
+        }
+      ]
+    },
+    {
+      "name": "Silk Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Greenish Gold",
+          "hex": "3a363b"
+        }
+      ]
+    },
+    {
+      "name": "Silk Multi Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue/Purple/Orange",
+          "hexes": [
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rosa Red, Sky Blue and Green",
+          "hex": "cf4977"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Chameleon Burnt Titanium Sparkle",
+          "hex": "878681",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    }
+  ]
+}

--- a/filaments/3dprintingcanada.json
+++ b/filaments/3dprintingcanada.json
@@ -1,0 +1,1850 @@
+{
+  "manufacturer": "3D Printing Canada",
+  "filaments": [
+    {
+      "name": "Budget PLA Refill {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "67bbc6e73107d-2"
+          ],
+          "eans": [
+            "8770620000903"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b",
+          "codes": [
+            "67bbc6eb0d2fc-2"
+          ],
+          "eans": [
+            "8770620000934"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "008000",
+          "codes": [
+            "67bbc8099178e-2"
+          ],
+          "eans": [
+            "8770620000941"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "67bbc6e88ee45"
+          ],
+          "eans": [
+            "8770620000927"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "67bbc6eed6f3b-2"
+          ],
+          "eans": [
+            "8770620000958"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "67bbc6e821f16"
+          ],
+          "eans": [
+            "8770620000910"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "Budget PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        },
+        {
+          "weight": 3000,
+          "spool_type": "plastic",
+          "spool_weight": 1400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "67bbc6e73107d-1"
+          ],
+          "eans": [
+            "8770620000170"
+          ]
+        },
+        {
+          "name": "Coffee",
+          "hex": "8b4513",
+          "codes": [
+            "67bbc6f3278b7"
+          ],
+          "eans": [
+            "8770620000286"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b",
+          "codes": [
+            "67bbc6eb0d2fc-1"
+          ],
+          "eans": [
+            "8770620000200"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "008000",
+          "codes": [
+            "67bbc8099178e-1"
+          ],
+          "eans": [
+            "8770620000651"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "67bbc6e88ee44"
+          ],
+          "eans": [
+            "8770620000194"
+          ]
+        },
+        {
+          "name": "Latte",
+          "hex": "8b4513",
+          "codes": [
+            "67bbc6f5724bd"
+          ],
+          "eans": [
+            "8770620000309"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "0000ff",
+          "codes": [
+            "67bbc6e8ef151"
+          ],
+          "eans": [
+            "8770620000224"
+          ]
+        },
+        {
+          "name": "Mint",
+          "hex": "008000",
+          "codes": [
+            "67bbc6ef6d1a7"
+          ],
+          "eans": [
+            "8770620000231"
+          ]
+        },
+        {
+          "name": "Olive Green",
+          "hex": "008000",
+          "codes": [
+            "67bbc6f2b76ee"
+          ],
+          "eans": [
+            "8770620000262"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500",
+          "codes": [
+            "67bbc6f00ebc6"
+          ],
+          "eans": [
+            "8770620000248"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "67bbc6f3d22b8"
+          ],
+          "eans": [
+            "8770620000293"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "67bbc6f10c03a"
+          ],
+          "eans": [
+            "8770620000279"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "67bbc6eed6f3b-1"
+          ],
+          "eans": [
+            "8770620000217"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "67bbc6e821f15"
+          ],
+          "eans": [
+            "8770620000187"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "67bbc6f039c87"
+          ],
+          "eans": [
+            "8770620000255"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "CanadianMade PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Antique Gold",
+          "hex": "0000ff",
+          "codes": [
+            "6a31e03d2d0b8"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "68fe9864611f8"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "codes": [
+            "68fe98676b74b"
+          ]
+        },
+        {
+          "name": "Glitter Blue",
+          "hex": "0000ff",
+          "codes": [
+            "2020GBLUE"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "0000ff",
+          "codes": [
+            "2020GGOLD"
+          ]
+        },
+        {
+          "name": "Medium Grey",
+          "hex": "808080",
+          "codes": [
+            "68fe986a6c038"
+          ]
+        },
+        {
+          "name": "Metallic Red",
+          "hex": "0000ff",
+          "codes": [
+            "2020MRED"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "codes": [
+            "67bbc27ba089e"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "68fe986a70cfe"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "68fe98646b85d"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "68fe986d6909a"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "Standard PLA Refill {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "6983c5fc0ef06"
+          ],
+          "eans": [
+            "8770620000408"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "codes": [
+            "6983c5fc486c3"
+          ],
+          "eans": [
+            "8770620000422"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "008000",
+          "codes": [
+            "6983c5fc53903"
+          ],
+          "eans": [
+            "8770620000439"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "6983c5fc60dcc"
+          ],
+          "eans": [
+            "8770620000446"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "6983c5fca33e9"
+          ],
+          "eans": [
+            "8770620000453"
+          ]
+        },
+        {
+          "name": "Warm White",
+          "hex": "ffffff",
+          "codes": [
+            "6983c5fbedd4b"
+          ],
+          "eans": [
+            "8770620000415"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "Standard PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 658
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "finish": "glossy",
+          "codes": [
+            "68fe8db39fad4"
+          ],
+          "eans": [
+            "8770620000767"
+          ]
+        },
+        {
+          "name": "Black/Gold/Purple",
+          "hexes": [
+            "000000",
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5e5da23e"
+          ],
+          "eans": [
+            "8770620001399"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "finish": "glossy",
+          "codes": [
+            "68fe8db67d4bc"
+          ],
+          "eans": [
+            "8770620000804"
+          ]
+        },
+        {
+          "name": "Blue/Green",
+          "hexes": [
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5e34d5aa"
+          ],
+          "eans": [
+            "8770620001153"
+          ]
+        },
+        {
+          "name": "Gold/Silver/Copper",
+          "hexes": [
+            "ffd700",
+            "c0c0c0",
+            "b87333"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d903243"
+          ],
+          "eans": [
+            "8770620001047"
+          ]
+        },
+        {
+          "name": "Golden",
+          "hex": "ffd700",
+          "finish": "glossy",
+          "codes": [
+            "68fe8db6d4743"
+          ],
+          "eans": [
+            "8770620000781"
+          ]
+        },
+        {
+          "name": "Pink/Gold",
+          "hexes": [
+            "ff69b4",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5e314526"
+          ],
+          "eans": [
+            "8770620000316"
+          ]
+        },
+        {
+          "name": "Purple/Gold",
+          "hexes": [
+            "800080",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5e3128f1"
+          ],
+          "eans": [
+            "8770620000323"
+          ]
+        },
+        {
+          "name": "Purple/Green/Gold",
+          "hexes": [
+            "800080",
+            "008000",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d89d6ff"
+          ],
+          "eans": [
+            "8770620001092"
+          ]
+        },
+        {
+          "name": "Purple/Yellow/Blue",
+          "hexes": [
+            "800080",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d9ed34b"
+          ],
+          "eans": [
+            "8770620001115"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "finish": "glossy",
+          "codes": [
+            "8770620000798"
+          ],
+          "eans": [
+            "8770620000798"
+          ]
+        },
+        {
+          "name": "Red/Blue",
+          "hexes": [
+            "ff0000",
+            "0000ff"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5e30377d"
+          ],
+          "eans": [
+            "8770620001146"
+          ]
+        },
+        {
+          "name": "Red/Blue/Gold",
+          "hexes": [
+            "ff0000",
+            "0000ff",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d8a31e1"
+          ],
+          "eans": [
+            "8770620001078"
+          ]
+        },
+        {
+          "name": "Red/Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5da0d94f"
+          ],
+          "eans": [
+            "8770620001139"
+          ]
+        },
+        {
+          "name": "Red/Gold/Purple",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d966afe"
+          ],
+          "eans": [
+            "8770620001054"
+          ]
+        },
+        {
+          "name": "Red/Green/Blue",
+          "hexes": [
+            "ff0000",
+            "008000",
+            "0000ff"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d90d2b2"
+          ],
+          "eans": [
+            "8770620001030"
+          ]
+        },
+        {
+          "name": "Red/Green/Gold",
+          "hexes": [
+            "ff0000",
+            "008000",
+            "ffd700"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d90e9bb"
+          ],
+          "eans": [
+            "8770620001085"
+          ]
+        },
+        {
+          "name": "Red/Green/Purple",
+          "hexes": [
+            "ff0000",
+            "008000",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d911ea3"
+          ],
+          "eans": [
+            "8770620001061"
+          ]
+        },
+        {
+          "name": "Red/Yellow/Blue",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d89ab0e"
+          ],
+          "eans": [
+            "8770620001016"
+          ]
+        },
+        {
+          "name": "Red/Yellow/Green",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "008000"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5d90db75"
+          ],
+          "eans": [
+            "8770620001023"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "finish": "glossy",
+          "codes": [
+            "68fe8db79a765"
+          ],
+          "eans": [
+            "8770620000774"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "finish": "glossy",
+          "codes": [
+            "68fe8db825e75"
+          ],
+          "eans": [
+            "8770620000811"
+          ]
+        },
+        {
+          "name": "Yellow/Green",
+          "hexes": [
+            "ffff00",
+            "008000"
+          ],
+          "multi_color_direction": "coaxial",
+          "codes": [
+            "6983c5da059b7"
+          ],
+          "eans": [
+            "8770620001122"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Standard PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 624
+        },
+        {
+          "weight": 2000,
+          "spool_type": "plastic",
+          "spool_weight": 1080
+        },
+        {
+          "weight": 5000,
+          "spool_type": "plastic",
+          "spool_weight": 1804
+        },
+        {
+          "weight": 10000,
+          "spool_type": "plastic",
+          "spool_weight": 5400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "STDPLABLK10K"
+          ]
+        },
+        {
+          "name": "Blue/White Jelly Gradient",
+          "hexes": [
+            "0000ff",
+            "ffffff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "6983c5e4a670c"
+          ],
+          "eans": [
+            "8770620000347"
+          ]
+        },
+        {
+          "name": "Crystal Gradient Cyan",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "00ffff",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "6983c5e4b25a3"
+          ],
+          "eans": [
+            "8770620000361"
+          ]
+        },
+        {
+          "name": "Dream Crystal",
+          "hex": "b8e0f0",
+          "codes": [
+            "6983c5e4c1329"
+          ],
+          "eans": [
+            "8770620000354"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "STDPLAGRY10K"
+          ]
+        },
+        {
+          "name": "Matte Black",
+          "hex": "000000",
+          "finish": "matte",
+          "codes": [
+            "67bbc6e247f73"
+          ]
+        },
+        {
+          "name": "Matte Blue",
+          "hex": "0000ff",
+          "finish": "matte",
+          "codes": [
+            "67bbc6e39f5db"
+          ]
+        },
+        {
+          "name": "Matte Green",
+          "hex": "008000",
+          "finish": "matte",
+          "codes": [
+            "67bbc6e45792c"
+          ]
+        },
+        {
+          "name": "Matte Grey",
+          "hex": "808080",
+          "finish": "matte",
+          "codes": [
+            "67bbc6e24e7d8"
+          ]
+        },
+        {
+          "name": "Matte Rainbow Macarons",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "00ffff",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "6983c5e5a45f1"
+          ],
+          "eans": [
+            "8770620000392"
+          ]
+        },
+        {
+          "name": "Matte Rainbow Spring Tea",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "00ffff",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "6983c5e50c1ea"
+          ],
+          "eans": [
+            "8770620000385"
+          ]
+        },
+        {
+          "name": "Matte Red",
+          "hex": "ff0000",
+          "finish": "matte",
+          "codes": [
+            "67bbc6e4554ae"
+          ]
+        },
+        {
+          "name": "Matte White",
+          "hex": "ffffff",
+          "finish": "matte",
+          "codes": [
+            "67bbc6e35dd2c"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "008000",
+          "codes": [
+            "67bbc6d36c5d1"
+          ]
+        },
+        {
+          "name": "Natural Transparent",
+          "hex": "e8e0d0",
+          "translucent": true,
+          "codes": [
+            "STDPLANTRN10K"
+          ]
+        },
+        {
+          "name": "Rainbow Candy",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "00ffff",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "6983c5e496ad7"
+          ],
+          "eans": [
+            "8770620000330"
+          ]
+        },
+        {
+          "name": "Rainbow Jade",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "00ffff",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "6983c5e4c1605"
+          ],
+          "eans": [
+            "8770620000378"
+          ]
+        },
+        {
+          "name": "Warm White",
+          "hex": "ffffff",
+          "codes": [
+            "STDPLAWWHT1K"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "STDPLAWHT10K"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "CanadianMade PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        },
+        {
+          "weight": 5000,
+          "spool_type": "plastic",
+          "spool_weight": 3250
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "finish": "matte",
+          "codes": [
+            "67bbc4e0d8a40"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "finish": "matte",
+          "codes": [
+            "2027BLUE"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "2020BROWN"
+          ]
+        },
+        {
+          "name": "Cayman Blue",
+          "hex": "0000ff",
+          "codes": [
+            "68fe8dcbb8a6c-1"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "finish": "matte",
+          "codes": [
+            "2027DKGREEN"
+          ]
+        },
+        {
+          "name": "Driftwood",
+          "hex": "0000ff",
+          "codes": [
+            "2020DRIFTWOOD"
+          ]
+        },
+        {
+          "name": "Evergreen",
+          "hex": "008000",
+          "codes": [
+            "68fe8dcb700bc"
+          ]
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "hex": "0000ff",
+          "codes": [
+            "68fe8dca3c2dd-1"
+          ]
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "2020Fuchsia"
+          ]
+        },
+        {
+          "name": "Grass Green",
+          "hex": "008000",
+          "codes": [
+            "68fe8dc970b6b-1"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "6983c5d8e1c6d"
+          ]
+        },
+        {
+          "name": "Gun Metal Grey",
+          "hex": "808080",
+          "finish": "matte",
+          "codes": [
+            "2027GUNGREY"
+          ]
+        },
+        {
+          "name": "Industrial Blue",
+          "hex": "0000ff",
+          "codes": [
+            "2020INDBLUE"
+          ]
+        },
+        {
+          "name": "Medium Grey",
+          "hex": "808080",
+          "finish": "matte",
+          "codes": [
+            "2027MEDGREY"
+          ]
+        },
+        {
+          "name": "Mocha",
+          "hex": "0000ff",
+          "codes": [
+            "2020MOCHA"
+          ]
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0000ff",
+          "codes": [
+            "67bbc4d361b93"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500",
+          "codes": [
+            "2020ORANGE"
+          ]
+        },
+        {
+          "name": "Peach",
+          "hex": "0000ff",
+          "codes": [
+            "2020PEACH"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "finish": "matte",
+          "codes": [
+            "2027RED-1"
+          ]
+        },
+        {
+          "name": "Royal Purple",
+          "hex": "800080",
+          "codes": [
+            "67bbc4e00fd4a"
+          ]
+        },
+        {
+          "name": "Sandstone",
+          "hex": "0000ff",
+          "codes": [
+            "2020SNDSTONE"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "008080",
+          "codes": [
+            "2020TEAL P"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "finish": "matte",
+          "codes": [
+            "2027WHITE-1"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        75
+      ]
+    },
+    {
+      "name": "Budget PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 650
+        },
+        {
+          "weight": 3000,
+          "spool_type": "plastic",
+          "spool_weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "67bbc809d7a5d"
+          ],
+          "eans": [
+            "8770620000668"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "codes": [
+            "67bbc80d3cfc4"
+          ],
+          "eans": [
+            "8770620000705"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "codes": [
+            "67bbc80fae0b4"
+          ],
+          "eans": [
+            "8770620000712"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "67bbc80ed63f7"
+          ],
+          "eans": [
+            "8770620000682"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500",
+          "codes": [
+            "67bbc810cb9f0"
+          ],
+          "eans": [
+            "8770620000736"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff0000",
+          "codes": [
+            "6a31e03d2d6fe"
+          ],
+          "eans": [
+            "8770620002082"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "67bbc80fd2a0d"
+          ],
+          "eans": [
+            "8770620000729"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "eaeaea",
+          "translucent": true,
+          "codes": [
+            "67bbc8101448c"
+          ],
+          "eans": [
+            "8770620000699"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "67bbc8125ec88"
+          ],
+          "eans": [
+            "8770620000675"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ]
+    },
+    {
+      "name": "CanadianMade PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        },
+        {
+          "weight": 5000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "2032BLACK-1"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "000000",
+          "codes": [
+            "2030DKGREEN"
+          ]
+        },
+        {
+          "name": "Fighter Jet  Blue",
+          "hex": "0000ff",
+          "codes": [
+            "6a31e0158e31d"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "6a31e03d2da8d"
+          ]
+        },
+        {
+          "name": "Gun Metal Grey",
+          "hex": "808080",
+          "codes": [
+            "2032GREY"
+          ]
+        },
+        {
+          "name": "Natural/Transparent",
+          "hex": "e8e0d0",
+          "translucent": true,
+          "codes": [
+            "67bbc6cd51c4a"
+          ]
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0000ff",
+          "codes": [
+            "6a31e01592976"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500",
+          "codes": [
+            "67bbc4d3910ce"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "2030PUR"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "2030RED"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "2032WHITE"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffffff",
+          "codes": [
+            "2030YELLOW"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        225,
+        255
+      ],
+      "bed_temp_range": [
+        55,
+        75
+      ]
+    },
+    {
+      "name": "Standard PETG Refill {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 746
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "6983c5f38a57d"
+          ],
+          "eans": [
+            "8770620000460"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "codes": [
+            "6983c5fa12e22"
+          ],
+          "eans": [
+            "8770620000491"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "6983c5fa709fe"
+          ],
+          "eans": [
+            "8770620000484"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "6983c5fa9c7ed"
+          ],
+          "eans": [
+            "8770620000507"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "eaeaea",
+          "translucent": true,
+          "codes": [
+            "6983c5fa40a02"
+          ],
+          "eans": [
+            "8770620000514"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "6983c5fc0f33e"
+          ],
+          "eans": [
+            "8770620000477"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ]
+    },
+    {
+      "name": "Standard PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 694
+        },
+        {
+          "weight": 5000,
+          "spool_type": "plastic",
+          "spool_weight": 1804
+        },
+        {
+          "weight": 10000,
+          "spool_type": "plastic",
+          "spool_weight": 5400
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "68fe8db278333"
+          ],
+          "eans": [
+            "8770620000842"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "68fe8db376a05"
+          ],
+          "eans": [
+            "8770620000866"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "008000",
+          "codes": [
+            "67bbc6d23273c"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "8770620000859"
+          ],
+          "eans": [
+            "8770620000859"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ]
+    },
+    {
+      "name": "Standard ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 746
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "68fe8dbb48ed8"
+          ],
+          "eans": [
+            "8770620000873"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "68fe8dbc9f773"
+          ],
+          "eans": [
+            "8770620000897"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "codes": [
+            "68fe8dbd2defb"
+          ],
+          "eans": [
+            "8770620000880"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ]
+    },
+    {
+      "name": "CanadianMade ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "68fe986ed44b8"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "000000",
+          "codes": [
+            "2050BLUE"
+          ]
+        },
+        {
+          "name": "Carbon Fiber",
+          "hex": "000000",
+          "codes": [
+            "6a31e0158f22b"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "68fe986ee38f9"
+          ]
+        },
+        {
+          "name": "Gun Metal Grey",
+          "hex": "000000",
+          "codes": [
+            "2050GUNGREY"
+          ]
+        },
+        {
+          "name": "Light Grey",
+          "hex": "000000",
+          "codes": [
+            "2050LGREY"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "000000",
+          "codes": [
+            "2050ORANGE"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "000000",
+          "codes": [
+            "2050RED"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "68fe986d5f983"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "000000",
+          "codes": [
+            "2050YELLOW"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        245,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        105
+      ]
+    },
+    {
+      "name": "Standard PC+ABS {color_name}",
+      "material": "PC+ABS",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic",
+          "spool_weight": 540
+        },
+        {
+          "weight": 10000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Carbon Fiber",
+          "hex": "000000",
+          "codes": [
+            "67bbc29504f07"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "6a31e015a36ca"
+          ]
+        }
+      ],
+      "country_of_origin": "Canada",
+      "extruder_temp_range": [
+        260,
+        300
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    }
+  ]
+}

--- a/filaments/3dsolutech.json
+++ b/filaments/3dsolutech.json
@@ -1,0 +1,347 @@
+{
+  "manufacturer": "3D Solutech",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Natural Clear",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Real Green",
+          "hex": "008502"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Real White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Transparent Yellow",
+          "hex": "e0e25a"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "cad0d3",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "00ff40"
+        },
+        {
+          "name": "Silver Metal",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Beige",
+          "hex": "808080"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue Denim",
+          "hex": "808080"
+        },
+        {
+          "name": "Camo green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "77523f"
+        },
+        {
+          "name": "Eggplant Purple",
+          "hex": "3e0d59"
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "e84566"
+        },
+        {
+          "name": "Lavender Purple",
+          "hex": "a77dc5"
+        },
+        {
+          "name": "Merlot Red",
+          "hex": "6c323e"
+        },
+        {
+          "name": "Natural Clear",
+          "hex": "808080"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "08063f"
+        },
+        {
+          "name": "Olive Drab",
+          "hex": "5c6039"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "7f9fbf"
+        },
+        {
+          "name": "Purple",
+          "hex": "521859"
+        },
+        {
+          "name": "Real Blue",
+          "hex": "3c3ce0"
+        },
+        {
+          "name": "Real Green",
+          "hex": "008502"
+        },
+        {
+          "name": "Real Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "Real Red",
+          "hex": "d60012"
+        },
+        {
+          "name": "Real White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Real Yellow",
+          "hex": "e6db60"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "ffb7c5"
+        },
+        {
+          "name": "Silver Metal",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Steel Blue",
+          "hex": "23415a"
+        },
+        {
+          "name": "Teal Blue",
+          "hex": "00c6ea"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "See Through Aqua Blue",
+          "hex": "0095ff"
+        },
+        {
+          "name": "See Through Orange",
+          "hex": "f77001"
+        },
+        {
+          "name": "See Through Purple",
+          "hex": "bc1a73"
+        },
+        {
+          "name": "See Through Red",
+          "hex": "be2829"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "See Thru Green",
+          "hex": "00ff40"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/3dtrcek.json
+++ b/filaments/3dtrcek.json
@@ -1,0 +1,2323 @@
+{
+  "manufacturer": "3DTrcek",
+  "filaments": [
+    {
+      "name": "ABS ESD {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black matte",
+          "hex": "1a1a1a",
+          "eans": [
+            "3830067447718"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS FR V0 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067441327"
+          ]
+        },
+        {
+          "name": "Light grey RAL 7035",
+          "hex": "c5c7c4",
+          "eans": [
+            "3830067444090"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067443598"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067440047"
+          ]
+        },
+        {
+          "name": "Light grey RAL 7035",
+          "hex": "c5c7c4",
+          "eans": [
+            "3830067443475"
+          ]
+        },
+        {
+          "name": "Natur",
+          "hex": "ebdec3",
+          "eans": [
+            "3830067440009"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067440061"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS+ Refill {color_name}",
+      "material": "ABS+",
+      "density": 1.06,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067446988"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067447145"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067447138"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS+ {color_name}",
+      "material": "ABS+",
+      "density": 1.06,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067444014"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067440115",
+            "3830067444670"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067440122"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067443666"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067440153"
+          ]
+        },
+        {
+          "name": "Light grey RAL 7035",
+          "hex": "c5c7c4",
+          "eans": [
+            "3830067440160"
+          ]
+        },
+        {
+          "name": "Natur",
+          "hex": "ebdec3",
+          "eans": [
+            "3830067440139"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067440146"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067440108",
+            "3830067443574"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS-GF {color_name}",
+      "material": "ABS-GF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "000028517046"
+          ]
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "ASA+ Refill {color_name}",
+      "material": "ASA+",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067447220"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067447084"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067447329"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067447343"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067447596"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067447336"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067447077"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA+ {color_name}",
+      "material": "ASA+",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067441518"
+          ]
+        },
+        {
+          "name": "Light grey RAL 7035",
+          "hex": "c5c7c4",
+          "eans": [
+            "3830067441549"
+          ]
+        },
+        {
+          "name": "Natur",
+          "hex": "ebdec3",
+          "eans": [
+            "3830067441532"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067440870",
+            "3830067445646"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HTPRO PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067446544"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067441068",
+            "3830067443239"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067441075"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067441099"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067441082"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067441051"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "High Speed PLA Matte Refill {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black matte",
+          "hex": "1a1a1a",
+          "eans": [
+            "3830067446940"
+          ]
+        },
+        {
+          "name": "Blue matte",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067446964"
+          ]
+        },
+        {
+          "name": "Red matte",
+          "hex": "c41e2a",
+          "eans": [
+            "3830067446971"
+          ]
+        },
+        {
+          "name": "White matte",
+          "hex": "f5f5f5",
+          "eans": [
+            "3830067446933"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "High Speed PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067445936"
+          ]
+        },
+        {
+          "name": "Beige matte",
+          "hex": "808080",
+          "eans": [
+            "3830067445882"
+          ]
+        },
+        {
+          "name": "Black matte",
+          "hex": "1a1a1a",
+          "eans": [
+            "3830067445868",
+            "3830067445943"
+          ]
+        },
+        {
+          "name": "Blue matte",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067445899"
+          ]
+        },
+        {
+          "name": "Bright red orange matte",
+          "hex": "ff8c00",
+          "eans": [
+            "3830067445998"
+          ]
+        },
+        {
+          "name": "Green matte",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067446247"
+          ]
+        },
+        {
+          "name": "Grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067445851",
+            "3830067445967"
+          ]
+        },
+        {
+          "name": "Military green matte",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067445929"
+          ]
+        },
+        {
+          "name": "Orange matte",
+          "hex": "ff8c00",
+          "eans": [
+            "3830067445912"
+          ]
+        },
+        {
+          "name": "Red matte",
+          "hex": "c41e2a",
+          "eans": [
+            "3830067445905"
+          ]
+        },
+        {
+          "name": "White matte",
+          "hex": "f5f5f5",
+          "eans": [
+            "3830067445844",
+            "3830067445950"
+          ]
+        },
+        {
+          "name": "Yellow matte",
+          "hex": "ffd700",
+          "eans": [
+            "3830067445875"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PAHT-CF {color_name}",
+      "material": "PAHT-CF",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        310
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067447299"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PC+ABS V0 {color_name}",
+      "material": "PC+ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067447558"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PCTG Refill {color_name}",
+      "material": "PCTG",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067447244"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067447237"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067447534"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067447527"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067447510"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PCTG {color_name}",
+      "material": "PCTG",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067446414"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067446377"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067447671"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067447688"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067446407"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067447404"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067446391"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067446384"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PET-CF {color_name}",
+      "material": "PET-CF",
+      "density": 1.38,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067446216"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG Matte Refill {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067447503"
+          ]
+        },
+        {
+          "name": "Black matte",
+          "hex": "1a1a1a",
+          "eans": [
+            "3830067446865"
+          ]
+        },
+        {
+          "name": "White matte",
+          "hex": "f5f5f5",
+          "eans": [
+            "3830067446872"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067444052"
+          ]
+        },
+        {
+          "name": "Black matte",
+          "hex": "1a1a1a",
+          "eans": [
+            "3830067444045",
+            "3830067444212"
+          ]
+        },
+        {
+          "name": "Blue matte",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067445707"
+          ]
+        },
+        {
+          "name": "Bright red orange matte",
+          "hex": "ff8c00",
+          "eans": [
+            "3830067446889"
+          ]
+        },
+        {
+          "name": "Dark blue matte",
+          "hex": "00008b",
+          "eans": [
+            "3830067445721"
+          ]
+        },
+        {
+          "name": "Green matte",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067446841"
+          ]
+        },
+        {
+          "name": "Grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067444083"
+          ]
+        },
+        {
+          "name": "Light Ivory Matte",
+          "hex": "808080",
+          "eans": [
+            "3830067447206"
+          ]
+        },
+        {
+          "name": "Light grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067444113"
+          ]
+        },
+        {
+          "name": "Moss green matte RAL6005",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067445738"
+          ]
+        },
+        {
+          "name": "Orange matte",
+          "hex": "ff8c00",
+          "eans": [
+            "3830067446858"
+          ]
+        },
+        {
+          "name": "Red matte",
+          "hex": "c41e2a",
+          "eans": [
+            "3830067444229"
+          ]
+        },
+        {
+          "name": "White matte",
+          "hex": "f5f5f5",
+          "eans": [
+            "3830067444106",
+            "3830067444199"
+          ]
+        },
+        {
+          "name": "Yellow matte",
+          "hex": "ffd700",
+          "eans": [
+            "3830067445714"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG Refill {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067447251"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067446285"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067447374"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067447619"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067446292"
+          ]
+        },
+        {
+          "name": "Light ivory RAL 1015",
+          "hex": "e6d2b5",
+          "eans": [
+            "3830067447633"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067446995"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067447459"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067446278"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "eans": [
+            "3830067447626"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067441891",
+            "3830067444168"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067440658",
+            "3830067441877"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067440634",
+            "3830067441907"
+          ]
+        },
+        {
+          "name": "Bright red orange RAL 2008",
+          "hex": "e86b22",
+          "eans": [
+            "3830067446032"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "493918",
+          "eans": [
+            "3830067443789"
+          ]
+        },
+        {
+          "name": "Dark blue",
+          "hex": "000080",
+          "eans": [
+            "3830067446049"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "a3a477",
+          "eans": [
+            "3830067440801"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067440795"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067440719",
+            "3830067441921"
+          ]
+        },
+        {
+          "name": "Light grey RAL 7035",
+          "hex": "c5c7c4",
+          "eans": [
+            "3830067440733",
+            "3830067444137"
+          ]
+        },
+        {
+          "name": "Light ivory RAL 1015",
+          "hex": "e6d2b5",
+          "eans": [
+            "3830067445400"
+          ]
+        },
+        {
+          "name": "May green RAL 6017",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067443697"
+          ]
+        },
+        {
+          "name": "Moss green RAL6005",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067446056"
+          ]
+        },
+        {
+          "name": "Neon green",
+          "hex": "78f343",
+          "eans": [
+            "3830067440689"
+          ]
+        },
+        {
+          "name": "Neon orange",
+          "hex": "ffa62d",
+          "eans": [
+            "3830067440665"
+          ]
+        },
+        {
+          "name": "Off-white RAL9010",
+          "hex": "f5f5f5",
+          "eans": [
+            "3830067446520"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff922f",
+          "eans": [
+            "3830067440696"
+          ]
+        },
+        {
+          "name": "Pastel blue RAL 5024",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067446018"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "5700ce",
+          "eans": [
+            "3830067441952"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067440641",
+            "3830067441914"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "7c7c7c",
+          "eans": [
+            "3830067440726",
+            "3830067441938"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067440740",
+            "3830067441945"
+          ]
+        },
+        {
+          "name": "Transparent blue",
+          "hex": "6eb5ff",
+          "translucent": true,
+          "eans": [
+            "3830067440757"
+          ]
+        },
+        {
+          "name": "Transparent green",
+          "hex": "90ee90",
+          "translucent": true,
+          "eans": [
+            "3830067440788"
+          ]
+        },
+        {
+          "name": "Transparent red",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067440764"
+          ]
+        },
+        {
+          "name": "Transparent yellow",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067440771"
+          ]
+        },
+        {
+          "name": "Water blue RAL 5021",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067444847"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067440627",
+            "3830067442126"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "eans": [
+            "3830067440702"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067443987"
+          ]
+        },
+        {
+          "name": "Beige matte",
+          "hex": "808080",
+          "eans": [
+            "3830067445424"
+          ]
+        },
+        {
+          "name": "Black matte",
+          "hex": "1a1a1a",
+          "eans": [
+            "3830067441006",
+            "3830067442423"
+          ]
+        },
+        {
+          "name": "Blue matte",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067441013"
+          ]
+        },
+        {
+          "name": "Green matte",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067447381"
+          ]
+        },
+        {
+          "name": "Grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067441044",
+            "3830067444342"
+          ]
+        },
+        {
+          "name": "Light grey matte",
+          "hex": "808080",
+          "eans": [
+            "3830067447701"
+          ]
+        },
+        {
+          "name": "Military green matte",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067443970"
+          ]
+        },
+        {
+          "name": "Red matte",
+          "hex": "c41e2a",
+          "eans": [
+            "3830067441020"
+          ]
+        },
+        {
+          "name": "White matte",
+          "hex": "f5f5f5",
+          "eans": [
+            "3830067440993",
+            "3830067442409"
+          ]
+        },
+        {
+          "name": "Yellow matte",
+          "hex": "ffd700",
+          "eans": [
+            "3830067441037"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA Refill {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067447695"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067446315"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067446902"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067447442"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067446322"
+          ]
+        },
+        {
+          "name": "Light ivory RAL 1015",
+          "hex": "e6d2b5",
+          "eans": [
+            "3830067447398"
+          ]
+        },
+        {
+          "name": "Luminescent",
+          "hex": "ccff00",
+          "glow": true,
+          "eans": [
+            "3830067447435"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff922f",
+          "eans": [
+            "3830067447176"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067446896"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067446308"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "eans": [
+            "3830067447466"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2400
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Anthracite grey RAL 7016",
+          "hex": "383e42",
+          "eans": [
+            "3830067441686"
+          ]
+        },
+        {
+          "name": "Baby Blue",
+          "hex": "8bbae9",
+          "eans": [
+            "3830067440450"
+          ]
+        },
+        {
+          "name": "Beige RAL 1001",
+          "hex": "d4b896",
+          "eans": [
+            "3830067440467"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067440481",
+            "3830067442393",
+            "3830067443765"
+          ]
+        },
+        {
+          "name": "Black glitter",
+          "hex": "3d3e3d",
+          "pattern": "sparkle",
+          "eans": [
+            "3830067440221"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067440542",
+            "3830067442447"
+          ]
+        },
+        {
+          "name": "Bright red orange RAL 2008",
+          "hex": "e86b22",
+          "eans": [
+            "3830067443710"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "493918",
+          "eans": [
+            "3830067440559"
+          ]
+        },
+        {
+          "name": "Dark blue",
+          "hex": "000080",
+          "eans": [
+            "3830067440375"
+          ]
+        },
+        {
+          "name": "Forest green",
+          "hex": "228b22",
+          "eans": [
+            "3830067440443"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "a3a477",
+          "eans": [
+            "3830067440412"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067440610"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067440337",
+            "3830067442461"
+          ]
+        },
+        {
+          "name": "Grey glitter",
+          "hex": "808080",
+          "pattern": "sparkle",
+          "eans": [
+            "3830067440320"
+          ]
+        },
+        {
+          "name": "Light grey RAL 7035",
+          "hex": "c5c7c4",
+          "eans": [
+            "3830067440573"
+          ]
+        },
+        {
+          "name": "Light ivory RAL 1015",
+          "hex": "e6d2b5",
+          "eans": [
+            "3830067443703"
+          ]
+        },
+        {
+          "name": "Lime",
+          "hex": "32cd32",
+          "eans": [
+            "3830067440429"
+          ]
+        },
+        {
+          "name": "Lithophane white",
+          "hex": "fffef0",
+          "eans": [
+            "3830067446360"
+          ]
+        },
+        {
+          "name": "Luminescent",
+          "hex": "ccff00",
+          "glow": true,
+          "eans": [
+            "3830067440252"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff",
+          "eans": [
+            "3830067443727"
+          ]
+        },
+        {
+          "name": "Marble",
+          "hex": "dedede",
+          "pattern": "marble",
+          "eans": [
+            "3830067440177"
+          ]
+        },
+        {
+          "name": "Metallic antracite",
+          "hex": "4a4a4a",
+          "eans": [
+            "3830067440207"
+          ]
+        },
+        {
+          "name": "Metallic bronze",
+          "hex": "49371b",
+          "eans": [
+            "3830067440269"
+          ]
+        },
+        {
+          "name": "Neon green",
+          "hex": "78f343",
+          "eans": [
+            "3830067440511"
+          ]
+        },
+        {
+          "name": "Neon orange",
+          "hex": "ffa62d",
+          "eans": [
+            "3830067440498"
+          ]
+        },
+        {
+          "name": "Neon red",
+          "hex": "ff1744",
+          "eans": [
+            "3830067440504"
+          ]
+        },
+        {
+          "name": "Neon yellow RAL 1026",
+          "hex": "ffff00",
+          "eans": [
+            "3830067440238"
+          ]
+        },
+        {
+          "name": "New gold",
+          "hex": "daa520",
+          "eans": [
+            "3830067443581"
+          ]
+        },
+        {
+          "name": "Olive Green",
+          "hex": "6b8e23",
+          "eans": [
+            "3830067440436"
+          ]
+        },
+        {
+          "name": "Opal white",
+          "hex": "f8f6f0",
+          "eans": [
+            "3830067443567"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff922f",
+          "eans": [
+            "3830067440283"
+          ]
+        },
+        {
+          "name": "Pearl white",
+          "hex": "ebf4f1",
+          "eans": [
+            "3830067440214"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "eans": [
+            "3830067440566"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "5700ce",
+          "eans": [
+            "3830067440603"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067440290",
+            "3830067442454"
+          ]
+        },
+        {
+          "name": "Satin pink",
+          "hex": "ff91a4",
+          "eans": [
+            "3830067440313"
+          ]
+        },
+        {
+          "name": "Satin turquoise",
+          "hex": "40e0d0",
+          "eans": [
+            "3830067440184"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "7c7c7c",
+          "eans": [
+            "3830067440351",
+            "3830067444373"
+          ]
+        },
+        {
+          "name": "Toxic yellow",
+          "hex": "d4e157",
+          "eans": [
+            "3830067440368"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067440382",
+            "3830067442478"
+          ]
+        },
+        {
+          "name": "Transparent blue",
+          "hex": "6eb5ff",
+          "translucent": true,
+          "eans": [
+            "3830067440399"
+          ]
+        },
+        {
+          "name": "Transparent glitter",
+          "hex": "ffffff",
+          "translucent": true,
+          "pattern": "sparkle",
+          "eans": [
+            "3830067440245"
+          ]
+        },
+        {
+          "name": "Transparent green",
+          "hex": "90ee90",
+          "translucent": true,
+          "eans": [
+            "3830067440597"
+          ]
+        },
+        {
+          "name": "Transparent orange",
+          "hex": "ffa500",
+          "translucent": true,
+          "eans": [
+            "3830067440405"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067440474",
+            "3830067442379",
+            "3830067442386"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "eans": [
+            "3830067440306"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Recycled PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Recycled",
+          "hex": "808080",
+          "eans": [
+            "3830067447312"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Recycled PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Recycled",
+          "hex": "808080",
+          "eans": [
+            "3830067447367"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Antique bronze",
+          "hex": "808080",
+          "eans": [
+            "3830067445172"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "808080",
+          "eans": [
+            "3830067445165"
+          ]
+        },
+        {
+          "name": "Emerald green",
+          "hex": "2e7d32",
+          "eans": [
+            "3830067445196"
+          ]
+        },
+        {
+          "name": "Pure gold",
+          "hex": "ffd700",
+          "eans": [
+            "3830067447091"
+          ]
+        },
+        {
+          "name": "Ruby red",
+          "hex": "c41e2a",
+          "eans": [
+            "3830067445202"
+          ]
+        },
+        {
+          "name": "Sapphire blue",
+          "hex": "1e3a8a",
+          "eans": [
+            "3830067445189"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "7c7c7c",
+          "eans": [
+            "3830067445158"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067445134"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "TPU Mix {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 700
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d4c4a8",
+          "codes": [
+            "3830067446452"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 700
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "eans": [
+            "3830067441129"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff",
+          "eans": [
+            "3830067441143"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00e171",
+          "eans": [
+            "3830067441211"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "9a9a9a",
+          "eans": [
+            "3830067441181"
+          ]
+        },
+        {
+          "name": "Luminescent",
+          "hex": "ccff00",
+          "glow": true,
+          "eans": [
+            "3830067447275"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff922f",
+          "eans": [
+            "3830067441150"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "5700ce",
+          "eans": [
+            "3830067441204"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "eans": [
+            "3830067441167"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "7c7c7c",
+          "eans": [
+            "3830067444076"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true,
+          "eans": [
+            "3830067441198"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "eans": [
+            "3830067441136"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "eans": [
+            "3830067441174"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Wood PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 700
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        65
+      ],
+      "country_of_origin": "Slovenia",
+      "colors": [
+        {
+          "name": "Bamboo",
+          "hex": "ba9d7d",
+          "eans": [
+            "3830067440931"
+          ]
+        },
+        {
+          "name": "Cork",
+          "hex": "808080",
+          "eans": [
+            "3830067441105"
+          ]
+        },
+        {
+          "name": "Pine tree",
+          "hex": "d1b898",
+          "eans": [
+            "3830067440955"
+          ]
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/Numakers.json
+++ b/filaments/Numakers.json
@@ -330,7 +330,7 @@
             "diameters": [
                 1.75
             ],
-            "extruder_temp_Range": [
+            "extruder_temp_range": [
                 210,
                 240
             ],

--- a/filaments/aceaddity.json
+++ b/filaments/aceaddity.json
@@ -1,0 +1,261 @@
+{
+    "manufacturer": "Aceaddity",
+    "filaments": [
+        {
+            "name": "PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                { "weight": 1000.0 }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 210],
+            "bed_temp_range": [30, 60],
+            "colors": [
+                { "name": "Black", "hex": "000000", "codes": ["B0CJLR62MF"] },
+                { "name": "Yellow", "hex": "FFF200", "codes": ["B0CJM935VF"] },
+                { "name": "Red", "hex": "ED1C24", "codes": ["B0CJM4DTFL"] },
+                { "name": "Blue", "hex": "005FE8", "codes": ["B0CJM8WTT7"] }
+            ]
+        },
+        {
+            "name": "Flash PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 140.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 220],
+            "bed_temp_range": [45, 60],
+            "colors": [
+                { "name": "Black", "hex": "000000", "codes": ["B0C7G7YRVK"] },
+                { "name": "White", "hex": "F6F6F6", "codes": ["B0C7G8Z1Y9"] },
+                { "name": "Grey", "hex": "7F7F7F", "codes": ["B0C7G5L66D"] },
+                { "name": "Yellow", "hex": "FFF200", "codes": ["B0C7G7Q154"] },
+                { "name": "Blue", "hex": "005FE8", "codes": ["B0C7G55M6M"] },
+                { "name": "Red", "hex": "ED1C24" }
+            ]
+        },
+        {
+            "name": "PETG {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                { "weight": 1000.0 }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [220, 240],
+            "bed_temp_range": [70, 80],
+            "colors": [
+                { "name": "Black", "hex": "212322", "codes": ["B0C7RCM75G"] },
+                { "name": "White", "hex": "F6F6F6" },
+                { "name": "Grey", "hex": "808080" },
+                { "name": "Space Grey", "hex": "989795" },
+                { "name": "Red", "hex": "D15B51", "codes": ["B0C7RBV438"] },
+                { "name": "Blue", "hex": "005FE8", "codes": ["B0C7RDV36B"] },
+                {
+                    "name": "Clear",
+                    "hex": "00FFFFFF",
+                    "translucent": true,
+                    "codes": ["B0C7RDGYB5"]
+                }
+            ]
+        },
+        {
+            "name": "Matte {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                { "weight": 1000.0 }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 220],
+            "bed_temp_range": [30, 60],
+            "finish": "matte",
+            "colors": [
+                { "name": "White", "hex": "F6F6F6", "codes": ["B0D97L4PNB"] },
+                { "name": "Water Green", "hex": "8FD4B4", "codes": ["B0D97N8J7Q"] },
+                { "name": "Light Pink", "hex": "E5A6B7", "codes": ["B0D97MP4Q6"] },
+                { "name": "Goose Yellow", "hex": "F5E868", "codes": ["B0D97MSJCT"] },
+                { "name": "Black", "hex": "000000", "codes": ["B0D97P2HTX"] },
+                { "name": "Pink Blue", "hex": "9B8EC4", "codes": ["B0D97ML822"] }
+            ]
+        },
+        {
+            "name": "Silk Magic Dual {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 140.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 220],
+            "bed_temp_range": [50, 60],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial",
+            "colors": [
+                {
+                    "name": "Blue & Rose Red",
+                    "hexes": ["005FE8", "C21E56"],
+                    "codes": ["B0BFLPR3B6"]
+                },
+                {
+                    "name": "Purple & Yellow",
+                    "hexes": ["7F00FF", "FFF200"],
+                    "codes": ["B0BFLR9SBY"]
+                },
+                {
+                    "name": "Gold & Red",
+                    "hexes": ["D5983E", "ED1C24"],
+                    "codes": ["B0BFLRVBJS"]
+                },
+                {
+                    "name": "Silver & Dark Blue",
+                    "hexes": ["A6A9AA", "1B3A6B"],
+                    "codes": ["B0BFM1WCTH"]
+                },
+                {
+                    "name": "Blue & Green",
+                    "hexes": ["005FE8", "22B14C"],
+                    "codes": ["B0BFM1S8MH"]
+                },
+                {
+                    "name": "Gold & Rose Red",
+                    "hexes": ["D5983E", "C21E56"],
+                    "codes": ["B0BFLR4W3H"]
+                }
+            ]
+        },
+        {
+            "name": "Silk Magic Tri {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 140.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 220],
+            "bed_temp_range": [50, 60],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial",
+            "colors": [
+                {
+                    "name": "Blue-Red-Green",
+                    "hexes": ["005FE8", "ED1C24", "22B14C"],
+                    "codes": ["B0BFLW7K4D"]
+                },
+                {
+                    "name": "Blue-Purple-Yellow",
+                    "hexes": ["005FE8", "7F00FF", "FFF200"],
+                    "codes": ["B0BFLX8KHW"]
+                },
+                {
+                    "name": "Blue-Green-Orange",
+                    "hexes": ["005FE8", "22B14C", "FF7F27"],
+                    "codes": ["B0BFLX3FNZ"]
+                },
+                {
+                    "name": "Gold-Copper-Black",
+                    "hexes": ["D5983E", "B36A51", "000000"],
+                    "codes": ["B0BFLXG5YF"]
+                },
+                {
+                    "name": "Gold-Silver-Copper",
+                    "hexes": ["D5983E", "A6A9AA", "B36A51"],
+                    "codes": ["B0BFLVCPHS"]
+                }
+            ]
+        },
+        {
+            "name": "Rainbow {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 140.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 220],
+            "bed_temp_range": [50, 60],
+            "finish": "glossy",
+            "multi_color_direction": "longitudinal",
+            "colors": [
+                {
+                    "name": "Cosmic",
+                    "hexes": ["5B3378", "3D5AFE", "7C4DFF", "00BCD4", "1A237E"],
+                    "codes": ["B0C7ZGTGD3"]
+                },
+                {
+                    "name": "Candy",
+                    "hexes": ["FF6EC7", "FF4081", "FFC107", "81D4FA", "E1BEE7"],
+                    "codes": ["B0C7ZFLJ8D"]
+                },
+                {
+                    "name": "Forest",
+                    "hexes": ["2E7D32", "558B2F", "8BC34A", "33691E", "689F38"],
+                    "codes": ["B0C7ZDB2ZZ"]
+                },
+                {
+                    "name": "Macaron",
+                    "hexes": ["F8BBD0", "B3E5FC", "C8E6C9", "FFF9C4", "E1BEE7"]
+                }
+            ]
+        },
+        {
+            "name": "Wood PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                { "weight": 1000.0 }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [205, 215],
+            "bed_temp_range": [50, 60],
+            "fill": "wood",
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Beige",
+                    "hex": "DD9268",
+                    "codes": ["B0D97P1Z47"]
+                }
+            ]
+        },
+        {
+            "name": "Marble {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                { "weight": 1000.0 }
+            ],
+            "diameters": [1.75],
+            "extruder_temp_range": [190, 220],
+            "bed_temp_range": [30, 60],
+            "pattern": "marble",
+            "colors": [
+                {
+                    "name": "Marble",
+                    "hex": "C2C0BA",
+                    "pattern": "marble",
+                    "codes": ["B0D97QFJLM"]
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/agf.json
+++ b/filaments/agf.json
@@ -1,0 +1,240 @@
+{
+  "manufacturer": "AGF",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "NATURAL",
+          "hex": "e3e1de"
+        },
+        {
+          "name": "RED",
+          "hex": "c31714"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "WHITE",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "HONEY GOLD",
+          "hex": "f29d38"
+        },
+        {
+          "name": "RED CHERRY",
+          "hex": "da425f"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "BLUE",
+          "hex": "0008ff"
+        },
+        {
+          "name": "BLUE SKY",
+          "hex": "3dc1e9"
+        },
+        {
+          "name": "Brown",
+          "hex": "8c604b"
+        },
+        {
+          "name": "CARAMEL",
+          "hex": "d19f4b"
+        },
+        {
+          "name": "Coral",
+          "hex": "e77e6a"
+        },
+        {
+          "name": "Gold",
+          "hex": "dfa64f"
+        },
+        {
+          "name": "Green",
+          "hex": "38922d"
+        },
+        {
+          "name": "GREY",
+          "hex": "6b6b6b"
+        },
+        {
+          "name": "LIGHT PINK",
+          "hex": "b17fb7"
+        },
+        {
+          "name": "Marble",
+          "hex": "a0a8ae"
+        },
+        {
+          "name": "METALLIC MENTHOL",
+          "hex": "92a6ab"
+        },
+        {
+          "name": "NATURAL",
+          "hex": "e1ddda"
+        },
+        {
+          "name": "NEON PINK",
+          "hex": "ed3747"
+        },
+        {
+          "name": "ORANGE",
+          "hex": "da5d2a"
+        },
+        {
+          "name": "PINK",
+          "hex": "ff00f7"
+        },
+        {
+          "name": "Purple",
+          "hex": "483aaa"
+        },
+        {
+          "name": "Red",
+          "hex": "dc221e"
+        },
+        {
+          "name": "RED STRAWBERRY",
+          "hex": "fa2047"
+        },
+        {
+          "name": "RED WINE",
+          "hex": "d92d35"
+        },
+        {
+          "name": "Skin",
+          "hex": "cdbe80"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "e5d057"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/aicopyto.json
+++ b/filaments/aicopyto.json
@@ -1,0 +1,268 @@
+{
+  "manufacturer": "AICOPYTO",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "China"
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Marble White",
+          "hex": "ffffff",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble",
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Space Grey",
+          "hex": "555758"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1e90ec"
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "Purple",
+          "hex": "493ebd"
+        },
+        {
+          "name": "Red",
+          "hex": "ed646b"
+        },
+        {
+          "name": "Silk Gold",
+          "hex": "ddcf3c"
+        },
+        {
+          "name": "Silver Silk",
+          "hex": "bec2cb"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black-Gold",
+          "hex": "000000"
+        },
+        {
+          "name": "Red-Black",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Red/Blue/Green",
+          "hexes": [
+            "ff0000",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Red Sparkle",
+          "hex": "808080",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Starry Sky",
+          "hex": "0f0f10",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle",
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/aiorobotics.json
+++ b/filaments/aiorobotics.json
@@ -1,0 +1,88 @@
+{
+  "manufacturer": "AIO Robotics",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "19d7f6"
+        },
+        {
+          "name": "Bright Blue",
+          "hex": "78fefb"
+        },
+        {
+          "name": "Bright Green",
+          "hex": "aff22c"
+        },
+        {
+          "name": "Green",
+          "hex": "04d4a2"
+        },
+        {
+          "name": "Grey",
+          "hex": "99928c"
+        },
+        {
+          "name": "Metal Bronze",
+          "hex": "898b1b"
+        },
+        {
+          "name": "Metal Gold",
+          "hex": "fff487"
+        },
+        {
+          "name": "Metal Silver",
+          "hex": "dde1e0"
+        },
+        {
+          "name": "Orange",
+          "hex": "fe8718"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffddf1"
+        },
+        {
+          "name": "Purple",
+          "hex": "965ea5"
+        },
+        {
+          "name": "Red",
+          "hex": "ee2e1c"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbee00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/alchemakes.json
+++ b/filaments/alchemakes.json
@@ -1,0 +1,889 @@
+{
+  "manufacturer": "Alchemakes",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Baby Pink",
+          "hex": "d29dbc"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Fire Truck Red",
+          "hex": "990000"
+        },
+        {
+          "name": "Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Mint",
+          "hex": "78d7dd"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ]
+    },
+    {
+      "name": "ABS-CF {color_name}",
+      "material": "ABS-CF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "extruder_temp_range": [
+        255,
+        285
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "ABS-GF {color_name}",
+      "material": "ABS-GF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "extruder_temp_range": [
+        255,
+        285
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "2555e4"
+        },
+        {
+          "name": "Green",
+          "hex": "006100"
+        },
+        {
+          "name": "Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Milky White",
+          "hex": "f5f5ef"
+        },
+        {
+          "name": "Orange",
+          "hex": "fb752d"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ]
+    },
+    {
+      "name": "ASA-CF {color_name}",
+      "material": "ASA-CF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "extruder_temp_range": [
+        255,
+        285
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "ASA-GF {color_name}",
+      "material": "ASA-GF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "extruder_temp_range": [
+        255,
+        285
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "PA6-CF {color_name}",
+      "material": "PA6-CF",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        300
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "1c4706"
+        },
+        {
+          "name": "Banana Yellow",
+          "hex": "fcf0a1"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Brown",
+          "hex": "522100"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "666666"
+        },
+        {
+          "name": "Desert Yellow",
+          "hex": "b48c46"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "990000"
+        },
+        {
+          "name": "Fresh Green",
+          "hex": "6cc6b7"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "1eff00"
+        },
+        {
+          "name": "Khaki",
+          "hex": "c2a584"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Light Skin",
+          "hex": "ffece2"
+        },
+        {
+          "name": "Milky White",
+          "hex": "f5f5ef"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "78d7dd"
+        },
+        {
+          "name": "Pink",
+          "hex": "d29dbc"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0095ff"
+        },
+        {
+          "name": "Taro Purple",
+          "hex": "996aaf"
+        },
+        {
+          "name": "Very Peri",
+          "hex": "39008f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow Orange",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Yves Klein Blue",
+          "hex": "002fa7"
+        },
+        {
+          "name": "Zinc Yellow",
+          "hex": "ffd500"
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG Metal {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Antique Bronze",
+          "hex": "4d2814"
+        },
+        {
+          "name": "Blue",
+          "hex": "000238"
+        },
+        {
+          "name": "Blue Grey",
+          "hex": "455159"
+        },
+        {
+          "name": "Brass",
+          "hex": "8b682d"
+        },
+        {
+          "name": "Bronze",
+          "hex": "8b7b2d"
+        },
+        {
+          "name": "Copper",
+          "hex": "834321"
+        },
+        {
+          "name": "Green",
+          "hex": "006100"
+        },
+        {
+          "name": "Purple",
+          "hex": "622d71"
+        },
+        {
+          "name": "Silver",
+          "hex": "878787"
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "1c4706"
+        },
+        {
+          "name": "Banana Yellow",
+          "hex": "fcf0a1"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blackout White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blood Orange",
+          "hex": "ff1100"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Cherry Blossom Pink",
+          "hex": "cd70a6"
+        },
+        {
+          "name": "Daisy Purple",
+          "hex": "39008f"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "990000"
+        },
+        {
+          "name": "Fluorescent Green",
+          "hex": "73ff00"
+        },
+        {
+          "name": "Fluorescent Orange",
+          "hex": "ff4d00"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "1eff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "666666"
+        },
+        {
+          "name": "Light Coffee",
+          "hex": "7a5948"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Milky White",
+          "hex": "f5f5ef"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "78d7dd"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000238"
+        },
+        {
+          "name": "Normal White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Pink",
+          "hex": "d29dbc"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0095ff"
+        },
+        {
+          "name": "Taro Purple",
+          "hex": "996aaf"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "6cc6b7"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow Orange",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Zinc Yellow",
+          "hex": "ffd500"
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ]
+    },
+    {
+      "name": "PETG-CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black 12%",
+          "hex": "000000"
+        },
+        {
+          "name": "Black 5%",
+          "hex": "000000"
+        },
+        {
+          "name": "Black Red",
+          "hex": "450d0d"
+        },
+        {
+          "name": "Graphite Grey",
+          "hex": "3d3d3d"
+        },
+        {
+          "name": "Indigo",
+          "hex": "000238"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "292d1a"
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PLA Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "ffffff"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "1c4706"
+        },
+        {
+          "name": "Banana Yellow",
+          "hex": "fcf0a1"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Desert Yellow",
+          "hex": "b48c46"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "990000"
+        },
+        {
+          "name": "Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Light Coffee",
+          "hex": "7a5948"
+        },
+        {
+          "name": "Light Khaki",
+          "hex": "a59f97"
+        },
+        {
+          "name": "Milky White",
+          "hex": "f5f5ef"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000238"
+        },
+        {
+          "name": "Pink",
+          "hex": "d29dbc"
+        },
+        {
+          "name": "Reddish Brown",
+          "hex": "371b0b"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0095ff"
+        },
+        {
+          "name": "Tan",
+          "hex": "e5d4c2"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fff700"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blood Orange",
+          "hex": "ff1100"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "512915"
+        },
+        {
+          "name": "Green",
+          "hex": "006100"
+        },
+        {
+          "name": "Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Light Coffee",
+          "hex": "7a5948"
+        },
+        {
+          "name": "Natural",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Pink",
+          "hex": "d29dbc"
+        },
+        {
+          "name": "Purple",
+          "hex": "6600ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Reddish Brown",
+          "hex": "371b0b"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0095ff"
+        },
+        {
+          "name": "Tan",
+          "hex": "e5d4c2"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd500"
+        },
+        {
+          "name": "Yellow Orange",
+          "hex": "ff7b00"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ]
+    },
+    {
+      "name": "PLA-CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "1c4706"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Maroon",
+          "hex": "450d0d"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000238"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "6d8196"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PP-GF {color_name}",
+      "material": "PP-GF",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "ababab"
+        }
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "fill": "glass fiber"
+    }
+  ]
+}

--- a/filaments/aliz.json
+++ b/filaments/aliz.json
@@ -1,0 +1,276 @@
+{
+  "manufacturer": "Aliz",
+  "filaments": [
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blackish green",
+          "hex": "253d24"
+        },
+        {
+          "name": "Blue",
+          "hex": "2486b9"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b614d"
+        },
+        {
+          "name": "Coffee",
+          "hex": "5c3719"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "3b5f3a"
+        },
+        {
+          "name": "Glitter Silver",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Green",
+          "hex": "43b244"
+        },
+        {
+          "name": "Lake Blue",
+          "hex": "3170a7"
+        },
+        {
+          "name": "Light Yellow",
+          "hex": "f7de98"
+        },
+        {
+          "name": "Milky White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Nickel Black",
+          "hex": "232323"
+        },
+        {
+          "name": "Orange",
+          "hex": "e52a00"
+        },
+        {
+          "name": "Pink",
+          "hex": "e0c8d1"
+        },
+        {
+          "name": "Red",
+          "hex": "c02c38"
+        },
+        {
+          "name": "Skin",
+          "hex": "d9cbb8"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "57c3c2"
+        },
+        {
+          "name": "Violet",
+          "hex": "8a4b9c"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wine Red",
+          "hex": "5c2223"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fed71a"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.31,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Durian Yellow",
+          "hex": "de952e"
+        },
+        {
+          "name": "Grass Gray",
+          "hex": "d7d3c8"
+        },
+        {
+          "name": "Milky White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Morandi Green",
+          "hex": "bdccb2"
+        },
+        {
+          "name": "Sesame Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Wood",
+          "hex": "d0b277"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Chocolate",
+          "hex": "808080"
+        },
+        {
+          "name": "Magenta",
+          "hex": "808080"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "80766e"
+        },
+        {
+          "name": "Blue",
+          "hex": "2486b9"
+        },
+        {
+          "name": "Cyan",
+          "hex": "4b8f8c"
+        },
+        {
+          "name": "Green",
+          "hex": "43b244"
+        },
+        {
+          "name": "Orange",
+          "hex": "c1651a"
+        },
+        {
+          "name": "Purple",
+          "hex": "8a4b9c"
+        },
+        {
+          "name": "Tea",
+          "hex": "be7e4a"
+        },
+        {
+          "name": "Yellow",
+          "hex": "d2b42c"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/alttab.json
+++ b/filaments/alttab.json
@@ -1,0 +1,288 @@
+{
+  "manufacturer": "AltTab",
+  "filaments": [
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        212,
+        217
+      ],
+      "bed_temp_range": [
+        58,
+        58
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "4f4f4f",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        237,
+        242
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Tri-Color (Gold/Silver/Copper)",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Tri-Color (Green/Blue/Red)",
+          "hexes": [
+            "00ff02",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Tri-Color (Red/Blue/Yellow)",
+          "hexes": [
+            "ff0000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        210
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "BLabs Purple",
+          "hex": "5e43b7"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Poly Cotton White",
+          "hex": "e6dddb"
+        },
+        {
+          "name": "Poly Fossil Grey",
+          "hex": "6f727e"
+        },
+        {
+          "name": "Poly Red",
+          "hex": "e72f1d"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2b00ff"
+        },
+        {
+          "name": "Cool White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Cream White",
+          "hex": "fcfbf4"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "8f8f8f"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7300"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbff00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Tri-Color (Gold/Silver/Copper)",
+          "hex": "d69200"
+        },
+        {
+          "name": "Tri-Color (Red/Yellow/Blue)",
+          "hexes": [
+            "ff0000",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Wood",
+          "hex": "cca381"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/alzament.json
+++ b/filaments/alzament.json
@@ -1,0 +1,249 @@
+{
+  "manufacturer": "Alzament",
+  "filaments": [
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fcd116"
+        },
+        {
+          "name": "Blue",
+          "hex": "0047ab"
+        },
+        {
+          "name": "Lava Red",
+          "hex": "cf1020"
+        },
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513"
+        },
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0047ab"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "finish": "glossy",
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "Dual Blue-Pink",
+          "hexes": [
+            "0047ab",
+            "ffc0cb"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Dual Black-Gold",
+          "hexes": [
+            "000000",
+            "d4af37"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Tri Red-Green-Blue",
+          "hexes": [
+            "ff0000",
+            "008000",
+            "0000ff"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Tri Gold-Silver-Copper",
+          "hexes": [
+            "d4af37",
+            "c0c0c0",
+            "b87333"
+          ],
+          "multi_color_direction": "coaxial"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/americanfilament.json
+++ b/filaments/americanfilament.json
@@ -1,0 +1,760 @@
+{
+  "manufacturer": "American Filament",
+  "filaments": [
+    {
+      "name": "American Filament PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "American Blue",
+          "hex": "06368a",
+          "codes": [
+            "PLUS_1KG_BLUE"
+          ]
+        },
+        {
+          "name": "American Red",
+          "hex": "ba061e",
+          "codes": [
+            "PLUS_1KG_RED"
+          ]
+        },
+        {
+          "name": "Amethyst Purple",
+          "hex": "4e3696",
+          "codes": [
+            "PLUS_1KG_AMETHYST"
+          ]
+        },
+        {
+          "name": "Army Green",
+          "hex": "666642",
+          "codes": [
+            "PLUS_1KG_ARMYG"
+          ]
+        },
+        {
+          "name": "Bone White",
+          "hex": "eaded2",
+          "codes": [
+            "PLUS_1KG_BONE"
+          ]
+        },
+        {
+          "name": "Burnt Orange",
+          "hex": "962a06",
+          "codes": [
+            "PLUS_1KG_BURNTO"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "361e12",
+          "codes": [
+            "PLUS_1KG_BROWN"
+          ]
+        },
+        {
+          "name": "Coyote Brown",
+          "hex": "ba7e4e",
+          "codes": [
+            "PLUS_1KG_COYBROWN"
+          ]
+        },
+        {
+          "name": "Coyote Tan",
+          "hex": "d2ae7e",
+          "codes": [
+            "PLUS_1KG_COYTAN"
+          ]
+        },
+        {
+          "name": "Dandelion Yellow",
+          "hex": "fff606",
+          "codes": [
+            "PLUS_1KG_DANDYELLOW"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "06361e",
+          "codes": [
+            "PLUS_1KG_DARKG"
+          ]
+        },
+        {
+          "name": "Desert Tan",
+          "hex": "968a7e",
+          "codes": [
+            "PLUS_1KG_DESERTT"
+          ]
+        },
+        {
+          "name": "Forest Green",
+          "hex": "067e4e",
+          "codes": [
+            "PLUS_1KG_FORESTG"
+          ]
+        },
+        {
+          "name": "Gunmetal Gray",
+          "hex": "4e5a5a",
+          "codes": [
+            "PLUS_1KG_GUNMETAL"
+          ]
+        },
+        {
+          "name": "Honey Gold",
+          "hex": "de962a",
+          "codes": [
+            "PLUS_1KG_HONEYG"
+          ]
+        },
+        {
+          "name": "Ice White",
+          "hex": "c6c6c6",
+          "codes": [
+            "PLUS_1KG_WHITE"
+          ]
+        },
+        {
+          "name": "Icy Blue",
+          "hex": "a2bac6",
+          "codes": [
+            "PLUS_1KG_ICYBLUE"
+          ]
+        },
+        {
+          "name": "Ivory White",
+          "hex": "f6deba",
+          "codes": [
+            "PLUS_1KG_IVORY"
+          ]
+        },
+        {
+          "name": "Matte Black",
+          "hex": "121212",
+          "codes": [
+            "PLUS_1KG_BLACK"
+          ],
+          "finish": "matte"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "12de72",
+          "codes": [
+            "PLUS_1KG_NGREEN"
+          ]
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ff7236",
+          "codes": [
+            "PLUS_1KG_NORANGE"
+          ]
+        },
+        {
+          "name": "Neon Pink",
+          "hex": "ea0672",
+          "codes": [
+            "PLUS_1KG_NPINK"
+          ]
+        },
+        {
+          "name": "Primer Gray",
+          "hex": "babaae",
+          "codes": [
+            "PLUS_1KG_PRIMER"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "72065a",
+          "codes": [
+            "PLUS_1KG_PURPLE"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0696ea",
+          "codes": [
+            "PLUS_1KG_SKYBLUE"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "06c6c6",
+          "codes": [
+            "PLUS_1KG_TEAL"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "American Filament Tough Pro PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "country_of_origin": "USA",
+      "tds_url": "https://cdn.shopify.com/s/files/1/0560/2741/4702/files/AF_Tough_Pro_PLA_Plus_Technical_DataSheet.pdf",
+      "colors": [
+        {
+          "name": "American Red",
+          "hex": "ae061e",
+          "codes": [
+            "TOUGH_1KG_RED"
+          ]
+        },
+        {
+          "name": "Army Green",
+          "hex": "4e4e2a",
+          "codes": [
+            "TOUGH_1KG_ARMYG"
+          ]
+        },
+        {
+          "name": "Coyote Brown",
+          "hex": "ba8a4e",
+          "codes": [
+            "TOUGH_1KG_COYBRO"
+          ]
+        },
+        {
+          "name": "Gunmetal Gray",
+          "hex": "5a5a4e",
+          "codes": [
+            "TOUGH_1KG_GUNMETAL"
+          ]
+        },
+        {
+          "name": "Onyx Black",
+          "hex": "121212",
+          "codes": [
+            "TOUGH_1KG_BLACK"
+          ]
+        },
+        {
+          "name": "Safety Orange",
+          "hex": "e85a00",
+          "codes": [
+            "TOUGH_1KG_SAF-ORAN"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "American Filament Regenerative PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "American Blue",
+          "hex": "060636",
+          "codes": [
+            "RGEN-PLUS_1KG_BLUE"
+          ]
+        },
+        {
+          "name": "American Red",
+          "hex": "8a0606",
+          "codes": [
+            "RGEN-PLUS_1KG_RED"
+          ]
+        },
+        {
+          "name": "Army Green",
+          "hex": "36361e",
+          "codes": [
+            "RGEN-PLUS_1KG_ARMYG"
+          ]
+        },
+        {
+          "name": "Burnt Orange",
+          "hex": "962a06",
+          "codes": [
+            "RGEN-PLUS_1KG_BURNTO"
+          ]
+        },
+        {
+          "name": "Coyote Tan",
+          "hex": "967242",
+          "codes": [
+            "RGEN-PLUS_1KG_COYTAN"
+          ]
+        },
+        {
+          "name": "Forest Green",
+          "hex": "064212",
+          "codes": [
+            "RGEN-PLUS_1KG_FORESTG"
+          ]
+        },
+        {
+          "name": "Gunmetal Gray",
+          "hex": "72727e",
+          "codes": [
+            "RGEN-PLUS_1KG_GUNMETAL"
+          ]
+        },
+        {
+          "name": "Ice White",
+          "hex": "c6c6c6",
+          "codes": [
+            "RGEN-PLUS_1KG_WHITE"
+          ]
+        },
+        {
+          "name": "Matte Black",
+          "hex": "1e1e1e",
+          "codes": [
+            "RGEN-PLUS_1KG_BLACK"
+          ],
+          "finish": "matte"
+        },
+        {
+          "name": "Neon Pink",
+          "hex": "ea0672",
+          "codes": [
+            "RGEN-PLUS_1KG_NPINK"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "American Filament PCTG {color_name}",
+      "material": "PCTG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 4000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        100
+      ],
+      "country_of_origin": "USA",
+      "tds_url": "https://cdn.shopify.com/s/files/1/0560/2741/4702/files/AF_PCTG_Technical_Data_Sheet_-_TDS.pdf",
+      "sds_url": "https://cdn.shopify.com/s/files/1/0560/2741/4702/files/AF_PCTG_US_Material_Safety_Data_Sheet_-_MSDS.pdf",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "36361e",
+          "codes": [
+            "PCTG_1KG_ARMYG",
+            "PCTG_4KG_ARMYG"
+          ]
+        },
+        {
+          "name": "Blizzard White",
+          "hex": "e8e8e8",
+          "codes": [
+            "PCTG_1KG_WHITE",
+            "PCTG_4KG_WHITE"
+          ]
+        },
+        {
+          "name": "Camo Brown",
+          "hex": "a25a2a",
+          "codes": [
+            "PCTG_1KG_CAMO-B"
+          ]
+        },
+        {
+          "name": "Construction Orange",
+          "hex": "e85a1e",
+          "codes": [
+            "PCTG_1KG_CONORANGE"
+          ]
+        },
+        {
+          "name": "Fire Engine Red",
+          "hex": "ff422a",
+          "codes": [
+            "PCTG_1KG_FIRERED"
+          ]
+        },
+        {
+          "name": "Gunmetal Gray",
+          "hex": "363636",
+          "codes": [
+            "PCTG_1KG_GUNMETAL",
+            "PCTG_4KG_GUNMETAL"
+          ]
+        },
+        {
+          "name": "Hi-Vis Yellow",
+          "hex": "deea06",
+          "codes": [
+            "PCTG_1KG_HV-YEL"
+          ]
+        },
+        {
+          "name": "Obsidian Black",
+          "hex": "2a2a2a",
+          "codes": [
+            "PCTG_1KG_BLACK",
+            "PCTG_4KG_BLACK"
+          ]
+        },
+        {
+          "name": "Police Blue",
+          "hex": "1a3a6e",
+          "codes": [
+            "PCTG_1KG_LEOBLUE"
+          ]
+        },
+        {
+          "name": "Safety Yellow",
+          "hex": "d28a1e",
+          "codes": [
+            "PCTG_1KG_SAF-YEL"
+          ]
+        },
+        {
+          "name": "Transparent Jade Green",
+          "hex": "066612",
+          "codes": [
+            "PCTG_1KG_TGREEN"
+          ],
+          "translucent": true
+        },
+        {
+          "name": "Transparent Royal Purple",
+          "hex": "7b2d8e",
+          "codes": [
+            "PCTG_1KG_ROYALPURP"
+          ],
+          "translucent": true
+        },
+        {
+          "name": "Transparent Ruby Red",
+          "hex": "c41e2a",
+          "codes": [
+            "PCTG_1KG_TRED"
+          ],
+          "translucent": true
+        },
+        {
+          "name": "Transparent Sapphire Blue",
+          "hex": "1e5a9e",
+          "codes": [
+            "PCTG_1KG_TBLUE"
+          ],
+          "translucent": true
+        },
+        {
+          "name": "Transparent Turn Signal Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PCTG_1KG_SIGNALORANGE"
+          ],
+          "translucent": true
+        },
+        {
+          "name": "Turquoise",
+          "hex": "1e7e7e",
+          "codes": [
+            "PCTG_1KG_TURQUOISE"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "American Filament Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "finish": "glossy",
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Amethyst Purple",
+          "hex": "ae8ac6",
+          "codes": [
+            "SILK_1KG_AMETHYST"
+          ]
+        },
+        {
+          "name": "Arctic White",
+          "hex": "e8e8e8",
+          "codes": [
+            "SILK_1KG_WHITE"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "1565c0",
+          "codes": [
+            "SILK_1KG_BLUE"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "06de96",
+          "codes": [
+            "SILK_1KG_EMERALD"
+          ]
+        },
+        {
+          "name": "Graphite",
+          "hex": "4a4a4a",
+          "codes": [
+            "SILK_1KG_GRAPHITE"
+          ]
+        },
+        {
+          "name": "Neon Green",
+          "hex": "7edea2",
+          "codes": [
+            "SILK_1KG_NGREEN"
+          ]
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "f6ba96",
+          "codes": [
+            "SILK_1KG_NORANGE"
+          ]
+        },
+        {
+          "name": "Neon Pink",
+          "hex": "ff96ba",
+          "codes": [
+            "SILK_1KG_NPINK"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "ba72ba",
+          "codes": [
+            "SILK_1KG_PURPLE"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "de728a",
+          "codes": [
+            "SILK_1KG_RED"
+          ]
+        },
+        {
+          "name": "Rose Gold",
+          "hex": "c9877a",
+          "codes": [
+            "SILK_1KG_ROSE"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "2ad2d2",
+          "codes": [
+            "SILK_1KG_TEAL"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "SILK_1KG_YELLOW"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "American Filament Lithophane PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Classic Lithophane White",
+          "hex": "f5f0e8",
+          "codes": [
+            "LITHO_1KG_CLW"
+          ]
+        },
+        {
+          "name": "Cool Lithophane Gray",
+          "hex": "9a9a9a",
+          "codes": [
+            "LITHO_1KG_COOLG"
+          ]
+        },
+        {
+          "name": "Crisp Lithophane Gray",
+          "hex": "6e6e6e",
+          "codes": [
+            "LITHO_1KG_CLG"
+          ]
+        },
+        {
+          "name": "Sepia Lithophane",
+          "hex": "8b6914",
+          "codes": [
+            "LITHO_1KG_SEPIA"
+          ]
+        },
+        {
+          "name": "Warm Lithophane White",
+          "hex": "f6dec6",
+          "codes": [
+            "LITHO_1KG_WLW"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "American Filament CMYK PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Cyan",
+          "hex": "06aede",
+          "codes": [
+            "CMYK_1KG_CYAN"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ea1296",
+          "codes": [
+            "CMYK_1KG_MAGENTA"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "fff65a",
+          "codes": [
+            "CMYK_1KG_YELLOW"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/amolen.json
+++ b/filaments/amolen.json
@@ -1,0 +1,64 @@
+{
+    "manufacturer": "Amolen",
+    "filaments": [
+        {
+            "name": "Amolen Silk PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 220
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                }
+            ]
+        },
+        {
+            "name": "Amolen Wood PLA {color_name}",
+            "material": "PLA",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 150,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 50,
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Walnut",
+                    "hex": "5C4033"
+                },
+                {
+                    "name": "Bamboo",
+                    "hex": "E1C699"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/amoybaby.json
+++ b/filaments/amoybaby.json
@@ -1,0 +1,243 @@
+{
+  "manufacturer": "Amoybaby",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Violet Phosphorescent",
+          "hex": "7269f7"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marine Canopy",
+          "hex": "808080"
+        },
+        {
+          "name": "Mystic haze",
+          "hex": "387378"
+        },
+        {
+          "name": "Solar Eclipse",
+          "hex": "503516"
+        },
+        {
+          "name": "Solar Horizon",
+          "hex": "5a4035"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3946f3"
+        },
+        {
+          "name": "Blue-Green",
+          "hex": "266aa0"
+        },
+        {
+          "name": "Gold",
+          "hex": "d29d00"
+        },
+        {
+          "name": "Green",
+          "hex": "008241"
+        },
+        {
+          "name": "Pearl White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "a22725"
+        },
+        {
+          "name": "Silver",
+          "hex": "878787"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ccff00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black / Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue Rose Red",
+          "hex": "3d9efe"
+        },
+        {
+          "name": "Dual Gold/Black",
+          "hexes": [
+            "808080",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold to Red",
+          "hex": "9c5122"
+        },
+        {
+          "name": "Green - Yellow",
+          "hex": "ccff00"
+        },
+        {
+          "name": "Purple-Green",
+          "hex": "3c3353"
+        }
+      ]
+    },
+    {
+      "name": "Silk Plus {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "ffbf00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue-Rose-Red",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ampertec.json
+++ b/filaments/ampertec.json
@@ -1,0 +1,491 @@
+{
+  "manufacturer": "Ampertec",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        235
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0433ff"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Neon Yellow",
+          "hex": "ede500"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0433ff"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Uv {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "White/Green",
+          "hexes": [
+            "ffffff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Purple",
+          "hex": "7b219f",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Luminous Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "ff2600"
+        }
+      ]
+    },
+    {
+      "name": "PA {color_name}",
+      "material": "PA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PA6 {color_name}",
+      "material": "PA6",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0433ff"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue (Pearlescent)",
+          "hex": "0433ff"
+        },
+        {
+          "name": "Gold",
+          "hex": "aa7942"
+        },
+        {
+          "name": "Green (Pearlescent)",
+          "hex": "00f900"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2600"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Yellow",
+          "hex": "e5e811"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0433ff"
+        },
+        {
+          "name": "Brown",
+          "hex": "5a1c00"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "49457f"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "04390f"
+        },
+        {
+          "name": "Gold",
+          "hex": "d3af37"
+        },
+        {
+          "name": "Grey",
+          "hex": "919191"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "68cdef"
+        },
+        {
+          "name": "Lila",
+          "hex": "9300f5"
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "b4ecac"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Pink",
+          "hex": "ef00e0"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2600"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Skin Tone",
+          "hex": "ffc4ab"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "ffbb00"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        235
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "929292"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2600"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fffb00"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/amz3d.json
+++ b/filaments/amz3d.json
@@ -1,0 +1,103 @@
+{
+  "manufacturer": "AMZ3D",
+  "filaments": [
+    {
+      "name": "AMZ3D PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "AMZ3D ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        95,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ankermake.json
+++ b/filaments/ankermake.json
@@ -1,0 +1,48 @@
+{
+  "manufacturer": "AnkerMake",
+  "filaments": [
+    {
+      "name": "AnkerMake PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 230],
+      "bed_temp_range": [45, 65],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Yellow", "hex": "F0F010"}
+      ]
+    },
+    {
+      "name": "AnkerMake PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 260],
+      "bed_temp_range": [60, 90],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"}
+      ]
+    }
+  ]
+}

--- a/filaments/arianeplast.json
+++ b/filaments/arianeplast.json
@@ -1,0 +1,200 @@
+{
+  "manufacturer": "Arianeplast",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2300.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0047ab"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0047ab"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        110,
+        130
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ataraxiaart.json
+++ b/filaments/ataraxiaart.json
@@ -1,0 +1,496 @@
+{
+    "manufacturer": "Ataraxia Art",
+    "filaments": [
+        {
+            "name": "PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Red",
+                    "hex": "CB333B"
+                },
+                {
+                    "name": "Black",
+                    "hex": "101820"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E2B719"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "8B6F47"
+                },
+                {
+                    "name": "Violet",
+                    "hex": "A5007B"
+                },
+                {
+                    "name": "White",
+                    "hex": "F4F9FF"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "0076B6"
+                },
+                {
+                    "name": "Grass Green",
+                    "hex": "009A44"
+                },
+                {
+                    "name": "Prusa Orange",
+                    "hex": "FE5000"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "5C3D31"
+                },
+                {
+                    "name": "Light Brown",
+                    "hex": "C5A572"
+                },
+                {
+                    "name": "Ivory White",
+                    "hex": "FFFFF0"
+                }
+            ],
+            "country_of_origin": "China"
+        },
+        {
+            "name": "Flexible PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                0,
+                40
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "101820"
+                },
+                {
+                    "name": "Red",
+                    "hex": "CB333B"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E2B719"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "8B6F47"
+                },
+                {
+                    "name": "Violet",
+                    "hex": "A5007B"
+                },
+                {
+                    "name": "White",
+                    "hex": "F4F9FF"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "0076B6"
+                },
+                {
+                    "name": "Green",
+                    "hex": "009A44"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FE5000"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "5C3D31"
+                },
+                {
+                    "name": "Light Brown",
+                    "hex": "C5A572"
+                },
+                {
+                    "name": "Ivory White",
+                    "hex": "FFFFF0"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "F5B6CD"
+                },
+                {
+                    "name": "Slate Gray",
+                    "hex": "8B8C89"
+                }
+            ],
+            "country_of_origin": "China"
+        },
+        {
+            "name": "PETG {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                240
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "212322"
+                },
+                {
+                    "name": "Red",
+                    "hex": "E4002B"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FEDB00"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FE5000"
+                },
+                {
+                    "name": "Yellow Gold",
+                    "hex": "BF9B30"
+                },
+                {
+                    "name": "Copper Mix Gold",
+                    "hex": "BF9B30"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "5CB8E9"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0032A0"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00A94F"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "F8A3BC"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "4F2683"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "A2AAAD"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "3D3028"
+                },
+                {
+                    "name": "Light Brown",
+                    "hex": "C5A572"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ],
+            "country_of_origin": "China"
+        },
+        {
+            "name": "Wood PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.28,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Natural",
+                    "hex": "C4A574"
+                },
+                {
+                    "name": "Walnut",
+                    "hex": "5C4033"
+                },
+                {
+                    "name": "White Pine",
+                    "hex": "E8DCC8"
+                },
+                {
+                    "name": "Brick Red",
+                    "hex": "8B4513"
+                }
+            ],
+            "fill": "wood",
+            "country_of_origin": "China"
+        },
+        {
+            "name": "Silk PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Ice Blue",
+                    "hex": "6EC6E6",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Fire Red",
+                    "hex": "D62828",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Blue-Green-Red",
+                    "hexes": [
+                        "0032A0",
+                        "009A44",
+                        "CB333B"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Blue-Yellow-Purple",
+                    "hexes": [
+                        "0032A0",
+                        "FEDB00",
+                        "4F2683"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Blue-Green-Orange",
+                    "hexes": [
+                        "0032A0",
+                        "009A44",
+                        "FE5000"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Blue-Yellow-Fuchsia",
+                    "hexes": [
+                        "0032A0",
+                        "FEDB00",
+                        "FF00FF"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Gold-Copper-Blue",
+                    "hexes": [
+                        "BF9B30",
+                        "B87333",
+                        "0032A0"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Gold-Copper-Black",
+                    "hexes": [
+                        "BF9B30",
+                        "B87333",
+                        "101820"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Gold-Green-Fuchsia",
+                    "hexes": [
+                        "BF9B30",
+                        "009A44",
+                        "FF00FF"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Pink-Green-Purple",
+                    "hexes": [
+                        "F8A3BC",
+                        "009A44",
+                        "4F2683"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Red-Yellow-Green",
+                    "hexes": [
+                        "CB333B",
+                        "FEDB00",
+                        "009A44"
+                    ],
+                    "multi_color_direction": "coaxial",
+                    "finish": "glossy"
+                }
+            ],
+            "finish": "glossy",
+            "country_of_origin": "China"
+        },
+        {
+            "name": "Rainbow PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Fast Color Change",
+                    "hexes": [
+                        "CB333B",
+                        "FEDB00",
+                        "009A44",
+                        "0032A0",
+                        "4F2683"
+                    ],
+                    "multi_color_direction": "longitudinal"
+                },
+                {
+                    "name": "Macaron Matte",
+                    "hexes": [
+                        "F8A3BC",
+                        "A2D5C6",
+                        "FEDB00",
+                        "B8A9C9",
+                        "A8D8EA"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "matte"
+                },
+                {
+                    "name": "Mini Rainbow",
+                    "hexes": [
+                        "F4F9FF",
+                        "F8A3BC",
+                        "A8D8EA",
+                        "FEDB00",
+                        "C5E99B"
+                    ],
+                    "multi_color_direction": "longitudinal"
+                },
+                {
+                    "name": "Silk Shiny Multicolor",
+                    "hexes": [
+                        "CB333B",
+                        "FEDB00",
+                        "009A44",
+                        "0032A0",
+                        "BF9B30"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Glitter Sparkle",
+                    "hexes": [
+                        "E4002B",
+                        "FEDB00",
+                        "009A44",
+                        "0032A0",
+                        "BF9B30"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "pattern": "sparkle",
+                    "finish": "glossy"
+                }
+            ],
+            "country_of_origin": "China"
+        }
+    ]
+}

--- a/filaments/atomicfilament.json
+++ b/filaments/atomicfilament.json
@@ -1,0 +1,113 @@
+{
+  "manufacturer": "Atomic Filament",
+  "filaments": [
+    {
+      "name": "Atomic PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        65
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Nuclear Neon Green",
+          "hex": "39ff14"
+        },
+        {
+          "name": "Candy Apple Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Jet Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Bright White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Sunset Orange",
+          "hex": "ff6f00"
+        },
+        {
+          "name": "Steel Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Translucent Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "Atomic PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Bright White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Natural Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/bambulab.json
+++ b/filaments/bambulab.json
@@ -200,7 +200,13 @@
             "colors": [
                 {
                     "name": "Ivory White",
-                    "hex": "FFFFFF"
+                    "hex": "FFFFFF",
+                    "codes": [
+                        "11100"
+                    ],
+                    "eans": [
+                        "6975337031345"
+                    ]
                 },
                 {
                     "name": "Latte Brown",
@@ -208,11 +214,23 @@
                 },
                 {
                     "name": "Desert Tan",
-                    "hex": "E8DBB7"
+                    "hex": "E8DBB7",
+                    "eans": [
+                        "6975337035053"
+                    ],
+                    "eans_refill": [
+                        "6975337038177"
+                    ]
                 },
                 {
                     "name": "Ash Gray",
-                    "hex": "9B9EA0"
+                    "hex": "9B9EA0",
+                    "codes": [
+                        "11102"
+                    ],
+                    "eans": [
+                        "6975337031352"
+                    ]
                 },
                 {
                     "name": "Lilac Purple",
@@ -232,7 +250,13 @@
                 },
                 {
                     "name": "Scarlet Red",
-                    "hex": "DE4343"
+                    "hex": "DE4343",
+                    "codes": [
+                        "11200"
+                    ],
+                    "eans": [
+                        "6975337031338"
+                    ]
                 },
                 {
                     "name": "Dark Red",
@@ -256,15 +280,27 @@
                 },
                 {
                     "name": "Marine Blue",
-                    "hex": "0078BF"
+                    "hex": "0078BF",
+                    "codes": [
+                        "11600"
+                    ]
                 },
                 {
                     "name": "Dark Blue",
-                    "hex": "042F56"
+                    "hex": "042F56",
+                    "eans": [
+                        "6975337031871"
+                    ]
                 },
                 {
                     "name": "Charcoal",
-                    "hex": "000000"
+                    "hex": "000000",
+                    "codes": [
+                        "11101"
+                    ],
+                    "eans": [
+                        "6975337031376"
+                    ]
                 },
                 {
                     "name": "Bone White",
@@ -301,6 +337,82 @@
             ]
         },
         {
+            "name": "Aero {color_name}",
+            "material": "PLA",
+            "density": 0.74,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 230,
+            "bed_temp": 40,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "F5F1DD"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "CECDCA"
+                }
+            ]
+        },
+        {
+            "name": "Lite {color_name}",
+            "material": "PLA",
+            "density": 1.4,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 35,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "999D9D"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Red",
+                    "hex": "C6001A"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "EFE255"
+                },
+                {
+                    "name": "Cyan",
+                    "hex": "4DAFDA"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "004EA8"
+                }
+            ]
+        },
+        {
             "name": "Tough+ {color_name}",
             "material": "PLA",
             "density": 1.21,
@@ -318,7 +430,13 @@
             "colors": [
                 {
                     "name": "Yellow",
-                    "hex": "F4D53F"
+                    "hex": "F4D53F",
+                    "codes": [
+                        "12401"
+                    ],
+                    "eans": [
+                        "6937285500670"
+                    ]
                 },
                 {
                     "name": "White",
@@ -776,6 +894,13 @@
                         "F78F77",
                         "E4505A"
                     ]
+                },
+                {
+                    "name": "Dusk Glare",
+                    "hexes": [
+                        "ED9558",
+                        "CE4406"
+                    ]
                 }
             ]
         },
@@ -836,8 +961,26 @@
                     "name": "Aurora Purple (Blue-Purple)",
                     "multi_color_direction": "longitudinal",
                     "hexes": [
-                        "1E63BF",
-                        "713D9C"
+                        "7F3696",
+                        "006EC9"
+                    ]
+                },
+                {
+                    "name": "South Beach",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "F772A4",
+                        "00918B"
+                    ]
+                },
+                {
+                    "name": "Dawn Radiance",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "EC984C",
+                        "6CD4BC",
+                        "A66EB9",
+                        "D87694"
                     ]
                 }
             ]
@@ -982,7 +1125,7 @@
                 },
                 {
                     "name": "Gray",
-                    "hex": "9EA2A2"
+                    "hex": "7F7E83"
                 },
                 {
                     "name": "Blue Gray",
@@ -1025,6 +1168,10 @@
                     "hex": "9E007E"
                 },
                 {
+                    "name": "Dark Brown",
+                    "hex": "4F2C1D"
+                },
+                {
                     "name": "Black",
                     "hex": "000000"
                 }
@@ -1053,7 +1200,13 @@
                 },
                 {
                     "name": "Translucent Light Blue",
-                    "hex": "61B0FF"
+                    "hex": "61B0FF",
+                    "codes": [
+                        "32600"
+                    ],
+                    "eans": [
+                        "6975337035961"
+                    ]
                 },
                 {
                     "name": "Translucent Olive",
@@ -1065,7 +1218,13 @@
                 },
                 {
                     "name": "Translucent Teal",
-                    "hex": "77EDD7"
+                    "hex": "77EDD7",
+                    "codes": [
+                        "32501"
+                    ],
+                    "eans": [
+                        "6975337035992"
+                    ]
                 },
                 {
                     "name": "Translucent Orange",
@@ -1081,7 +1240,10 @@
                 },
                 {
                     "name": "Clear",
-                    "hex": "FFFFFF"
+                    "hex": "000000",
+                    "codes": [
+                        "32101"
+                    ]
                 }
             ]
         },
@@ -1120,11 +1282,17 @@
                 },
                 {
                     "name": "Blue",
-                    "hex": "002E96"
+                    "hex": "002E96",
+                    "codes": [
+                        "33600"
+                    ]
                 },
                 {
                     "name": "Black",
-                    "hex": "000000"
+                    "hex": "000000",
+                    "codes": [
+                        "33102"
+                    ]
                 },
                 {
                     "name": "White",
@@ -1132,7 +1300,13 @@
                 },
                 {
                     "name": "Cream",
-                    "hex": "F9DFB9"
+                    "hex": "F9DFB9",
+                    "codes": [
+                        "33401"
+                    ],
+                    "eans": [
+                        "6937285507990"
+                    ]
                 },
                 {
                     "name": "Lime Green",
@@ -1140,7 +1314,13 @@
                 },
                 {
                     "name": "Forest Green",
-                    "hex": "39541A"
+                    "hex": "39541A",
+                    "codes": [
+                        "33502"
+                    ],
+                    "eans": [
+                        "6937285508010"
+                    ]
                 },
                 {
                     "name": "Lake Blue",
@@ -1148,7 +1328,13 @@
                 },
                 {
                     "name": "Peanut Brown",
-                    "hex": "875718"
+                    "hex": "875718",
+                    "codes": [
+                        "33801"
+                    ],
+                    "eans": [
+                        "6937285508041"
+                    ]
                 },
                 {
                     "name": "Gray",
@@ -1378,7 +1564,7 @@
                 },
                 {
                     "name": "Clear Black",
-                    "hex": "5A5161"
+                    "hex": "000000"
                 },
                 {
                     "name": "Black",

--- a/filaments/basf.json
+++ b/filaments/basf.json
@@ -1,0 +1,233 @@
+{
+  "manufacturer": "BASF",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "707070"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Bronze 8008",
+          "hex": "c9962e"
+        },
+        {
+          "name": "Gold",
+          "hex": "957f2d"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "001eff"
+        },
+        {
+          "name": "Gelb",
+          "hex": "fffb00"
+        },
+        {
+          "name": "Grey",
+          "hex": "6b6b6b"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff9300"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White 20070",
+          "hex": "fffff0"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        250
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "black 45D",
+          "hex": "000000"
+        },
+        {
+          "name": "Gelb",
+          "hex": "fffb00"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Natur",
+          "hex": "e0d3b1"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Ice Blau",
+          "hex": "caf0fe"
+        }
+      ]
+    },
+    {
+      "name": "Ultra {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Pearl White",
+          "hex": "f8f6f0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/basfforwardam.json
+++ b/filaments/basfforwardam.json
@@ -1,0 +1,58 @@
+{
+  "manufacturer": "BASF Forward AM",
+  "filaments": [
+    {
+      "name": "Ultrafuse PLA {color_name}",
+      "material": "PLA",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 215,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 750,
+          "spool_weight": 215,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [210, 230],
+      "bed_temp_range": [50, 70],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    },
+    {
+      "name": "Ultrafuse PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 215,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 750,
+          "spool_weight": 215,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [220, 260],
+      "bed_temp_range": [60, 80],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    }
+  ]
+}

--- a/filaments/basicfil.json
+++ b/filaments/basicfil.json
@@ -1,0 +1,156 @@
+{
+  "manufacturer": "BASICFIL",
+  "filaments": [
+    {
+      "name": "PET {color_name}",
+      "material": "PET",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "clear",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Orange",
+          "hex": "f49d25"
+        },
+        {
+          "name": "ROUGE",
+          "hex": "df1c07"
+        },
+        {
+          "name": "Signal White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 90
+        },
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "1f92b4"
+        },
+        {
+          "name": "Green",
+          "hex": "2d6c3a"
+        },
+        {
+          "name": "Grey",
+          "hex": "787878"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2600"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbe941"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PET",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Trans. Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/bavariafilaments.json
+++ b/filaments/bavariafilaments.json
@@ -1,0 +1,445 @@
+{
+  "manufacturer": "Bavaria Filaments",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pearlthane Grey",
+          "hex": "d5d5d5"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Rot",
+          "hex": "bf3736"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "34f000"
+        },
+        {
+          "name": "Schwarz",
+          "hex": "000000"
+        },
+        {
+          "name": "Testgrau",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Apfelgrün",
+          "hex": "02c735"
+        },
+        {
+          "name": "Messing",
+          "hex": "b2966e"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Testgrau",
+          "hex": "444444"
+        },
+        {
+          "name": "Beige",
+          "hex": "cfac82"
+        },
+        {
+          "name": "Dunkelblau",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Gold",
+          "hex": "ebdb00"
+        },
+        {
+          "name": "Leuchtgrün",
+          "hex": "91d35a"
+        },
+        {
+          "name": "Oliv",
+          "hex": "51533e"
+        },
+        {
+          "name": "Orange",
+          "hex": "da5100"
+        },
+        {
+          "name": "Schwarz",
+          "hex": "000000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Weiß",
+          "hex": "fafafa"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Fantasy Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Anthrazit",
+          "hex": "383e42"
+        },
+        {
+          "name": "Beige",
+          "hex": "ddc6a1"
+        },
+        {
+          "name": "Beige (neu)",
+          "hex": "cfac82"
+        },
+        {
+          "name": "Braun",
+          "hex": "735747"
+        },
+        {
+          "name": "Bübchenblau",
+          "hex": "4698fc"
+        },
+        {
+          "name": "Clear / Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Dunkelblau",
+          "hex": "0f4f8f"
+        },
+        {
+          "name": "Fantasy Black",
+          "hex": "28292b"
+        },
+        {
+          "name": "Gelb",
+          "hex": "f3d245"
+        },
+        {
+          "name": "Gelb-Grün",
+          "hex": "92d856"
+        },
+        {
+          "name": "Grau",
+          "hex": "ebeae6"
+        },
+        {
+          "name": "Grey",
+          "hex": "c8cbc8"
+        },
+        {
+          "name": "Grün",
+          "hex": "085838"
+        },
+        {
+          "name": "Kupfer",
+          "hex": "5a5048"
+        },
+        {
+          "name": "Leuchtgrün",
+          "hex": "7ee96b"
+        },
+        {
+          "name": "Leuchtrosa",
+          "hex": "fb0fff"
+        },
+        {
+          "name": "Marmor Grau",
+          "hex": "cbd7d1"
+        },
+        {
+          "name": "Marmor Weiß",
+          "hex": "ebebeb"
+        },
+        {
+          "name": "Metallic Blau",
+          "hex": "288ed7"
+        },
+        {
+          "name": "Metallic Grün",
+          "hex": "006f38"
+        },
+        {
+          "name": "Metallic Violett",
+          "hex": "65387d"
+        },
+        {
+          "name": "Oliv",
+          "hex": "51533e"
+        },
+        {
+          "name": "Orange",
+          "hex": "f56b05"
+        },
+        {
+          "name": "Pastelltürkis",
+          "hex": "7fb0b2"
+        },
+        {
+          "name": "Petrol",
+          "hex": "4095ba"
+        },
+        {
+          "name": "Rosa",
+          "hex": "ee81c6"
+        },
+        {
+          "name": "Rot",
+          "hex": "ff212b"
+        },
+        {
+          "name": "Rot (neu)",
+          "hex": "bf3736"
+        },
+        {
+          "name": "Rubinrot",
+          "hex": "721422"
+        },
+        {
+          "name": "Sandstein",
+          "hex": "f2db9c"
+        },
+        {
+          "name": "Schwarz",
+          "hex": "000000"
+        },
+        {
+          "name": "Seidenmatt Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Seidenmatt Weiss",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Skin",
+          "hex": "e9ada5"
+        },
+        {
+          "name": "Testgrau",
+          "hex": "444444"
+        },
+        {
+          "name": "Violett",
+          "hex": "8b5989"
+        },
+        {
+          "name": "Wasserblau",
+          "hex": "256d7b"
+        },
+        {
+          "name": "Wasserblau (Makitablau)",
+          "hex": "007577"
+        },
+        {
+          "name": "Weiß",
+          "hex": "fafafa"
+        }
+      ]
+    },
+    {
+      "name": "Pastello {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Pastell Blau",
+          "hex": "52a3c2"
+        },
+        {
+          "name": "Pastellgelb",
+          "hex": "efa94a"
+        }
+      ]
+    },
+    {
+      "name": "Recycled {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        245
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "e9651d"
+        },
+        {
+          "name": "Repro Grün",
+          "hex": "008012"
+        },
+        {
+          "name": "Rot",
+          "hex": "bf3736"
+        },
+        {
+          "name": "Weiß",
+          "hex": "fafafa"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/bblife.json
+++ b/filaments/bblife.json
@@ -1,0 +1,239 @@
+{
+  "manufacturer": "Bblife",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Glow in Dark Blue",
+          "hex": "94e3fe"
+        },
+        {
+          "name": "Glow Rainbow",
+          "hex": "808080"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        0,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Acid Blue",
+          "hex": "00d1ff"
+        },
+        {
+          "name": "Blue",
+          "hex": "2ea8ff"
+        },
+        {
+          "name": "Blue-Purple Rainbow",
+          "hex": "7ac8ff"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "00ff2a"
+        },
+        {
+          "name": "Metallic Copper",
+          "hex": "f6bc82"
+        },
+        {
+          "name": "Metallic Gold",
+          "hex": "d3af37"
+        },
+        {
+          "name": "Pearlescent White",
+          "hex": "f8fafc"
+        },
+        {
+          "name": "Purple",
+          "hex": "c23dff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Rose Gold",
+          "hex": "d185a3"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "0259e3"
+        },
+        {
+          "name": "Shiny Pearlescent Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Silk Pearl White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Silver",
+          "hex": "878787"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "ffff8b"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White/Blue",
+          "hexes": [
+            "808080",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Multi Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Multi Rainbow",
+          "hex": "00ff00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Fast Change Rainbow",
+          "hex": "808080"
+        },
+        {
+          "name": "Rainbow Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Orange Rainbow",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/behant.json
+++ b/filaments/behant.json
@@ -1,0 +1,359 @@
+{
+  "manufacturer": "Behant",
+  "filaments": [
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Dark Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "12b1e6"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "faf591"
+        },
+        {
+          "name": "Silver",
+          "hex": "b4b4b4"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Beige / Off-white",
+          "hex": "fffbed"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0042aa"
+        },
+        {
+          "name": "Green",
+          "hex": "669c35"
+        },
+        {
+          "name": "Purple",
+          "hex": "874efe"
+        }
+      ]
+    },
+    {
+      "name": "Silk Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Greem Orange",
+          "hex": "0056d6"
+        },
+        {
+          "name": "Blue Green Orange",
+          "hex": "0080ff"
+        },
+        {
+          "name": "Gold Silver Copper",
+          "hex": "fdc700"
+        },
+        {
+          "name": "Red Green Blue",
+          "hex": "e22400"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "e22400"
+        }
+      ]
+    },
+    {
+      "name": "Silk Plus {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Candy series",
+          "hex": "a020f0"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Nebula Purple Sparkle",
+          "hex": "4e436e",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear Blue",
+          "hex": "0000e8"
+        },
+        {
+          "name": "Clear Yellow",
+          "hex": "ffff62"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6a00"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/bestfilament.json
+++ b/filaments/bestfilament.json
@@ -1,0 +1,227 @@
+{
+  "manufacturer": "Bestfilament",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Emerald",
+          "hex": "005b5b"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8306"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff46ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Dark Gray",
+          "hex": "202020"
+        }
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        240
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Brown",
+          "hex": "7f4829"
+        },
+        {
+          "name": "Lime",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8306"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "ffe6c3"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8306"
+        },
+        {
+          "name": "Серебристый металлик",
+          "hex": "a4a6a3"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/bing3d.json
+++ b/filaments/bing3d.json
@@ -1,0 +1,206 @@
+{
+  "manufacturer": "BING3D",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        60,
+        80
+      ],
+      "bed_temp_range": [
+        215,
+        215
+      ],
+      "colors": [
+        {
+          "name": "VERDE MILITAR/GREEN ARMY",
+          "hex": "6fb356"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "F {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        55
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "000000"
+        },
+        {
+          "name": "Christmas Green",
+          "hex": "005a27"
+        },
+        {
+          "name": "Grey",
+          "hex": "5e5c64"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "da94ff"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7800"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff72b6"
+        },
+        {
+          "name": "Red",
+          "hex": "e60005"
+        },
+        {
+          "name": "Walnut",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood",
+          "hex": "e1ca89"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        }
+      ]
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "ABS-GF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        280
+      ],
+      "bed_temp_range": [
+        70,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "90969a"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Florescent Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Fluorescent Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "da94ff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood",
+          "hex": "87510b"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/biqu.json
+++ b/filaments/biqu.json
@@ -1,0 +1,225 @@
+{
+    "manufacturer": "BIQU",
+    "filaments": [
+        {
+            "name": "PLA GO {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 384
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                195,
+                215
+            ],
+            "bed_temp_range": [
+                55,
+                65
+            ],
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1D1D1D"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "7C7C7C"
+                },
+                {
+                    "name": "White",
+                    "hex": "E7E7DF"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "1649B3"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "D3C446"
+                },
+                {
+                    "name": "Green",
+                    "hex": "6FB33F"
+                },
+                {
+                    "name": "Red",
+                    "hex": "AD1E1A"
+                },
+                {
+                    "name": "Apricot",
+                    "hex": "DCBBAA"
+                }
+            ]
+        },
+        {
+            "name": "PLA Aura Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                55,
+                65
+            ],
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "EFEAE3"
+                },
+                {
+                    "name": "Green",
+                    "hex": "B9E9CD"
+                },
+                {
+                    "name": "Cheese Yellow",
+                    "hex": "F2E66D"
+                },
+                {
+                    "name": "Ice Blue",
+                    "hex": "B5D5E4"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "8E949A"
+                },
+                {
+                    "name": "Lavender Purple",
+                    "hex": "8B87C9"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "F7D0D6"
+                }
+            ]
+        },
+        {
+            "name": "PLA HS {color_name}",
+            "material": "PLA+HS",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                240
+            ],
+            "bed_temp_range": [
+                0,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "E8F0F0"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "C0C0C8"
+                },
+                {
+                    "name": "Black",
+                    "hex": "303030"
+                }
+            ]
+        },
+        {
+            "name": "PLA-HR {color_name}",
+            "material": "PLA+HR",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 600
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                240
+            ],
+            "bed_temp_range": [
+                65,
+                75
+            ],
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "F0F0F0"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "F43613"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "1399F3"
+                },
+                {
+                    "name": "Black",
+                    "hex": "303030"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "A07452"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F5B613"
+                },
+                {
+                    "name": "Blue+Orange+White",
+                    "hexes": [
+                        "1399F3",
+                        "F43613",
+                        "F0F0F0"
+                    ],
+                    "multi_color_direction": "coaxial"
+                },
+                {
+                    "name": "Yellow+Orange+White",
+                    "hexes": [
+                        "F5B613",
+                        "F43613",
+                        "F0F0F0"
+                    ],
+                    "multi_color_direction": "coaxial"
+                },
+                {
+                    "name": "Red+Purple+White",
+                    "hexes": [
+                        "E05050",
+                        "B060B0",
+                        "F0F0F0"
+                    ],
+                    "multi_color_direction": "coaxial"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/blackforestfilaments.json
+++ b/filaments/blackforestfilaments.json
@@ -1,0 +1,204 @@
+{
+  "manufacturer": "Black Forest Filaments",
+  "filaments": [
+    {
+      "name": "ASA HF {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "dbdbdb"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 800
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Fire Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000080"
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "f95a12"
+        },
+        {
+          "name": "Zinc Yellow",
+          "hex": "faca31"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "pattern": "marble",
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Glitter",
+          "hex": "ffffff",
+          "pattern": "sparkle"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Metal {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "be5b2b"
+        }
+      ]
+    },
+    {
+      "name": "PLA Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "fill": "wood",
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Bamboo",
+          "hex": "ada58e"
+        },
+        {
+          "name": "Cork",
+          "hex": "ada58e"
+        },
+        {
+          "name": "Wood",
+          "hex": "ada58e"
+        }
+      ]
+    },
+    {
+      "name": "PA6-CF15 {color_name}",
+      "material": "PA6-CF15",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/buddy3d.json
+++ b/filaments/buddy3d.json
@@ -312,7 +312,7 @@
             "country_of_origin": "Czech Republic"
         },
         {
-            "name": "PLA+ Lithophane",
+            "name": "PLA+ Lithophane {color_name}",
             "material": "PLA+",
             "density": 1.24,
             "finish": "matte",

--- a/filaments/buddy3d.json
+++ b/filaments/buddy3d.json
@@ -1,0 +1,586 @@
+{
+    "manufacturer": "Buddy3D",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp": 55,
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2187ED"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "732C00"
+                },
+                {
+                    "name": "Green",
+                    "hex": "40ED60"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "B8B7AB"
+                },
+                {
+                    "name": "Lila",
+                    "hex": "985AE8"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FC7ED6"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF423B"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "A6A6A6"
+                },
+                {
+                    "name": "White",
+                    "hex": "FAFAFA"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F7EC13"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PLA Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "finish": "glossy",
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp": 55,
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "1D95E0",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Bronze",
+                    "hex": "C99A60",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "E89C74",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Dark Gold",
+                    "hex": "DBC63D",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "FFD500",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Ice Blue",
+                    "hex": "96DEFF",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FC62B9",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Red",
+                    "hex": "F55858",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Rose",
+                    "hex": "F08BC9",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Ultra Violet",
+                    "hex": "A328D4",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5",
+                    "finish": "glossy"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PLA Glitter {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp": 55,
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black Gold",
+                    "hex": "141413",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Dark Green",
+                    "hex": "42754F",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Green",
+                    "hex": "5BE37F",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF006A",
+                    "pattern": "sparkle"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PLA Pearl {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "finish": "glossy",
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp": 55,
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "3548D4",
+                    "finish": "glossy"
+                },
+                {
+                    "name": "Green",
+                    "hex": "2EA656",
+                    "finish": "glossy"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PLA Stone {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "pattern": "marble",
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp": 55,
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Marble Grey",
+                    "hex": "E5E6E8",
+                    "pattern": "marble"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PLA+ Skin tone {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "finish": "matte",
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "477C",
+                    "hex": "623B2A",
+                    "finish": "matte"
+                },
+                {
+                    "name": "478C",
+                    "hex": "703F2A",
+                    "finish": "matte"
+                },
+                {
+                    "name": "479C",
+                    "hex": "AA8066",
+                    "finish": "matte"
+                },
+                {
+                    "name": "480C",
+                    "hex": "C6A992",
+                    "finish": "matte"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PLA+ Lithophane",
+            "material": "PLA+",
+            "density": 1.24,
+            "finish": "matte",
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Lithophane",
+                    "hex": "FFFFFF",
+                    "finish": "matte",
+                    "translucent": true
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 250,
+            "extruder_temp_range": [
+                240,
+                260
+            ],
+            "bed_temp": 80,
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "288AE0"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "613500"
+                },
+                {
+                    "name": "Green",
+                    "hex": "6ACF85"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "878787"
+                },
+                {
+                    "name": "Lila",
+                    "hex": "7634AD"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FC3714"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "B0B0B0"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFF645"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "PETG Matt {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "finish": "matte",
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 250,
+            "extruder_temp_range": [
+                240,
+                260
+            ],
+            "bed_temp": 80,
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "finish": "matte"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF",
+                    "finish": "matte"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "ASA {color_name}",
+            "material": "ASA",
+            "density": 1.05,
+            "weights": [
+                {
+                    "weight": 750.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 260,
+            "extruder_temp_range": [
+                250,
+                270
+            ],
+            "bed_temp": 110,
+            "bed_temp_range": [
+                100,
+                120
+            ],
+            "colors": [
+                {
+                    "name": "Natural",
+                    "hex": "EBEDDA",
+                    "translucent": true
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 750.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 255,
+            "extruder_temp_range": [
+                230,
+                260
+            ],
+            "bed_temp": 100,
+            "bed_temp_range": [
+                80,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "080808"
+                },
+                {
+                    "name": "Green",
+                    "hex": "22D133"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "EBEDDA",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "ABS FR {color_name}",
+            "material": "ABS+FR",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 750.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 255,
+            "extruder_temp_range": [
+                230,
+                260
+            ],
+            "bed_temp": 100,
+            "bed_temp_range": [
+                80,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "080808"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "EBEDDA",
+                    "translucent": true
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        },
+        {
+            "name": "ABS ESD {color_name}",
+            "material": "ABS+ESD",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 750.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 255,
+            "extruder_temp_range": [
+                230,
+                260
+            ],
+            "bed_temp": 100,
+            "bed_temp_range": [
+                80,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "080808"
+                }
+            ],
+            "country_of_origin": "Czech Republic"
+        }
+    ]
+}

--- a/filaments/cailab.json
+++ b/filaments/cailab.json
@@ -1,0 +1,844 @@
+{
+    "manufacturer": "CaiLab",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                35,
+                55
+            ],
+            "colors": [
+                {
+                    "name": "Red",
+                    "hex": "E03233",
+                    "codes": [
+                        "AC199"
+                    ]
+                },
+                {
+                    "name": "Begonia",
+                    "hex": "FF7184",
+                    "codes": [
+                        "AC190"
+                    ]
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E3C517",
+                    "codes": [
+                        "AC107"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FE6C3A",
+                    "codes": [
+                        "AC021"
+                    ]
+                },
+                {
+                    "name": "Gray",
+                    "hex": "45474B",
+                    "codes": [
+                        "AC11"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "083B88",
+                    "codes": [
+                        "AC2145"
+                    ]
+                },
+                {
+                    "name": "Magenta",
+                    "hex": "D73A93",
+                    "codes": [
+                        "AC239"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "1E1A18",
+                    "codes": [
+                        "AC419"
+                    ]
+                },
+                {
+                    "name": "Chocolate",
+                    "hex": "503B2A",
+                    "codes": [
+                        "AC476"
+                    ]
+                },
+                {
+                    "name": "Light Blue",
+                    "hex": "AFEDE7",
+                    "codes": [
+                        "AC635"
+                    ]
+                },
+                {
+                    "name": "Bright Orange",
+                    "hex": "E04D01",
+                    "codes": [
+                        "AC1655"
+                    ]
+                },
+                {
+                    "name": "Cyan",
+                    "hex": "318FD6",
+                    "codes": [
+                        "AC2925"
+                    ]
+                },
+                {
+                    "name": "Peach Fuzz",
+                    "hex": "E9AF81",
+                    "codes": [
+                        "AC6023"
+                    ]
+                },
+                {
+                    "name": "Sakura Pink",
+                    "hex": "F5BECC",
+                    "codes": [
+                        "AC6050"
+                    ]
+                },
+                {
+                    "name": "Hunter Green",
+                    "hex": "1B332C",
+                    "codes": [
+                        "AC6060"
+                    ]
+                },
+                {
+                    "name": "Lime",
+                    "hex": "D6E42E",
+                    "codes": [
+                        "AC6192"
+                    ]
+                },
+                {
+                    "name": "Desert",
+                    "hex": "C3AF7F",
+                    "codes": [
+                        "AC7501"
+                    ]
+                },
+                {
+                    "name": "Lavender",
+                    "hex": "6054A5",
+                    "codes": [
+                        "AC2725"
+                    ]
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "515423",
+                    "codes": [
+                        "AC2306"
+                    ]
+                },
+                {
+                    "name": "Brown",
+                    "hex": "8F6743",
+                    "codes": [
+                        "AC2317"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "00A22A",
+                    "codes": [
+                        "AC2420"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "7F7F7F",
+                    "codes": [
+                        "ATM422"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "B6B2AF",
+                    "codes": [
+                        "AC9003"
+                    ]
+                },
+                {
+                    "name": "Violet",
+                    "hex": "692B8F",
+                    "codes": [
+                        "AC266"
+                    ]
+                },
+                {
+                    "name": "Army Green",
+                    "hex": "667450",
+                    "codes": [
+                        "AC5753"
+                    ]
+                },
+                {
+                    "name": "Crimson",
+                    "hex": "670B0F",
+                    "codes": [
+                        "AC1807"
+                    ]
+                },
+                {
+                    "name": "Light Gray",
+                    "hex": "7D807D",
+                    "codes": [
+                        "AC421"
+                    ]
+                },
+                {
+                    "name": "Lilac",
+                    "hex": "914EB0",
+                    "codes": [
+                        "AC2583"
+                    ]
+                },
+                {
+                    "name": "Mango Yellow",
+                    "hex": "FEAE01",
+                    "codes": [
+                        "AC2010"
+                    ]
+                },
+                {
+                    "name": "Old Glory Blue",
+                    "hex": "29477F",
+                    "codes": [
+                        "AC281"
+                    ]
+                },
+                {
+                    "name": "Mustard Yellow",
+                    "hex": "D3B120",
+                    "codes": [
+                        "AC115"
+                    ]
+                },
+                {
+                    "name": "Clear",
+                    "hex": "B9B9B9",
+                    "codes": [
+                        "ACL"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Dark Brown",
+                    "hex": "7B4D26",
+                    "codes": [
+                        "AC7517"
+                    ]
+                },
+                {
+                    "name": "Apricot",
+                    "hex": "CAB3AA",
+                    "codes": [
+                        "AC7604"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "262626",
+                    "codes": [
+                        "G419"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2B46A4",
+                    "codes": [
+                        "G2145"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "E6E6E6",
+                    "codes": [
+                        "G9003"
+                    ]
+                },
+                {
+                    "name": "Translucent",
+                    "hex": "BABABA",
+                    "codes": [
+                        "GCL"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Gray",
+                    "hex": "5E6166",
+                    "codes": [
+                        "G11"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "E84E51",
+                    "codes": [
+                        "G199"
+                    ]
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E8D652",
+                    "codes": [
+                        "G107"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FD6E2F",
+                    "codes": [
+                        "G021"
+                    ]
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "4A5328",
+                    "codes": [
+                        "G2306"
+                    ]
+                },
+                {
+                    "name": "Brown",
+                    "hex": "644025",
+                    "codes": [
+                        "G2317"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "00C901",
+                    "codes": [
+                        "G2420"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "6B4E9D",
+                    "codes": [
+                        "G2725"
+                    ]
+                },
+                {
+                    "name": "Cyan",
+                    "hex": "008CD0",
+                    "codes": [
+                        "G2925"
+                    ]
+                },
+                {
+                    "name": "Skin",
+                    "hex": "FBCEB3",
+                    "codes": [
+                        "G6023"
+                    ]
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FECFD0",
+                    "codes": [
+                        "G6050"
+                    ]
+                },
+                {
+                    "name": "Hunter Green",
+                    "hex": "415E36",
+                    "codes": [
+                        "G2265"
+                    ]
+                },
+                {
+                    "name": "Golden",
+                    "hex": "E3B043",
+                    "codes": [
+                        "G6005"
+                    ]
+                },
+                {
+                    "name": "Grass Green",
+                    "hex": "79D03E",
+                    "codes": [
+                        "G2421"
+                    ]
+                },
+                {
+                    "name": "Beige",
+                    "hex": "FFEAA8",
+                    "codes": [
+                        "G155"
+                    ]
+                },
+                {
+                    "name": "Ice Blue",
+                    "hex": "C0DFDF",
+                    "codes": [
+                        "G635"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "7B7D7A",
+                    "codes": [
+                        "G422"
+                    ]
+                },
+                {
+                    "name": "Coffee",
+                    "hex": "462E21",
+                    "codes": [
+                        "G2469"
+                    ]
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "2C1C8E",
+                    "codes": [
+                        "G2369"
+                    ]
+                },
+                {
+                    "name": "Translucent Blue",
+                    "hex": "7AC3F2",
+                    "codes": [
+                        "G637"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Brown",
+                    "hex": "DFAF89",
+                    "codes": [
+                        "G728"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Green",
+                    "hex": "6AE9CE",
+                    "codes": [
+                        "G6142"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Pink",
+                    "hex": "F7A1A1",
+                    "codes": [
+                        "G176"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Yellow",
+                    "hex": "F1EE65",
+                    "codes": [
+                        "G6192"
+                    ],
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Orange",
+                    "hex": "FFB17C",
+                    "codes": [
+                        "G1375"
+                    ],
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                240,
+                270
+            ],
+            "bed_temp_range": [
+                90,
+                95
+            ],
+            "colors": [
+                {
+                    "name": "Yellow",
+                    "hex": "F2CE35",
+                    "codes": [
+                        "ABS107"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "AD1D12",
+                    "codes": [
+                        "ABS186"
+                    ]
+                },
+                {
+                    "name": "Gray",
+                    "hex": "7F7F7F",
+                    "codes": [
+                        "ABS11"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "4E277A",
+                    "codes": [
+                        "ABS2725"
+                    ]
+                },
+                {
+                    "name": "Green",
+                    "hex": "53A81B",
+                    "codes": [
+                        "ABS2420"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "98948F",
+                    "codes": [
+                        "ABS422"
+                    ]
+                },
+                {
+                    "name": "Sakura Pink",
+                    "hex": "DCA1A9",
+                    "codes": [
+                        "ABS6050"
+                    ]
+                },
+                {
+                    "name": "White",
+                    "hex": "B6B6B6",
+                    "codes": [
+                        "ABS9003"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "212121",
+                    "codes": [
+                        "ABS419"
+                    ]
+                },
+                {
+                    "name": "Orange",
+                    "hex": "F96B38",
+                    "codes": [
+                        "ABS021"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "142C8A",
+                    "codes": [
+                        "ABS2145"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Matte {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                35,
+                55
+            ],
+            "colors": [
+                {
+                    "name": "Ivory",
+                    "hex": "BCBBB0",
+                    "codes": [
+                        "MT9003"
+                    ]
+                },
+                {
+                    "name": "Rose Quartz",
+                    "hex": "BE988B",
+                    "codes": [
+                        "MT1404"
+                    ]
+                },
+                {
+                    "name": "Pudding Yellow",
+                    "hex": "E5CE79",
+                    "codes": [
+                        "MT2001"
+                    ]
+                },
+                {
+                    "name": "Latte",
+                    "hex": "AB845A",
+                    "codes": [
+                        "MT2317"
+                    ]
+                },
+                {
+                    "name": "Robin's Egg Blue",
+                    "hex": "62AFA1",
+                    "codes": [
+                        "MT319"
+                    ]
+                },
+                {
+                    "name": "Skin",
+                    "hex": "DFC19F",
+                    "codes": [
+                        "MT4030"
+                    ]
+                },
+                {
+                    "name": "Hazy Blue",
+                    "hex": "667582",
+                    "codes": [
+                        "MT6109"
+                    ]
+                },
+                {
+                    "name": "Matcha Green",
+                    "hex": "A6AC57",
+                    "codes": [
+                        "MT7492"
+                    ]
+                },
+                {
+                    "name": "Black",
+                    "hex": "222222",
+                    "codes": [
+                        "MT419"
+                    ]
+                },
+                {
+                    "name": "Sakura Pink",
+                    "hex": "E3B4C4",
+                    "codes": [
+                        "MT6050"
+                    ]
+                },
+                {
+                    "name": "Misty Lilac",
+                    "hex": "C1AAC8",
+                    "codes": [
+                        "MT256"
+                    ]
+                }
+            ],
+            "finish": "matte"
+        },
+        {
+            "name": "Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                35,
+                55
+            ],
+            "colors": [
+                {
+                    "name": "Sunshine Gold",
+                    "hex": "FEB101",
+                    "codes": [
+                        "AS123"
+                    ]
+                },
+                {
+                    "name": "Gold",
+                    "hex": "876304",
+                    "codes": [
+                        "AS6006"
+                    ]
+                },
+                {
+                    "name": "Blue",
+                    "hex": "013F96",
+                    "codes": [
+                        "AS2145"
+                    ]
+                },
+                {
+                    "name": "Red",
+                    "hex": "B41C10",
+                    "codes": [
+                        "AS199"
+                    ]
+                },
+                {
+                    "name": "Silver",
+                    "hex": "76757A",
+                    "codes": [
+                        "AS422"
+                    ]
+                },
+                {
+                    "name": "Pearl White",
+                    "hex": "DDD9CE",
+                    "codes": [
+                        "AS9003"
+                    ]
+                },
+                {
+                    "name": "Rose",
+                    "hex": "C42057",
+                    "codes": [
+                        "AS205"
+                    ]
+                },
+                {
+                    "name": "Xmas Green",
+                    "hex": "017523",
+                    "codes": [
+                        "AS347"
+                    ]
+                },
+                {
+                    "name": "Midnight Black",
+                    "hex": "363636",
+                    "codes": [
+                        "AS419"
+                    ]
+                },
+                {
+                    "name": "Copper",
+                    "hex": "874E2D",
+                    "codes": [
+                        "AS471"
+                    ]
+                },
+                {
+                    "name": "Coral Pink",
+                    "hex": "FF8A8B",
+                    "codes": [
+                        "AS1775"
+                    ]
+                },
+                {
+                    "name": "Crimson",
+                    "hex": "871114",
+                    "codes": [
+                        "AS1807"
+                    ]
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800D64",
+                    "codes": [
+                        "AS2602"
+                    ]
+                },
+                {
+                    "name": "Brown Copper",
+                    "hex": "85400F",
+                    "codes": [
+                        "AS4013"
+                    ]
+                },
+                {
+                    "name": "Robin's Egg Blue",
+                    "hex": "7CC9B7",
+                    "codes": [
+                        "AS319"
+                    ]
+                },
+                {
+                    "name": "Bronze",
+                    "hex": "7F7E49",
+                    "codes": [
+                        "AS5767"
+                    ]
+                },
+                {
+                    "name": "Taro Purple",
+                    "hex": "D3BCD6",
+                    "codes": [
+                        "AS256"
+                    ]
+                }
+            ],
+            "finish": "glossy"
+        }
+    ]
+}

--- a/filaments/californiafilament.json
+++ b/filaments/californiafilament.json
@@ -1,0 +1,387 @@
+{
+  "manufacturer": "California Filament",
+  "filaments": [
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Fluorescent Green",
+          "hex": "01ff07"
+        },
+        {
+          "name": "Fluorescent Orange",
+          "hex": "ffab01"
+        },
+        {
+          "name": "Fluorescent Rose",
+          "hex": "ff5750"
+        },
+        {
+          "name": "Fluorescent Yellow",
+          "hex": "fffc02"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Green Glow",
+          "hex": "459d00"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Olive Green",
+          "hex": "6e705a"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Matte Blue",
+          "hex": "8fb0ce"
+        },
+        {
+          "name": "Matte Red",
+          "hex": "97392c"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "65d8ec"
+        },
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Bronze",
+          "hex": "bda570"
+        },
+        {
+          "name": "Burgundy (limited edition)",
+          "hex": "800020"
+        },
+        {
+          "name": "Candy Red",
+          "hex": "b82d44"
+        },
+        {
+          "name": "Caribbean Blue",
+          "hex": "19b1a8"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "623412"
+        },
+        {
+          "name": "Cloudy White",
+          "hex": "f2f2ed"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Driftwood",
+          "hex": "8b6a4f"
+        },
+        {
+          "name": "Fluorescent Green",
+          "hex": "01ff07"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "093122"
+        },
+        {
+          "name": "Garnet Red (limited edition)",
+          "hex": "82261c"
+        },
+        {
+          "name": "Golden Yellow",
+          "hex": "ffc000"
+        },
+        {
+          "name": "GRASS GREEN",
+          "hex": "7cfc00"
+        },
+        {
+          "name": "Gray",
+          "hex": "656577"
+        },
+        {
+          "name": "Kiwi Green",
+          "hex": "d0ff8a"
+        },
+        {
+          "name": "Lemon",
+          "hex": "ebdc87"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "53d5fd"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "c4c3c5"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "c4d600"
+        },
+        {
+          "name": "Marble",
+          "hex": "c9c7c8"
+        },
+        {
+          "name": "Ochre",
+          "hex": "cc7722"
+        },
+        {
+          "name": "Off White",
+          "hex": "faf9f6"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Outer Space Blue (limited edition)",
+          "hex": "1f4277"
+        },
+        {
+          "name": "Paper White",
+          "hex": "f9fbff"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "bff3f7"
+        },
+        {
+          "name": "Peach",
+          "hex": "f9d3e0"
+        },
+        {
+          "name": "Pink",
+          "hex": "e873a6"
+        },
+        {
+          "name": "Pistachio",
+          "hex": "bcd9ad"
+        },
+        {
+          "name": "Plum",
+          "hex": "1f0e25"
+        },
+        {
+          "name": "Rust",
+          "hex": "c25a3c"
+        },
+        {
+          "name": "Sage",
+          "hex": "91946e"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87cefa"
+        },
+        {
+          "name": "Solid White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Teal",
+          "hex": "0095a9"
+        },
+        {
+          "name": "Translucent teal",
+          "hex": "008080"
+        },
+        {
+          "name": "Violet",
+          "hex": "808080"
+        },
+        {
+          "name": "Wheat",
+          "hex": "f5deb3"
+        },
+        {
+          "name": "Yellow",
+          "hex": "c3d117"
+        },
+        {
+          "name": "Zinc",
+          "hex": "92898a"
+        }
+      ]
+    },
+    {
+      "name": "Pink {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Pink - Purple",
+          "hex": "c58eab"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        271
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Translucent Blue",
+          "hex": "0502c5"
+        },
+        {
+          "name": "Translucent Clear",
+          "hex": "c4c4c4"
+        },
+        {
+          "name": "Translucent Green",
+          "hex": "009a44"
+        },
+        {
+          "name": "Translucent Orange",
+          "hex": "ff911a"
+        },
+        {
+          "name": "Translucent Red",
+          "hex": "ff6a74"
+        },
+        {
+          "name": "Translucent Teal",
+          "hex": "2fbaa9"
+        },
+        {
+          "name": "Translucent Yellow",
+          "hex": "ffeeaa"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/capital3d.json
+++ b/filaments/capital3d.json
@@ -1,0 +1,129 @@
+{
+  "manufacturer": "Capital 3D",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "country_of_origin": "Australia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.32,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        20,
+        60
+      ],
+      "country_of_origin": "Australia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "ccccd0"
+        },
+        {
+          "name": "Leahs Green",
+          "hex": "e5ec8d"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Red",
+          "hex": "f7573b"
+        },
+        {
+          "name": "Silver",
+          "hex": "aaadb7"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "country_of_origin": "Australia",
+      "colors": [
+        {
+          "name": "Black Sparkle",
+          "hex": "524f57",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Burnt Titanium",
+          "hex": "293658",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Nebula",
+          "hex": "8568b5",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    }
+  ]
+}

--- a/filaments/carbon.json
+++ b/filaments/carbon.json
@@ -1,0 +1,230 @@
+{
+  "manufacturer": "Carbon",
+  "filaments": [
+    {
+      "name": "High Speed Cf {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        271
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Food Grade - Blue",
+          "hex": "42b0ff"
+        },
+        {
+          "name": "Food Grade - Gray",
+          "hex": "616161"
+        },
+        {
+          "name": "Food Grade - Semi Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Food Grade - White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Food Safe Green",
+          "hex": "32c759"
+        },
+        {
+          "name": "Purple",
+          "hex": "761858"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Food Grade - White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Food Grade Gray",
+          "hex": "999999"
+        },
+        {
+          "name": "Semi-Transparent Food Grade",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Food Grade - Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Food Grade - Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "007c51"
+        }
+      ]
+    },
+    {
+      "name": "Special {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        36,
+        36
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "e1e8ef"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/cctree.json
+++ b/filaments/cctree.json
@@ -1,0 +1,109 @@
+{
+  "manufacturer": "CCTREE",
+  "filaments": [
+    {
+      "name": "CCTREE PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a1b9a"
+        }
+      ]
+    },
+    {
+      "name": "CCTREE PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/chckx.json
+++ b/filaments/chckx.json
@@ -1,0 +1,634 @@
+{
+  "manufacturer": "CHCKX",
+  "filaments": [
+    {
+      "name": "Crystal {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "8bbdfd"
+        },
+        {
+          "name": "Purple",
+          "hex": "8d8bfd"
+        }
+      ]
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PETG-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Gray",
+          "hex": "b0b0b0"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Matte Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Red and Yellow",
+          "hex": "e70d0d"
+        },
+        {
+          "name": "Yellow-Green",
+          "hex": "e4ef4e"
+        },
+        {
+          "name": "Yellow-Pink",
+          "hex": "f2e76e"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Candy",
+          "hex": "35850a"
+        },
+        {
+          "name": "Candy 2",
+          "hex": "e1aeef"
+        },
+        {
+          "name": "Candy 3",
+          "hex": "5e94c9"
+        }
+      ]
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black, Red, and Orange",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue, Green, and Purple",
+          "hex": "56a6f5"
+        },
+        {
+          "name": "Blue, Green, and Yellow",
+          "hex": "43ea64"
+        },
+        {
+          "name": "Blue, Yellow, and Pink",
+          "hex": "efe362"
+        },
+        {
+          "name": "CHCKX",
+          "hex": "f55193"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Glass Aurora 1",
+          "hex": "aaccee"
+        },
+        {
+          "name": "Glass Blue-Purple",
+          "hex": "8d8bfd"
+        },
+        {
+          "name": "Glass Candy Colors",
+          "hex": "efaeea"
+        },
+        {
+          "name": "Glass Ice Cream",
+          "hex": "e78be9"
+        },
+        {
+          "name": "Glass Macarons",
+          "hex": "b3d4f5"
+        },
+        {
+          "name": "Glass Starry Sea",
+          "hex": "ebefae"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey",
+          "hex": "606060"
+        },
+        {
+          "name": "Matte Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Matte White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Pink",
+          "hex": "d357fe"
+        },
+        {
+          "name": "Red",
+          "hex": "e32400"
+        },
+        {
+          "name": "SKIN Color",
+          "hex": "c3b998"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "248ff9"
+        },
+        {
+          "name": "Brown",
+          "hex": "553d00"
+        },
+        {
+          "name": "Color",
+          "hex": "f3e1e1"
+        },
+        {
+          "name": "Crystal Purple",
+          "hex": "8d8bfd"
+        },
+        {
+          "name": "Flash Blue",
+          "hex": "8bbdfd"
+        },
+        {
+          "name": "Green",
+          "hex": "80ff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "898989"
+        },
+        {
+          "name": "Metallic Coffee Brown",
+          "hex": "503e38"
+        },
+        {
+          "name": "Metallic Orange",
+          "hex": "955d48"
+        },
+        {
+          "name": "Metallic Rose Gold",
+          "hex": "a26872"
+        },
+        {
+          "name": "Metallic Teal (Green Eye)",
+          "hex": "7ba79d"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Orange-Light",
+          "hex": "fba966"
+        },
+        {
+          "name": "Purple",
+          "hex": "61177c"
+        },
+        {
+          "name": "Red",
+          "hex": "fa0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c4c4c4"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Four Seasons of Autumn",
+          "hex": "e8a354"
+        },
+        {
+          "name": "Four Seasons of Spring",
+          "hex": "ff8afb"
+        },
+        {
+          "name": "Four Seasons of Summer",
+          "hex": "79f269"
+        },
+        {
+          "name": "Four Seasons of Winter",
+          "hex": "66aac7"
+        },
+        {
+          "name": "Powder Blue",
+          "hex": "d77af0"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Bamboo Green",
+          "hex": "58b04e"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Energetic Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Gray",
+          "hex": "646b73"
+        },
+        {
+          "name": "Light Yellow",
+          "hex": "eee850"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "Peach Pink",
+          "hex": "fc5073"
+        },
+        {
+          "name": "Pink",
+          "hex": "fd9dba"
+        },
+        {
+          "name": "Purple",
+          "hex": "ab79c7"
+        },
+        {
+          "name": "Silver",
+          "hex": "4c5057"
+        },
+        {
+          "name": "Skin-Color",
+          "hex": "f3e2de"
+        },
+        {
+          "name": "Starry Blue",
+          "hex": "1044bb"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black and Red",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue Green",
+          "hex": "0080ff"
+        },
+        {
+          "name": "Red/Pink/Purple",
+          "hexes": [
+            "ff0000",
+            "808080",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black/Blue/Purple",
+          "hexes": [
+            "000000",
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue, Black, and Purple",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Green/Purple/Copper",
+          "hexes": [
+            "008000",
+            "800080",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Red/Blue/Green",
+          "hexes": [
+            "ff0000",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Gold/Green",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "White/Blue/Green",
+          "hexes": [
+            "808080",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "White/Gold/Green",
+          "hexes": [
+            "808080",
+            "ffd700",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Yellow/Blue/Purple",
+          "hexes": [
+            "ffff00",
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/chitusystems.json
+++ b/filaments/chitusystems.json
@@ -1,0 +1,187 @@
+{
+  "manufacturer": "Chitu Systems",
+  "filaments": [
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue-Putplr",
+          "hex": "6d778e",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Gradient Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Conjure Matte Rainbow",
+          "hex": "80b3e5"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        260
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black Dark Green",
+          "hex": "07310f"
+        },
+        {
+          "name": "Black Gold",
+          "hex": "36370b"
+        },
+        {
+          "name": "Black Purple",
+          "hex": "2a0a33"
+        },
+        {
+          "name": "Black Red",
+          "hex": "3f0d0d"
+        },
+        {
+          "name": "Blue Green",
+          "hex": "43b3ae"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black Blue Purple",
+          "hex": "000000"
+        },
+        {
+          "name": "Green/Gold/Orange",
+          "hexes": [
+            "008000",
+            "ffd700",
+            "32feb5"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Purple Orange Blue",
+          "hex": "d60a23"
+        },
+        {
+          "name": "Red Blue Green",
+          "hex": "ff2b2b"
+        },
+        {
+          "name": "Red Gold Blue",
+          "hex": "d60a23"
+        },
+        {
+          "name": "Red Gold Purple",
+          "hex": "d60a23"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "d60a23"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/clasohlson.json
+++ b/filaments/clasohlson.json
@@ -1,0 +1,471 @@
+{
+  "manufacturer": "Clas Ohlson",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black / 39-1775",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Blue / 39-2659",
+          "hexes": [
+            "0000ff",
+            "415987"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Purple / 39-2660",
+          "hexes": [
+            "800080",
+            "452d85"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Aluminium / 38-9248-1",
+          "hex": "939395"
+        },
+        {
+          "name": "Bronze / 38-9248-2",
+          "hex": "6e6741"
+        },
+        {
+          "name": "Copper / 38-9248-3",
+          "hex": "8d6b4b"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium / 39-2657",
+          "hex": "2f4e6a"
+        },
+        {
+          "name": "Nebula Purple / 39-2658",
+          "hex": "6e64aa"
+        }
+      ]
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Natural / 39-1776",
+          "hex": "e5e5e5"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black / 38-9247-1",
+          "hexes": [
+            "000000",
+            "090203"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / 38-9247-4",
+          "hexes": [
+            "0000ff",
+            "212d85"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green / 38-9247-5",
+          "hexes": [
+            "008000",
+            "9cbd4b"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / 38-9247-3",
+          "hexes": [
+            "ff0000",
+            "b63f23"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "White / 38-9247-2",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black / 39-1777",
+          "hex": "000000"
+        },
+        {
+          "name": "White / 39-1778",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black / 39-1773",
+          "hex": "000000"
+        },
+        {
+          "name": "White / 39-1774",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Gold / 39-1782",
+          "hexes": [
+            "ffd700",
+            "ac9125"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Grey / 39-1779",
+          "hex": "414141"
+        },
+        {
+          "name": "Silver / 39-1780",
+          "hex": "8b8d90"
+        },
+        {
+          "name": "White / 39-1781",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black / 38-7986-1",
+          "hexes": [
+            "000000",
+            "0f0f10"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / 38-7986-4",
+          "hexes": [
+            "0000ff",
+            "385bea"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gray",
+          "hex": "737981"
+        },
+        {
+          "name": "Green / 38-7986-5",
+          "hexes": [
+            "008000",
+            "a5d400"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Nature / 38-7986-10",
+          "hex": "c4ab7b"
+        },
+        {
+          "name": "Orange / 38-7986-9",
+          "hex": "dd8223"
+        },
+        {
+          "name": "Red / 38-7986-3",
+          "hexes": [
+            "ff0000",
+            "c03f2e"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Transparent / 38-7986-7",
+          "hex": "cdc9be"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow / 38-7986-8",
+          "hexes": [
+            "ffff00",
+            "e5dc34"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Wood",
+          "hex": "c7a071"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/cmacaiv.json
+++ b/filaments/cmacaiv.json
@@ -1,0 +1,236 @@
+{
+  "manufacturer": "CMACAIV",
+  "filaments": [
+    {
+      "name": "Color Change Uv {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Color Change White to Purple",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White to Red",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Fantasy/Dreamy",
+          "hex": "808080"
+        },
+        {
+          "name": "minicolor",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Candy Rainbow",
+          "hex": "808080"
+        },
+        {
+          "name": "Multicolor gradient",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow B",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "S-series Silk Blue/Red/Yellow/Green",
+          "hexes": [
+            "808080",
+            "ff0000",
+            "ffff00",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Macaron",
+          "hex": "808080"
+        },
+        {
+          "name": "Multicolor Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Red",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Green",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Kingfisher Rainbow (Blue, Purple, Yellow, Green)",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/coex.json
+++ b/filaments/coex.json
@@ -1,0 +1,161 @@
+{
+  "manufacturer": "COEX",
+  "filaments": [
+    {
+      "name": "COEX PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a1b9a"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    },
+    {
+      "name": "COEX PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        }
+      ]
+    },
+    {
+      "name": "COEX ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        95,
+        110
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/colido.json
+++ b/filaments/colido.json
@@ -1,0 +1,243 @@
+{
+  "manufacturer": "CoLiDo",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        95,
+        95
+      ],
+      "colors": [
+        {
+          "name": "white",
+          "hex": "fffdfd"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "05201b"
+        },
+        {
+          "name": "Blue",
+          "hex": "14b1fd"
+        },
+        {
+          "name": "Brass",
+          "hex": "ffbaad"
+        },
+        {
+          "name": "Gold",
+          "hex": "c4a730"
+        },
+        {
+          "name": "Green",
+          "hex": "38ff8e"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "d47d88"
+        },
+        {
+          "name": "Silver",
+          "hex": "a6e8e6"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "005faf"
+        },
+        {
+          "name": "Gray",
+          "hex": "8b928e"
+        },
+        {
+          "name": "Green",
+          "hex": "61ffc2"
+        },
+        {
+          "name": "Orange",
+          "hex": "ea7c32"
+        },
+        {
+          "name": "Silver",
+          "hex": "9fa2b1"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood",
+          "hex": "decab0"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fcf916"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "c4a730"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "2452ab"
+        },
+        {
+          "name": "Purple",
+          "hex": "9c90c2"
+        },
+        {
+          "name": "Red",
+          "hex": "cf2626"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "04ff00"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/colorfabb.json
+++ b/filaments/colorfabb.json
@@ -1,0 +1,317 @@
+{
+  "manufacturer": "colorFabb",
+  "filaments": [
+    {
+      "name": "PLA/PHA {color_name}",
+      "material": "PLA+PHA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 170,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 350,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Standard Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Standard White",
+          "hex": "f0ebed"
+        },
+        {
+          "name": "Dutch Orange",
+          "hex": "f55905"
+        },
+        {
+          "name": "Blue Lilac",
+          "hex": "7f689e"
+        },
+        {
+          "name": "Mint Turquoise",
+          "hex": "85c3b8"
+        },
+        {
+          "name": "Intense Green",
+          "hex": "9cdb3c"
+        },
+        {
+          "name": "Blue Grey",
+          "hex": "6a7a8a"
+        },
+        {
+          "name": "Shining Silver",
+          "hex": "9b9b9b"
+        },
+        {
+          "name": "Signal Red",
+          "hex": "a51f16"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "2a7ebe"
+        }
+      ]
+    },
+    {
+      "name": "PLA Economy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 2200,
+          "spool_weight": 350,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Economy Black",
+          "hex": "111111"
+        },
+        {
+          "name": "Economy White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Economy Red",
+          "hex": "c91c1c"
+        },
+        {
+          "name": "Economy Silver",
+          "hex": "a3a3a3"
+        }
+      ]
+    },
+    {
+      "name": "PETG Economy {color_name}",
+      "material": "PETG",
+      "density": 1.28,
+      "weights": [
+        {
+          "weight": 2200,
+          "spool_weight": 350,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Economy Black",
+          "hex": "111111"
+        },
+        {
+          "name": "Economy White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Economy Red",
+          "hex": "c91c1c"
+        },
+        {
+          "name": "Economy Silver",
+          "hex": "a3a3a3"
+        },
+        {
+          "name": "Economy Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Economy Grey",
+          "hex": "72777a"
+        }
+      ]
+    },
+    {
+      "name": "nGen {color_name}",
+      "material": "COPE",
+      "density": 1.20,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 170,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        75,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "111111"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "c91c1c"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        },
+        {
+          "name": "Dark Green",
+          "hex": "1c4a24"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6f00"
+        },
+        {
+          "name": "Light Green",
+          "hex": "a0e050"
+        }
+      ]
+    },
+    {
+      "name": "copperFill",
+      "material": "PLA+PHA",
+      "density": 3.90,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 170,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "a87850"
+        }
+      ]
+    },
+    {
+      "name": "bronzeFill",
+      "material": "PLA+PHA",
+      "density": 3.90,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 170,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "bfa58a"
+        }
+      ]
+    },
+    {
+      "name": "brassFill",
+      "material": "PLA+PHA",
+      "density": 3.10,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 170,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brass",
+          "hex": "caa558"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/colorfabb.json
+++ b/filaments/colorfabb.json
@@ -224,7 +224,7 @@
       ]
     },
     {
-      "name": "copperFill",
+      "name": "copperFill {color_name}",
       "material": "PLA+PHA",
       "density": 3.90,
       "weights": [
@@ -254,7 +254,7 @@
       ]
     },
     {
-      "name": "bronzeFill",
+      "name": "bronzeFill {color_name}",
       "material": "PLA+PHA",
       "density": 3.90,
       "weights": [
@@ -284,7 +284,7 @@
       ]
     },
     {
-      "name": "brassFill",
+      "name": "brassFill {color_name}",
       "material": "PLA+PHA",
       "density": 3.10,
       "weights": [

--- a/filaments/colorfil.json
+++ b/filaments/colorfil.json
@@ -1,0 +1,88 @@
+{
+  "manufacturer": "colorfil",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "2a2725"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Bordeux",
+          "hex": "800000"
+        },
+        {
+          "name": "Brown",
+          "hex": "6b3220"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "116600"
+        },
+        {
+          "name": "Green",
+          "hex": "00fe9c"
+        },
+        {
+          "name": "Light Green",
+          "hex": "7cb93e"
+        },
+        {
+          "name": "Natural",
+          "hex": "bec4c2"
+        },
+        {
+          "name": "Orange",
+          "hex": "dc4e23"
+        },
+        {
+          "name": "Pink",
+          "hex": "d77893"
+        },
+        {
+          "name": "Purple",
+          "hex": "7149ab"
+        },
+        {
+          "name": "Red",
+          "hex": "b30900"
+        },
+        {
+          "name": "Transparent / Przeźroczysty",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/comgrow.json
+++ b/filaments/comgrow.json
@@ -1,0 +1,100 @@
+{
+  "manufacturer": "Comgrow",
+  "filaments": [
+    {
+      "name": "Comgrow PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        }
+      ]
+    },
+    {
+      "name": "Comgrow PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/conjure.json
+++ b/filaments/conjure.json
@@ -1,0 +1,466 @@
+{
+  "manufacturer": "Conjure",
+  "filaments": [
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium Green",
+          "hex": "2f5f57"
+        },
+        {
+          "name": "Purple Blue",
+          "hex": "0042aa"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Rainbow 2",
+          "hex": "ffffff"
+        },
+        {
+          "name": "RAINBOW TO GLOW MULTICOLOR",
+          "hex": "5669f5"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Dual Black Red",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "616970"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black / Dark Green",
+          "hexes": [
+            "000000",
+            "006400"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black Red",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue / Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Dual Black Purple",
+          "hex": "000000"
+        },
+        {
+          "name": "Dual Blue Green",
+          "hex": "008cb4"
+        },
+        {
+          "name": "Dual Red Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Gold / Black",
+          "hexes": [
+            "ffd700",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "hotpink/blue",
+          "hexes": [
+            "ad4fd8",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "No. 1",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black Purple Blue",
+          "hex": "000000"
+        },
+        {
+          "name": "Green/Gold/Orange",
+          "hexes": [
+            "008000",
+            "ffd700",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Purple-Orange-Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Blue Green Tri-Color",
+          "hex": "58b7ef"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "0061ff"
+        },
+        {
+          "name": "Red/Gold/Blue",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Gold/Purple",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Rose",
+          "hex": "3d1b00"
+        },
+        {
+          "name": "Walnut",
+          "hex": "6c3f19"
+        },
+        {
+          "name": "White Oak",
+          "hex": "bfa58e"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/cookiecad.json
+++ b/filaments/cookiecad.json
@@ -1,0 +1,106 @@
+{
+  "manufacturer": "Cookiecad",
+  "filaments": [
+    {
+      "name": "Cookiecad PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blueberry Muffin",
+          "hex": "4a6fa5"
+        },
+        {
+          "name": "Strawberry Lemonade",
+          "hex": "f06292"
+        },
+        {
+          "name": "Mint Chip",
+          "hex": "a5d6a7"
+        },
+        {
+          "name": "Lavender",
+          "hex": "b39ddb"
+        },
+        {
+          "name": "Peach",
+          "hex": "ffab91"
+        },
+        {
+          "name": "Butter Yellow",
+          "hex": "fff176"
+        },
+        {
+          "name": "Baby Blue",
+          "hex": "81d4fa"
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "Cookiecad Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "finish": "glossy",
+      "colors": [
+        {
+          "name": "Silk Gold",
+          "hex": "d4a017"
+        },
+        {
+          "name": "Silk Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Silk Rose Gold",
+          "hex": "c9877a"
+        },
+        {
+          "name": "Silk Copper",
+          "hex": "b87333"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/copymaster.json
+++ b/filaments/copymaster.json
@@ -1,0 +1,162 @@
+{
+  "manufacturer": "Copymaster3D",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Polar White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Slime Green",
+          "hex": "32cd32"
+        },
+        {
+          "name": "Slime Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Perfect Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Pretty Pink",
+          "hex": "ffc0cb"
+        },
+        {
+          "name": "Pearl Gold",
+          "hex": "d4af37"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/creality.json
+++ b/filaments/creality.json
@@ -320,6 +320,10 @@
                 {
                     "name": "Blue",
                     "hex": "0000FF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "AAA9A8"
                 }
             ]
         }

--- a/filaments/creator.json
+++ b/filaments/creator.json
@@ -1,0 +1,177 @@
+{
+  "manufacturer": "Creator",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Volcanic Rock Gray",
+          "hex": "6b6965"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Luminous Rainbow",
+          "hex": "ca7e72"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Abyssal Red",
+          "hex": "5d203e"
+        },
+        {
+          "name": "Aurora Purple",
+          "hex": "9052ba"
+        },
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Burnt Titanium",
+          "hex": "6d2463"
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Green",
+          "hex": "75d769"
+        },
+        {
+          "name": "Nebula Purple",
+          "hex": "0f4a9c"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "4e5d27"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "841c15"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "426973"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dreamy Trio",
+          "hex": "e4cda5"
+        },
+        {
+          "name": "Metal Rainbow",
+          "hex": "f8d768"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/creozone.json
+++ b/filaments/creozone.json
@@ -1,0 +1,195 @@
+{
+  "manufacturer": "CREOZONE",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "e58c10"
+        },
+        {
+          "name": "Silver",
+          "hex": "bac0c5"
+        }
+      ]
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG Premium {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0e0d0f"
+        },
+        {
+          "name": "Blue",
+          "hex": "323aaa"
+        },
+        {
+          "name": "Clear",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "51b251"
+        },
+        {
+          "name": "Red",
+          "hex": "c20c20"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f7f500"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Turquoise",
+          "hex": "80e3ea"
+        },
+        {
+          "name": "Violet",
+          "hex": "5830b5"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/d3dsigma.json
+++ b/filaments/d3dsigma.json
@@ -1,0 +1,291 @@
+{
+  "manufacturer": "D3D Sigma",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Economy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Metallic Silver",
+          "hex": "868f98"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        255
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "747474"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "064c7f"
+        },
+        {
+          "name": "Bright Blue",
+          "hex": "4fcaf3"
+        },
+        {
+          "name": "Cyan",
+          "hex": "65e3ec"
+        },
+        {
+          "name": "Transparent",
+          "hex": "f5f2ea"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ecce09"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "f9971f"
+        },
+        {
+          "name": "Gold",
+          "hex": "cf9b34"
+        },
+        {
+          "name": "Silver",
+          "hex": "bababa"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "9fe7f1"
+        },
+        {
+          "name": "Bone White",
+          "hex": "e7e2d2"
+        },
+        {
+          "name": "Bright Green",
+          "hex": "49db14"
+        },
+        {
+          "name": "Cappuccino",
+          "hex": "722b0f"
+        },
+        {
+          "name": "Caterpillar Yellow",
+          "hex": "dbbb1f"
+        },
+        {
+          "name": "Concrete Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Gold",
+          "hex": "e9a326"
+        },
+        {
+          "name": "Lavender Purple",
+          "hex": "a858dc"
+        },
+        {
+          "name": "Light Beige",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "afb8c0"
+        },
+        {
+          "name": "Orange",
+          "hex": "fb7310"
+        },
+        {
+          "name": "Regal Red",
+          "hex": "db4b4e"
+        },
+        {
+          "name": "Silver",
+          "hex": "bebbb6"
+        },
+        {
+          "name": "Strawberry Cream",
+          "hex": "fcc7ca"
+        },
+        {
+          "name": "Teal",
+          "hex": "00ffee"
+        },
+        {
+          "name": "Terracotta",
+          "hex": "e67b5a"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/dasfilament.json
+++ b/filaments/dasfilament.json
@@ -4,10 +4,10 @@
         {
             "name": "{color_name}",
             "material": "PLA",
-            "density": 1.23,
+            "density": 1.24,
             "weights": [
                 {
-                    "weight": 800,
+                    "weight": 1000,
                     "spool_weight": 212
                 }
             ],
@@ -140,10 +140,10 @@
         {
             "name": "{color_name} - Refill",
             "material": "PLA",
-            "density": 1.23,
+            "density": 1.24,
             "weights": [
                 {
-                    "weight": 800,
+                    "weight": 1000,
                     "spool_weight": 0
                 }
             ],
@@ -276,10 +276,10 @@
         {
             "name": "{color_name}",
             "material": "PETG",
-            "density": 1.27,
+            "density": 1.29,
             "weights": [
                 {
-                    "weight": 800,
+                    "weight": 1000,
                     "spool_weight": 250
                 }
             ],
@@ -424,10 +424,10 @@
         {
             "name": "{color_name} - Refill",
             "material": "PETG",
-            "density": 1.27,
+            "density": 1.29,
             "weights": [
                 {
-                    "weight": 800,
+                    "weight": 1000,
                     "spool_weight": 0
                 }
             ],

--- a/filaments/deeplee.json
+++ b/filaments/deeplee.json
@@ -12,9 +12,7 @@
                     "spool_type": "cardboard"
                 }
             ],
-            "diameters": [
-                1.75
-            ],
+            "diameters": [1.75],
             "extruder_temp": 220,
             "bed_temp": 60,
             "colors": [
@@ -82,6 +80,75 @@
                 {
                     "name": "White",
                     "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 140,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Matte Beige",
+                    "hex": "EFD8BE"
+                },
+                {
+                    "name": "Matte Navy Blue",
+                    "hex": "000080"
+                },
+                {
+                    "name": "Matte Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Matte Blue Grey",
+                    "hex": "6699CC"
+                },
+                {
+                    "name": "Matte Gris ardoise",
+                    "hex": "989898"
+                },
+                {
+                    "name": "Matte Ice Blue",
+                    "hex": "84BDF5"
+                },
+                {
+                    "name": "Matte Mint Green",
+                    "hex": "ADEBB3"
+                },
+                {
+                    "name": "Matte Ruby Red",
+                    "hex": "E60000"
+                },
+                {
+                    "name": "Matte Sakura Pink",
+                    "hex": "FFB7C5"
+                },
+                {
+                    "name": "Matte Slate Grey",
+                    "hex": "B0B0B2"
+                },
+                {
+                    "name": "Matte Sunshine Yellow",
+                    "hex": "EBCA49"
+                },
+                {
+                    "name": "Matte Teal Green",
+                    "hex": "00D2D0"
+                },
+                {
+                    "name": "Matte White",
+                    "hex": "F4F4F4"
                 }
             ]
         }

--- a/filaments/dikale.json
+++ b/filaments/dikale.json
@@ -1,0 +1,539 @@
+{
+  "manufacturer": "Dikale",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "a5ff6d"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Luminous Blue",
+          "hex": "009dff"
+        }
+      ]
+    },
+    {
+      "name": "Luminous Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silk Blue + Purple + Black",
+          "hexes": [
+            "00b5fe",
+            "800080",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "707070"
+        },
+        {
+          "name": "Purple",
+          "hex": "d400ff"
+        },
+        {
+          "name": "Translucent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple/Black",
+          "hexes": [
+            "800080",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose Red + Sky Blue + Green",
+          "hexes": [
+            "e047aa",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f0cc33"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "efca00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 339
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black + Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue + Purple + Black",
+          "hexes": [
+            "0000ff",
+            "800080",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Gold + Red + Orange",
+          "hexes": [
+            "ffd700",
+            "ff0000",
+            "f0a820"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold + Silver + Copper",
+          "hexes": [
+            "ffd700",
+            "f3d237"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red + Gold + Purple",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose Red + Sky Blue + Green",
+          "hexes": [
+            "ed118c",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "Sky Blue + Purple + Yellow",
+          "hexes": [
+            "0a9ee8",
+            "800080",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 340
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff1e"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "fafafa"
+        },
+        {
+          "name": "Yellow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green/Blue",
+          "hexes": [
+            "008000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Pink/Sky blue",
+          "hex": "f58ad8"
+        }
+      ]
+    },
+    {
+      "name": "Silk Multi Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silk Rose Red + Sky Blue + Green",
+          "hexes": [
+            "ff0000",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Tri Color Blue Purple Black",
+          "hex": "0078ff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Rose Red+Sky Blue+Green",
+          "hexes": [
+            "0b9de8",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/do3d.json
+++ b/filaments/do3d.json
@@ -1,0 +1,236 @@
+{
+  "manufacturer": "DO3D",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow in the Dark Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black to Orange Gradient",
+          "hex": "000000"
+        },
+        {
+          "name": "Bright Green",
+          "hex": "24ff27"
+        },
+        {
+          "name": "Coffee Gold",
+          "hex": "967265"
+        },
+        {
+          "name": "Copper",
+          "hex": "d67200"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00fbff"
+        },
+        {
+          "name": "Dural Color",
+          "hex": "ffea00"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffb300"
+        },
+        {
+          "name": "Green",
+          "hex": "41cb87"
+        },
+        {
+          "name": "Metallic Silver",
+          "hex": "a8a8a8"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "2a75d3"
+        },
+        {
+          "name": "Shiny ruby red",
+          "hex": "c6322e"
+        },
+        {
+          "name": "Silk Purple",
+          "hex": "ff00ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff66"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        200
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "f7d9bf"
+        },
+        {
+          "name": "black",
+          "hex": "808080"
+        },
+        {
+          "name": "Cyan",
+          "hex": "69cefa"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "5fe31e"
+        },
+        {
+          "name": "Orange",
+          "hex": "f15205"
+        },
+        {
+          "name": "Pink",
+          "hex": "e4a3c3"
+        },
+        {
+          "name": "Purple",
+          "hex": "b46bd6"
+        },
+        {
+          "name": "Rose Red",
+          "hex": "df1970"
+        },
+        {
+          "name": "silk black",
+          "hex": "000000"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "9ddfdb"
+        },
+        {
+          "name": "Yellow",
+          "hex": "e9e02b"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue-Red",
+          "hex": "0a3bff"
+        },
+        {
+          "name": "Dural Silk Blue/White",
+          "hex": "439ef9"
+        },
+        {
+          "name": "Purple-Black",
+          "hex": "b212fd"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "fast change Vi/Re/Or/Ge/Bl",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/dowell3d.json
+++ b/filaments/dowell3d.json
@@ -1,0 +1,209 @@
+{
+  "manufacturer": "DOWELL 3D",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "081016"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "4f4f51"
+        },
+        {
+          "name": "Zinc Yellow",
+          "hex": "f6b10c"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Florescent Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Fluorescent Orange",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Grey",
+          "hex": "6e6e6e"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "c2c2c2"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Taro Purple",
+          "hex": "ba6bff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Milky White",
+          "hex": "e5e9eb"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "7e6ef7"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "2c160c"
+        },
+        {
+          "name": "Gray",
+          "hex": "ababab"
+        },
+        {
+          "name": "Light coffeee",
+          "hex": "b95a50"
+        },
+        {
+          "name": "Light skin",
+          "hex": "eac490"
+        },
+        {
+          "name": "Red",
+          "hex": "df410c"
+        },
+        {
+          "name": "Reddish Brown",
+          "hex": "590303"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "80c4f5"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f4f76e"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/dremc.json
+++ b/filaments/dremc.json
@@ -1,0 +1,405 @@
+{
+  "manufacturer": "DREMC",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        95,
+        95
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Grey",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Natural",
+          "hex": "e5d3bf"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "68d64e"
+        },
+        {
+          "name": "Orange",
+          "hex": "f06829"
+        },
+        {
+          "name": "Purple",
+          "hex": "68d64e"
+        },
+        {
+          "name": "Red",
+          "hex": "d32b2f"
+        },
+        {
+          "name": "Teal",
+          "hex": "2382d7"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f0bd11"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ASA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        290
+      ],
+      "bed_temp_range": [
+        95,
+        95
+      ],
+      "colors": [
+        {
+          "name": "Aegean Blue",
+          "hex": "4b63b4"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Brick Red",
+          "hex": "922737"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a006a"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PET-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        300
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "212226"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Pitch Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "ASA-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Natural",
+          "hex": "f2ede8"
+        },
+        {
+          "name": "Off White",
+          "hex": "f4f4f4"
+        },
+        {
+          "name": "Voron Red",
+          "hex": "e02e2f"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PETG",
+      "density": 1.28,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Metallic Silver",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "PC+ABS {color_name}",
+      "material": "PC+ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        95,
+        95
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.32,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Matte Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Matte Grey",
+          "hex": "deddda"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "9d4f32"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/dremel.json
+++ b/filaments/dremel.json
@@ -1,0 +1,202 @@
+{
+  "manufacturer": "Dremel",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500.0,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 750.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        }
+      ]
+    },
+    {
+      "name": "ECO-ABS {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500.0,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 750.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "Nylon {color_name}",
+      "material": "NYLON",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 750.0,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        300
+      ],
+      "bed_temp_range": [
+        55,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/dudv2.json
+++ b/filaments/dudv2.json
@@ -1,0 +1,198 @@
+{
+  "manufacturer": "DUDV2",
+  "filaments": [
+    {
+      "name": "TPU AMS STTPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "302025"
+        },
+        {
+          "name": "Pink",
+          "hex": "f01950"
+        },
+        {
+          "name": "Purple",
+          "hex": "740067"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG Dual {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        245
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "multi_color_direction": "longitudinal",
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black+Green",
+          "hexes": [
+            "000000",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "ee7e4f"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Desert Bone",
+          "hex": "d1d283"
+        },
+        {
+          "name": "Fast Rainbow",
+          "hex": "027df7"
+        },
+        {
+          "name": "Military Camouflage",
+          "hex": "efe7ae"
+        },
+        {
+          "name": "Swamp Rainbow",
+          "hex": "d5ee59"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "008000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/duramic3d.json
+++ b/filaments/duramic3d.json
@@ -1,0 +1,62 @@
+{
+  "manufacturer": "Duramic 3D",
+  "filaments": [
+    {
+      "name": "Duramic 3D PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 140,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [25, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"},
+        {"name": "Yellow", "hex": "F0F010"}
+      ]
+    },
+    {
+      "name": "Duramic 3D PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 140,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [70, 80],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    }
+  ]
+}

--- a/filaments/eibos.json
+++ b/filaments/eibos.json
@@ -1,0 +1,200 @@
+{
+  "manufacturer": "EIBOS",
+  "filaments": [
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "finish": "matte",
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Cypress",
+          "hex": "0e4e27"
+        },
+        {
+          "name": "Oceana",
+          "hex": "3d5976"
+        },
+        {
+          "name": "Terracotta",
+          "hex": "e1897f"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "finish": "matte",
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "4c4d4d"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Milk White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "finish": "glossy",
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black/Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Blue & Fuchsia",
+          "hexes": [
+            "0000ff",
+            "ff00ff"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Di-chromatic gold & red",
+          "hex": "d4af37"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "finish": "glossy",
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black / Blue / Purple",
+          "hexes": [
+            "000000",
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red+Green+Dark Blue",
+          "hexes": [
+            "ff0000",
+            "008000",
+            "000080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red+Yellow+Blue",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/elegoo.json
+++ b/filaments/elegoo.json
@@ -573,6 +573,53 @@
           "hex": "ffffff"
         }
       ]
+    },
+    {
+      "name": "{color_name}",
+      "material": "TPU-95A",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 175,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 230,
+      "bed_temp": 40,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "b5b7b8"
+        },
+        {
+          "name": "Blue",
+          "hex": "2240af"
+        },
+        {
+          "name": "Red",
+          "hex": "ea140e"
+        },
+        {
+          "name": "Green",
+          "hex": "02e601"
+        },
+        {
+          "name": "Translucent",
+          "hex": "e9e9e7"
+        }
+      ]
     }
   ]
 }

--- a/filaments/ender.json
+++ b/filaments/ender.json
@@ -1,0 +1,281 @@
+{
+  "manufacturer": "Ender",
+  "filaments": [
+    {
+      "name": "Cmyk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Jade Green",
+          "hex": "34d5b5"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Candy Pink",
+          "hex": "ff10f0"
+        },
+        {
+          "name": "Silver",
+          "hex": "7a7c7d"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 1290
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "00b837"
+        },
+        {
+          "name": "Grey",
+          "hex": "8b8f98"
+        },
+        {
+          "name": "Light blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "2366bc"
+        },
+        {
+          "name": "Ender PLA Grey",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Ender PLA Red",
+          "hex": "c80404"
+        },
+        {
+          "name": "Red",
+          "hex": "ee1717"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f4f76e"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "00ff08"
+        },
+        {
+          "name": "Beige",
+          "hex": "ffe4a8"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3ea8f4"
+        },
+        {
+          "name": "Dark Red",
+          "hex": "8b0000"
+        },
+        {
+          "name": "Green",
+          "hex": "aff181"
+        },
+        {
+          "name": "Grey",
+          "hex": "b5bbbf"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "e03c31"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/enotepad.json
+++ b/filaments/enotepad.json
@@ -1,0 +1,353 @@
+{
+  "manufacturer": "Enotepad",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "7f7f7f"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "00f900"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Light grey marble",
+          "hex": "adadad",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Deep Purple",
+          "hex": "8a2ee5"
+        },
+        {
+          "name": "Yellow",
+          "hex": "d9c530"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "3dc26b"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Twinkling Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Bronze",
+          "hex": "5ca382"
+        },
+        {
+          "name": "Light Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "d37944"
+        },
+        {
+          "name": "Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "00f900"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Shiny Multicolor Ye/Gr/Bl/Pu/Re",
+          "hex": "dc9e18"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "545454"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        170,
+        190
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Wood 1",
+          "hex": "967e63"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/envirolaser3d.json
+++ b/filaments/envirolaser3d.json
@@ -1,0 +1,241 @@
+{
+  "manufacturer": "Envirolaser 3D",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "3d3e37"
+        },
+        {
+          "name": "Milk White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Cheese Yellow",
+          "hex": "808080"
+        },
+        {
+          "name": "Graphite",
+          "hex": "808080"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "Matte Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Forest Green",
+          "hex": "122b1f"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Silk Like {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Brick Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Copper",
+          "hex": "808080"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Deep Teal",
+          "hex": "808080"
+        },
+        {
+          "name": "Fog Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Lavender",
+          "hex": "808080"
+        },
+        {
+          "name": "Lemonade",
+          "hex": "808080"
+        },
+        {
+          "name": "Off White",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Pink",
+          "hex": "808080"
+        },
+        {
+          "name": "Raging Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "Silver Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Tri-Colour: Gold Red and Black",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        },
+        {
+          "name": "Wine Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "808080"
+        },
+        {
+          "name": "Youth Red",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/eolasprints.json
+++ b/filaments/eolasprints.json
@@ -1,0 +1,1575 @@
+{
+  "manufacturer": "Eolas Prints",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 900,
+          "spool_weight": 500,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 4500,
+          "spool_weight": 1100,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "ABS-PRM-1.75M-BLK-900G",
+            "ABS-PRM-1.75M-BLK-2.2KG",
+            "ABS-PRM-1.75M-BLK-4.5KG"
+          ],
+          "eans": [
+            "8436583684979",
+            "8436583684986",
+            "8436583685143"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00bcd4",
+          "codes": [
+            "ABS-PRM-1.75M-CYN-900G"
+          ],
+          "eans": [
+            "8436583685051"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "ABS-PRM-1.75M-GRY-900G",
+            "ABS-PRM-1.75M-GRY-2.2KG",
+            "ABS-PRM-1.75M-GRY-4.5KG"
+          ],
+          "eans": [
+            "8436583685037",
+            "8436583685044",
+            "8436583685150"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "ABS-PRM-1.75M-RED-900G"
+          ],
+          "eans": [
+            "8436583684993"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "ABS-PRM-1.75M-WHT-900G",
+            "ABS-PRM-1.75M-WHT-2.2KG",
+            "ABS-PRM-1.75M-WHT-4.5KG"
+          ],
+          "eans": [
+            "8436583685006",
+            "8436583685020",
+            "8436583685013"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 900,
+          "spool_weight": 700,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 4500,
+          "spool_weight": 1300,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "ASA-PRM-1.75M-BLK-900G",
+            "ASA-PRM-1.75M-BLK-2.2KG",
+            "ASA-PRM-1.75M-BLK-4.5KG"
+          ],
+          "eans": [
+            "8436583685464",
+            "8436583685518",
+            "8436583685549"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00bcd4",
+          "codes": [
+            "ASA-PRM-1.75M-CYN-900G"
+          ],
+          "eans": [
+            "8436583685495"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "ASA-PRM-1.75M-GRY-900G",
+            "ASA-PRM-1.75M-GRY-2.2KG",
+            "ASA-PRM-1.75M-GRY-4.5KG"
+          ],
+          "eans": [
+            "8436583685471",
+            "8436583685525",
+            "8436583685556"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "ASA-PRM-1.75M-ORG-900G"
+          ],
+          "eans": [
+            "8436583685488"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "ASA-PRM-1.75M-WHT-900G",
+            "ASA-PRM-1.75M-WHT-2.2KG",
+            "ASA-PRM-1.75M-WHT-4.5KG"
+          ],
+          "eans": [
+            "8436583685457",
+            "8436583685501",
+            "8436583685532"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    },
+    {
+      "name": "PETG Transition {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 250,
+          "spool_weight": 350,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Transition",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "PTG-TRN-1.75M-250G",
+            "PTG-TRN-1.75M-1KG"
+          ],
+          "eans": [
+            "8436583683521",
+            "8436583683538"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        245
+      ],
+      "bed_temp_range": [
+        60,
+        90
+      ]
+    },
+    {
+      "name": "PETG UV Resistant {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PTG-UV-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583684931"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PTG-UV-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583684955"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        245
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 700,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PTG-PRM-1.75M-BLK-1KG",
+            "PTG-PRM-1.75M-BLK-2.5KG",
+            "PTG-PRM-1.75M-BLK-5KG"
+          ],
+          "eans": [
+            "8436583683293",
+            "8436583684689",
+            "8436583684764"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00bcd4",
+          "codes": [
+            "PTG-PRM-1.75M-CYN-1KG"
+          ],
+          "eans": [
+            "8436583683408"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PTG-PRM-1.75M-GRN-1KG"
+          ],
+          "eans": [
+            "8436583685372"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "PTG-PRM-1.75M-GRY-1KG",
+            "PTG-PRM-1.75M-GRY-2.5KG",
+            "PTG-PRM-1.75M-GRY-5KG"
+          ],
+          "eans": [
+            "8436583683361",
+            "8436583684702",
+            "8436583684771"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "translucent": true,
+          "codes": [
+            "PTG-PRM-1.75M-NTR-1KG",
+            "PTG-PRM-1.75M-NTR-2.5KG",
+            "PTG-PRM-1.75M-NTR-5KG"
+          ],
+          "eans": [
+            "8436583683385",
+            "8436583684719",
+            "8436583684788"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PTG-PRM-1.75M-RED-1KG"
+          ],
+          "eans": [
+            "8436583683316"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PTG-PRM-1.75M-WHT-1KG",
+            "PTG-PRM-2.85M-WHT-2.5KG",
+            "PTG-PRM-1.75M-WHT-5KG"
+          ],
+          "eans": [
+            "8436583683330",
+            "8436583684696",
+            "8436583683347"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        245
+      ],
+      "bed_temp_range": [
+        60,
+        90
+      ]
+    },
+    {
+      "name": "High Speed PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-HSD-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583685396"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PLA-HSD-1.75M-BLU-1KG"
+          ],
+          "eans": [
+            "8436583685402"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "PLA-HSD-1.75M-GRY-1KG"
+          ],
+          "eans": [
+            "8436583685426"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PLA-HSD-1.75M-RED-1KG"
+          ],
+          "eans": [
+            "8436583685389"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-HSD-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583685419"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Antibacterial {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-ABL-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583685709"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-ABL-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583685716"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Ingeo 850 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-850-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583680001"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "PLA-850-1.75M-GRY-1KG"
+          ],
+          "eans": [
+            "8436583680186"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-850-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583680179"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ]
+    },
+    {
+      "name": "PLA Ingeo 870 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-870-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583680360"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "PLA-870-1.75M-GRY-1KG"
+          ],
+          "eans": [
+            "8436583680384"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-870-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583680377"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "finish": "matte",
+          "codes": [
+            "PLA-PRM-1.75M-BLK-M-1KG"
+          ],
+          "eans": [
+            "8436583684832"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "finish": "matte",
+          "codes": [
+            "PLA-PRM-1.75M-BLU-M-1KG"
+          ],
+          "eans": [
+            "8436583684849"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "finish": "matte",
+          "codes": [
+            "PLA-PRM-1.75M-RED-M-1KG"
+          ],
+          "eans": [
+            "8436583684870"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "finish": "matte",
+          "codes": [
+            "PLA-PRM-1.75M-WHT-M-1KG"
+          ],
+          "eans": [
+            "8436583684856"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00",
+          "finish": "matte",
+          "codes": [
+            "PLA-PRM-1.75M-YLW-M-1KG"
+          ],
+          "eans": [
+            "8436583684863"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA Neon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PLA-NEO-1.75M-GRN-1KG"
+          ],
+          "eans": [
+            "8436583685822"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PLA-NEO-1.75M-ORG-1KG"
+          ],
+          "eans": [
+            "8436583685815"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "PLA-NEO-1.75M-PNK-1KG"
+          ],
+          "eans": [
+            "8436583685839"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00",
+          "codes": [
+            "PLA-NEO-1.75M-YLW-1KG"
+          ],
+          "eans": [
+            "8436583685808"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "cd7f32",
+          "finish": "glossy",
+          "codes": [
+            "PLA-SLK-1.75M-BRZ-1KG"
+          ],
+          "eans": [
+            "8436583685310"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "finish": "glossy",
+          "codes": [
+            "PLA-SLK-1.75M-COP-1KG"
+          ],
+          "eans": [
+            "8436583685327"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "finish": "glossy",
+          "codes": [
+            "PLA-SLK-1.75M-GLD-1KG"
+          ],
+          "eans": [
+            "8436583685297"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "finish": "glossy",
+          "codes": [
+            "PLA-SLK-1.75M-SLV-1KG"
+          ],
+          "eans": [
+            "8436583685303"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA Transition {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Transition",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "PLA-TRN-1.75M-1KG"
+          ],
+          "eans": [
+            "8436583683262"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 700,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "89cff0",
+          "codes": [
+            "PLA-PRM-1.75M-BBL-1KG"
+          ],
+          "eans": [
+            "8436583684290"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "f5f5dc",
+          "codes": [
+            "PLA-PRM-1.75M-BEG-1KG"
+          ],
+          "eans": [
+            "8436583680223"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-PRM-1.75M-BLK-1KG",
+            "PLA-PRM-1.75M-BLK-2.5KG",
+            "PLA-PRM-1.75M-BLK-5KG"
+          ],
+          "eans": [
+            "8436583683217",
+            "8436583683934",
+            "8436583683941"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PLA-PRM-1.75M-BLU-1KG"
+          ],
+          "eans": [
+            "8436583683231"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "eans": [
+            "8436583685853"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00bcd4",
+          "codes": [
+            "PLA-PRM-1.75M-CYN-1KG"
+          ],
+          "eans": [
+            "8436583683989"
+          ]
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "5c4033",
+          "eans": [
+            "8436583685846"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "codes": [
+            "PLA-PRM-1.75M-DGN-1KG"
+          ],
+          "eans": [
+            "8436583684191"
+          ]
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "4a4a4a",
+          "codes": [
+            "PLA-PRM-1.75M-DGR-1KG"
+          ],
+          "eans": [
+            "8436583684092"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PLA-PRM-1.75M-GRN-1KG"
+          ],
+          "eans": [
+            "8436583684177"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "PLA-PRM-1.75M-GRY-1KG",
+            "PLA-PRM-1.75M-GRY-2.5KG",
+            "PLA-PRM-1.75M-GRY-5KG"
+          ],
+          "eans": [
+            "8436583684115",
+            "8436583684122",
+            "8436583684139"
+          ]
+        },
+        {
+          "name": "Light Orange",
+          "hex": "ffb347",
+          "codes": [
+            "PLA-PRM-1.75M-LOG-1KG"
+          ],
+          "eans": [
+            "8436583684238"
+          ]
+        },
+        {
+          "name": "Mint",
+          "hex": "98ff98",
+          "codes": [
+            "PLA-PRM-1.75M-MNT-1KG"
+          ],
+          "eans": [
+            "8436583684023"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "translucent": true,
+          "codes": [
+            "PLA-PRM-1.75M-NTR-1KG",
+            "PLA-PRM-1.75M-NTR-2.5KG",
+            "PLA-PRM-1.75M-NTR-5KG"
+          ],
+          "eans": [
+            "8436583684313",
+            "8436583684320",
+            "8436583684337"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PLA-PRM-1.75M-ORG-1KG"
+          ],
+          "eans": [
+            "8436583683965"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "PLA-PRM-1.75M-PNK-1KG"
+          ],
+          "eans": [
+            "8436583684009"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PLA-PRM-1.75M-RED-1KG"
+          ],
+          "eans": [
+            "8436583684351"
+          ]
+        },
+        {
+          "name": "Skin",
+          "hex": "e8beac",
+          "codes": [
+            "PLA-PRM-1.75M-SKN-1KG"
+          ],
+          "eans": [
+            "8436583685204"
+          ]
+        },
+        {
+          "name": "Straw",
+          "hex": "e4d96f",
+          "codes": [
+            "PLA-PRM-1.75M-STW-1KG"
+          ],
+          "eans": [
+            "8436583684214"
+          ]
+        },
+        {
+          "name": "Turquoise",
+          "hex": "40e0d0",
+          "codes": [
+            "PLA-PRM-1.75M-TQS-1KG"
+          ],
+          "eans": [
+            "8436583684252"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "8a2be2",
+          "codes": [
+            "PLA-PRM-1.75M-VLT-1KG"
+          ],
+          "eans": [
+            "8436583684276"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-PRM-1.75M-WHT-1KG",
+            "PLA-PRM-1.75M-WHT-2.5KG",
+            "PLA-PRM-1.75M-WHT-5KG"
+          ],
+          "eans": [
+            "8436583684054",
+            "8436583684061",
+            "8436583684078"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00",
+          "codes": [
+            "PLA-PRM-1.75M-YLW-1KG"
+          ],
+          "eans": [
+            "8436583684153"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "TPU 93A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "89cff0",
+          "codes": [
+            "TPU-FLX-1.75M-BBL-1KG"
+          ],
+          "eans": [
+            "8436583683712"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "f5f5dc",
+          "codes": [
+            "TPU-FLX-1.75M-BEG-1KG"
+          ],
+          "eans": [
+            "8436583683606"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TPU-FLX-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583683477"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "TPU-FLX-1.75M-BLU-1KG"
+          ],
+          "eans": [
+            "8436583683552"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00bcd4",
+          "codes": [
+            "TPU-FLX-1.75M-CYN-1KG"
+          ],
+          "eans": [
+            "8436583683576"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "codes": [
+            "TPU-FLX-1.75M-DGN-1KG"
+          ],
+          "eans": [
+            "8436583683668"
+          ]
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "4a4a4a",
+          "codes": [
+            "TPU-FLX-1.75M-DGR-1KG"
+          ],
+          "eans": [
+            "8436583683620"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "TPU-FLX-1.75M-GRN-1KG"
+          ],
+          "eans": [
+            "8436583683651"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TPU-FLX-1.75M-GRY-1KG"
+          ],
+          "eans": [
+            "8436583683637"
+          ]
+        },
+        {
+          "name": "Light Orange",
+          "hex": "ffb347",
+          "codes": [
+            "TPU-FLX-1.75M-LOG-1KG"
+          ],
+          "eans": [
+            "8436583683682"
+          ]
+        },
+        {
+          "name": "Mint",
+          "hex": "98ff98",
+          "codes": [
+            "TPU-FLX-1.75M-MNT-1KG"
+          ],
+          "eans": [
+            "8436583683590"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "translucent": true,
+          "codes": [
+            "TPU-FLX-1.75M-NTR-1KG"
+          ],
+          "eans": [
+            "8436583683729"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "TPU-FLX-1.75M-ORG-1KG"
+          ],
+          "eans": [
+            "8436583683569"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "TPU-FLX-1.75M-PNK-1KG"
+          ],
+          "eans": [
+            "8436583683583"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "TPU-FLX-1.75M-RED-1KG"
+          ],
+          "eans": [
+            "8436583683736"
+          ]
+        },
+        {
+          "name": "Straw",
+          "hex": "e4d96f",
+          "codes": [
+            "TPU-FLX-1.75M-STW-1KG"
+          ],
+          "eans": [
+            "8436583683675"
+          ]
+        },
+        {
+          "name": "Turquoise",
+          "hex": "40e0d0",
+          "codes": [
+            "TPU-FLX-1.75M-TQS-1KG"
+          ],
+          "eans": [
+            "8436583683699"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "8a2be2",
+          "codes": [
+            "TPU-FLX-1.75M-VLT-1KG"
+          ],
+          "eans": [
+            "8436583683705"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "TPU-FLX-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583683613"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00",
+          "codes": [
+            "TPU-FLX-1.75M-YLW-1KG"
+          ],
+          "eans": [
+            "8436583683644"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "TPU D53 {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TPU-D53-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583685679"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TPU-D53-1.75M-GRY-1KG"
+          ],
+          "eans": [
+            "8436583685693"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "TPU-D53-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583685747"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "TPU D60 UV Resistant {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TPU-D60-1.75M-BLK-1KG"
+          ],
+          "eans": [
+            "8436583685433"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "TPU-D60-1.75M-WHT-1KG"
+          ],
+          "eans": [
+            "8436583685754"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        225,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "TPU Transition {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 250,
+          "spool_weight": 350,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Transition",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "TPU-TRN-1.75M-250G",
+            "TPU-TRN-1.75M-1KG"
+          ],
+          "eans": [
+            "8436583683491",
+            "8436583683507"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ]
+    }
+  ]
+}

--- a/filaments/eono.json
+++ b/filaments/eono.json
@@ -1,0 +1,689 @@
+{
+  "manufacturer": "eono",
+  "filaments": [
+    {
+      "name": "85A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        250
+      ],
+      "bed_temp_range": [
+        35,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black Colorshift",
+          "hex": "000040"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Purple to Pink",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Glitter Gold-Black",
+          "hex": "000000",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Bright White",
+          "hex": "fafafa"
+        },
+        {
+          "name": "citrine",
+          "hex": "ede939"
+        },
+        {
+          "name": "Green Starry",
+          "hex": "004000"
+        },
+        {
+          "name": "jadeit",
+          "hex": "74d96d"
+        },
+        {
+          "name": "kunzite",
+          "hex": "7269f7"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "d4e3fe"
+        },
+        {
+          "name": "Transparent",
+          "hex": "c5c7c9"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black Blue",
+          "hex": "000000"
+        },
+        {
+          "name": "Black White",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PVB",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Marble White",
+          "hex": "f4f4f4",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Gray",
+          "hex": "68696a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0091e4"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "e8ba3b"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Light blue",
+          "hex": "00ffff"
+        },
+        {
+          "name": "Pink",
+          "hex": "eb97ed"
+        },
+        {
+          "name": "Silk Purple",
+          "hex": "5742ae"
+        },
+        {
+          "name": "Weiss",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0a2989"
+        },
+        {
+          "name": "Grey",
+          "hex": "787878"
+        },
+        {
+          "name": "Silver",
+          "hex": "787878"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PP {color_name}",
+      "material": "PP",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PVB {color_name}",
+      "material": "PVB",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000305"
+        },
+        {
+          "name": "Grey",
+          "hex": "58595a"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Candy Series",
+          "hex": "2effb9"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue&Green&Gold",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Blue/Purple/Yellow",
+          "hexes": [
+            "0000ff",
+            "800080",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green/Purple/Copper",
+          "hexes": [
+            "008000",
+            "800080",
+            "008e00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Gold/Blue",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose Red/Blue/Green",
+          "hexes": [
+            "941100",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Roses red & blue & green",
+          "hex": "b36ef7"
+        },
+        {
+          "name": "‎3-Silk Rot Gold Blau",
+          "hex": "3a88fe"
+        }
+      ]
+    },
+    {
+      "name": "TPU Silk {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "f8ba47"
+        },
+        {
+          "name": "Purple",
+          "hex": "ff00ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black  ⚡Conductive",
+          "hex": "000000"
+        },
+        {
+          "name": "Transparent",
+          "hex": "c5c7c9"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/epax.json
+++ b/filaments/epax.json
@@ -1,0 +1,762 @@
+{
+  "manufacturer": "EPAX",
+  "filaments": [
+    {
+      "name": "Fast PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 315,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "EPAX-FPLA175B1"
+          ]
+        },
+        {
+          "name": "Cool White",
+          "hex": "f0f4f8",
+          "codes": [
+            "EPAX-FPLA175CW1"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "EPAX-FPLA175OR1"
+          ]
+        },
+        {
+          "name": "Candy Red",
+          "hex": "e32636",
+          "codes": [
+            "EPAX-FPLA175CANDYRED1"
+          ]
+        },
+        {
+          "name": "Fire Engine Red",
+          "hex": "ce2029",
+          "codes": [
+            "EPAX-FPLA175FER1"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "EPAX-FPLA175GREY1"
+          ]
+        },
+        {
+          "name": "Warm White",
+          "hex": "f5f0e1",
+          "codes": [
+            "EPAX-FPLA175WW1"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "4b5320",
+          "codes": [
+            "EPAX-FPLA175MG1"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "EPAX-FPLA175BLUE1"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "EPAX-FPLA175PPL1"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00bcd4",
+          "codes": [
+            "EPAX-FPLA175CYAN1"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00",
+          "codes": [
+            "EPAX-FPLA175Y1"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff1493",
+          "codes": [
+            "EPAX-FPLA175M1"
+          ]
+        },
+        {
+          "name": "Pine Green",
+          "hex": "01796f",
+          "codes": [
+            "EPAX-FPLA175PG1"
+          ]
+        },
+        {
+          "name": "Natural Translucent",
+          "hex": "e8dcc8",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPLA175NATURAL1"
+          ]
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPLA175CLEAR1"
+          ]
+        },
+        {
+          "name": "Neutral White",
+          "hex": "fafafa",
+          "codes": [
+            "EPAX-FPLA175NW1"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000080",
+          "codes": [
+            "EPAX-FPLA175NAVYBLUE1"
+          ]
+        },
+        {
+          "name": "Dark Chocolate Brown",
+          "hex": "3d2314",
+          "codes": [
+            "EPAX-FPLA175DARKCHOC1"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "a67c52",
+          "codes": [
+            "EPAX-FPLA175LIGHTBROWN1"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "EPAX-FPLA175PINK1"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "EPAX-FPLA175LIGHTBLUE1"
+          ]
+        },
+        {
+          "name": "Nebula Purple",
+          "hex": "4b0082",
+          "pattern": "sparkle",
+          "codes": [
+            "EPAX-FPLA175NEBULAPURPLE1"
+          ]
+        },
+        {
+          "name": "Deep Space",
+          "hex": "1a1a2e",
+          "pattern": "sparkle",
+          "codes": [
+            "EPAX-FPLA175DEEPSPACE1"
+          ]
+        },
+        {
+          "name": "Purple Peony",
+          "hex": "9b59b6",
+          "pattern": "sparkle",
+          "codes": [
+            "EPAX-FPLA175PURPLEPEONY1"
+          ]
+        },
+        {
+          "name": "Solar Flare",
+          "hex": "ff4500",
+          "pattern": "sparkle",
+          "codes": [
+            "EPAX-FPLA175SOLARFLARE1"
+          ]
+        },
+        {
+          "name": "Cosmic Plum",
+          "hex": "6a0dad",
+          "pattern": "sparkle",
+          "codes": [
+            "EPAX-FPLA175COSMICPLUM1"
+          ]
+        },
+        {
+          "name": "Candy Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "EPAX-FPLA175CANDYRAINBOW1"
+          ]
+        },
+        {
+          "name": "Luminous Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "glow": true,
+          "codes": [
+            "EPAX-FPLA175LUMIRAINBOW1"
+          ]
+        },
+        {
+          "name": "Marble",
+          "hex": "f5f5f0",
+          "pattern": "marble",
+          "codes": [
+            "EPAX-FPLA175MARBLE1"
+          ]
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "39ff14",
+          "glow": true,
+          "codes": [
+            "EPAX-FPLA175LUMIGREEN1"
+          ]
+        },
+        {
+          "name": "Matte Black",
+          "hex": "1a1a1a",
+          "finish": "matte",
+          "codes": [
+            "EPAX-FPLA175MATTEBLACK1"
+          ]
+        },
+        {
+          "name": "Pastel Mint",
+          "hex": "98ff98",
+          "codes": [
+            "EPAX-FPLA175PASTELMINT1"
+          ]
+        },
+        {
+          "name": "Glass Light Blue",
+          "hex": "87cefa",
+          "translucent": true
+        },
+        {
+          "name": "Glass Green",
+          "hex": "90ee90",
+          "translucent": true
+        },
+        {
+          "name": "Apricot",
+          "hex": "fbceb1"
+        },
+        {
+          "name": "Bone",
+          "hex": "e3dac9"
+        },
+        {
+          "name": "Glass Red",
+          "hex": "ff6b6b",
+          "translucent": true
+        },
+        {
+          "name": "Glass Purple",
+          "hex": "ba55d3",
+          "translucent": true
+        },
+        {
+          "name": "Glass Yellow",
+          "hex": "ffef96",
+          "translucent": true
+        },
+        {
+          "name": "Glass Blue",
+          "hex": "4169e1",
+          "translucent": true
+        },
+        {
+          "name": "Glass Orange",
+          "hex": "ff9f40",
+          "translucent": true
+        },
+        {
+          "name": "Lavender",
+          "hex": "e6e6fa"
+        },
+        {
+          "name": "Pale Yellow",
+          "hex": "fffacd"
+        },
+        {
+          "name": "Pastel Orange",
+          "hex": "ffcc99"
+        },
+        {
+          "name": "Matcha Green",
+          "hex": "8fbc8f"
+        }
+      ]
+    },
+    {
+      "name": "Magic Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 315,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Mermaid",
+          "hexes": [
+            "0000ff",
+            "800080",
+            "32cd32"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-MERMAID"
+          ]
+        },
+        {
+          "name": "Peacock",
+          "hexes": [
+            "800000",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-PEACOCK"
+          ]
+        },
+        {
+          "name": "Patina",
+          "hexes": [
+            "008000",
+            "800080",
+            "b87333"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-PATINA"
+          ]
+        },
+        {
+          "name": "Prism",
+          "hexes": [
+            "ffc0cb",
+            "0000ff",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-PRISM"
+          ]
+        },
+        {
+          "name": "Bayou",
+          "hexes": [
+            "0000ff",
+            "008000",
+            "b76e79"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-BAYOU"
+          ]
+        },
+        {
+          "name": "Treasure",
+          "hexes": [
+            "ffd700",
+            "c0c0c0",
+            "b87333"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-TREASURE"
+          ]
+        },
+        {
+          "name": "Royal Harvest",
+          "hexes": [
+            "ffd700",
+            "b87333",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy"
+        },
+        {
+          "name": "Mystic Forest",
+          "hexes": [
+            "0000ff",
+            "008000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy"
+        },
+        {
+          "name": "Techno",
+          "hexes": [
+            "ff00ff",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-TECHNO"
+          ]
+        },
+        {
+          "name": "Coral Sunrise",
+          "hexes": [
+            "f88379",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy"
+        },
+        {
+          "name": "Blue Lagoon",
+          "hexes": [
+            "00ffff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy"
+        },
+        {
+          "name": "Tarnished Copper",
+          "hexes": [
+            "2a3439",
+            "b87333"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-TARNISHED"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-GOLD"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "finish": "glossy",
+          "codes": [
+            "EPAX-MAGIC175-SILVER"
+          ]
+        },
+        {
+          "name": "Regal Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Fast PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 315,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Solid Black",
+          "hex": "000000",
+          "codes": [
+            "EPAX-FPETG175BLK1"
+          ]
+        },
+        {
+          "name": "Solid White",
+          "hex": "ffffff",
+          "codes": [
+            "EPAX-FPETG175WHITE1"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00",
+          "codes": [
+            "EPAX-FPETG175YELLOW1"
+          ]
+        },
+        {
+          "name": "Glass Red-Orange",
+          "hex": "ff4500",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPETG175GLASSRED1"
+          ]
+        },
+        {
+          "name": "Glass Blue",
+          "hex": "4169e1",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPETG175GLASSBLUE1"
+          ]
+        },
+        {
+          "name": "Glass Light Blue",
+          "hex": "87cefa",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPETG175GLASSLIGHTBLUE1"
+          ]
+        },
+        {
+          "name": "Glass Green",
+          "hex": "90ee90",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPETG175GLASSGREEN1"
+          ]
+        },
+        {
+          "name": "Glass Gray",
+          "hex": "a9a9a9",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPETG175GLASSGREY1"
+          ]
+        },
+        {
+          "name": "Glass Purple",
+          "hex": "ba55d3",
+          "translucent": true,
+          "codes": [
+            "EPAX-FPETG175GLASSPURPLE1"
+          ]
+        },
+        {
+          "name": "Glass Orange",
+          "hex": "ff9f40",
+          "translucent": true
+        },
+        {
+          "name": "Glass Ruby Red",
+          "hex": "e0115f",
+          "translucent": true
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff",
+          "translucent": true
+        },
+        {
+          "name": "Deep Space",
+          "hex": "1a1a2e",
+          "codes": [
+            "EPAX-FPETG175DEEPSPACE1"
+          ]
+        },
+        {
+          "name": "Nebula Purple",
+          "hex": "4b0082",
+          "codes": [
+            "EPAX-FPETG175NEBULAPURPLE1"
+          ]
+        },
+        {
+          "name": "Metallic Purple",
+          "hex": "6a0dad"
+        },
+        {
+          "name": "Metallic Gray",
+          "hex": "708090"
+        },
+        {
+          "name": "Metallic Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Metallic Blue",
+          "hex": "1e90ff"
+        },
+        {
+          "name": "Metallic Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Metallic Green",
+          "hex": "2e8b57"
+        },
+        {
+          "name": "Metallic Red",
+          "hex": "dc143c"
+        },
+        {
+          "name": "Mulberry Sparkle",
+          "hex": "70193d",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Blueberry Sparkle",
+          "hex": "4f86f7",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "ccff00"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "39ff14"
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ff6700"
+        },
+        {
+          "name": "Crystal Candy Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "translucent": true
+        },
+        {
+          "name": "Crystal Sugarplum",
+          "hex": "9b59b6",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "PETG-CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 315,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    }
+  ]
+}

--- a/filaments/epelay.json
+++ b/filaments/epelay.json
@@ -1,0 +1,184 @@
+{
+  "manufacturer": "Epelay",
+  "filaments": [
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "313b47"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blood Crimson",
+          "hex": "800000"
+        },
+        {
+          "name": "Cocoa Brown",
+          "hex": "745b4b"
+        },
+        {
+          "name": "Lake Blue",
+          "hex": "0ad2f5"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Purple",
+          "hex": "e392fe"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "5596e2"
+        },
+        {
+          "name": "Green",
+          "hex": "4bd156"
+        },
+        {
+          "name": "Purple",
+          "hex": "9d0ca7"
+        },
+        {
+          "name": "Red",
+          "hex": "e1093f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9f765"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Deep Blue&Green",
+          "hex": "072a6c"
+        },
+        {
+          "name": "Deep Blue&Purple",
+          "hex": "072a6c"
+        },
+        {
+          "name": "Gold&Red",
+          "hex": "ffd700"
+        },
+        {
+          "name": "green&rose red",
+          "hex": "c21e56"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/eryone.json
+++ b/filaments/eryone.json
@@ -8,7 +8,8 @@
             "weights": [
                 {
                     "weight": 1000.0,
-                    "spool_weight": 187.0
+                    "spool_weight": 187.0,
+                    "spool_type": "cardboard"
                 }
             ],
             "diameters": [
@@ -107,6 +108,28 @@
                     "hex": "80817F"
                 }
                
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 500.0,
+                    "spool_weight": 130.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
             ]
         }
     ]

--- a/filaments/esun.json
+++ b/filaments/esun.json
@@ -137,6 +137,11 @@
                     "weight": 1000,
                     "spool_weight": 170,
                     "spool_type": "cardboard"
+                },
+                {
+                    "weight": 3000,
+                    "spool_weight": 630,
+                    "spool_type": "plastic"
                 }
             ],
             "diameters": [
@@ -354,7 +359,7 @@
                     "hex": "ebcfa7"
                 }
             ]
-        },        
+        },
         {
             "name": "ePLA+HS {color_name}",
             "material": "PLA+",
@@ -690,6 +695,97 @@
                 }
             ]
         },
+    {
+        "name": "PLA-Matte Dual Color {color_name}",
+        "material": "PLA",
+        "density": 1.174,
+        "weights": [
+            {
+                "weight": 1000,
+                "spool_weight": 170,
+                "spool_type": "cardboard"
+            }
+        ],
+        "diameters": [
+            1.75
+        ],
+        "extruder_temp": 220,
+        "bed_temp": 60,
+        "colors": [
+            {
+                "name": "GREEN PINK",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "7dd274",
+                    "d556bd"
+                ]
+            },
+            {
+                "name": "BLUE GREEN",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "2c4772",
+                    "79b9a1"
+                ]
+            },
+            {
+                "name": "BLACK RED",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "3d3d3f",
+                    "ec4235"
+                ]
+            },
+            {
+                "name": "BLACK WHITE",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "292a2c",
+                    "dadae2"
+                ]
+            },
+            {
+                "name": "BLUE PURPLE",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "5f71f1",
+                    "c683d0"
+                ]
+            },
+            {
+                "name": "GREEN PURPLE",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "81da7e",
+                    "423270"
+                ]
+            },
+            {
+                "name": "PURPLE YELLOW",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "8d57d1",
+                    "ffcc23"
+                ]
+            },
+            {
+                "name": "RED BLUE",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "b93c44",
+                    "526be2"
+                ]
+            },
+            {
+                "name": "RED YELLOW",
+                "multi_color_direction": "coaxial",
+                "hexes": [
+                    "f9634a",
+                    "fe8f64"
+                ]
+            }
+        ]
+    },
      {
             "name": "PLA-Matte {color_name}",
             "material": "PLA",
@@ -873,6 +969,43 @@
                 {
                     "name": "Luminous Blue",
                     "hex": "2c95cc"
+                }
+            ]
+        },
+        {
+            "name": "PETG-Basic {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "extruder_temp": 260,
+            "extruder_temp_range": [
+                250,
+                265
+            ],
+            "bed_temp": 70,
+            "bed_temp_range": [
+                65,
+                80
+            ],
+            "fill": null,
+            "finish": null,
+            "multi_color_direction": null,
+            "pattern": null,
+            "translucent": true,
+            "glow": false,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 160,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "colors": [
+                {
+                    "name": "Translucent Orange",
+                    "hex": "ff8126"
                 }
             ]
         },
@@ -1070,7 +1203,7 @@
             "diameters": [
                 1.75
             ],
-            "extruder_temp_rang": [230, 270],
+            "extruder_temp_range": [230, 270],
             "bed_temp_range": [100, 115],
             "colors": [
                 {"name": "Black", "hex": "000000"},
@@ -1145,6 +1278,49 @@
                 {
                     "name": "Change by temp",
                     "hex": "d93325"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG-CF",
+            "density": 1.26,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 220,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 250,
+            "bed_temp": 80,
+            "colors": [
+                {
+                    "name": "Antique Brass",
+                    "hex": "a8918b"
+                },
+                {
+                    "name": "Dark Green",
+                    "hex": "60706f"
+                },
+                {
+                    "name": "Dark Grey",
+                    "hex": "5f6366"
+                },
+                {
+                    "name": "Black",
+                    "hex": "2c2c2a"
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "5c626e"
+                },
+                {
+                    "name": "Black Red",
+                    "hex": "423c3e"
                 }
             ]
         }

--- a/filaments/eumakers.json
+++ b/filaments/eumakers.json
@@ -1,0 +1,1668 @@
+{
+  "manufacturer": "EUMAKERS",
+  "filaments": [
+    {
+      "name": "PA Carbon Fiber {color_name}",
+      "material": "PA-CF",
+      "density": 1.0,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PA_NYLON_CARBON_FIBER_Polymer_DataSheet.pdf",
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PA Glass Fiber {color_name}",
+      "material": "PA-GF",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Translucent White",
+          "translucent": true,
+          "hex": "F2F2F2"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PA_NYLON_GLASS_FIBER_Polymer_DataSheet.pdf",
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "PLA Anti Hydrolysis {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Eco {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Recycled Spool Pair",
+          "hex": "751C1B"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "PLA Fast Prints {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_FAST_PRINTS_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        145,
+        160
+      ],
+      "bed_temp": 60,
+      "bed_temp_range": [
+        60,
+        60
+      ]
+    },
+    {
+      "name": "PLA Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "435AA5"
+        },
+        {
+          "name": "Green",
+          "hex": "6EB52C"
+        },
+        {
+          "name": "Orange",
+          "hex": "FDC600"
+        },
+        {
+          "name": "Pink",
+          "hex": "E71280"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAE900"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Anthracite",
+          "pattern": "sparkle",
+          "hex": "3D3935"
+        },
+        {
+          "name": "Black",
+          "pattern": "sparkle",
+          "hex": "000000"
+        },
+        {
+          "name": "Fog Grey",
+          "pattern": "sparkle",
+          "hex": "A8A9AD"
+        },
+        {
+          "name": "Taupe Grey",
+          "pattern": "sparkle",
+          "hex": "8B8371"
+        },
+        {
+          "name": "Transparent",
+          "translucent": true,
+          "hex": "C8C9C7"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Glossy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "finish": "glossy",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "finish": "glossy",
+          "hex": "174551"
+        },
+        {
+          "name": "Brick Brown",
+          "finish": "glossy",
+          "hex": "BC3617"
+        },
+        {
+          "name": "Green",
+          "finish": "glossy",
+          "hex": "88BD36"
+        },
+        {
+          "name": "Red",
+          "finish": "glossy",
+          "hex": "E63330"
+        },
+        {
+          "name": "Violet",
+          "finish": "glossy",
+          "hex": "A61676"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA High Impact {color_name}",
+      "material": "PLA",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_HIGH_IMPACT_PLA_Polymer_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Iridescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Amber",
+          "hex": "B06D49"
+        },
+        {
+          "name": "Green",
+          "hex": "32824B"
+        },
+        {
+          "name": "Marsala",
+          "hex": "891811"
+        },
+        {
+          "name": "Starry Sky",
+          "hex": "5259A3"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "finish": "matte",
+          "hex": "D3BC8D"
+        },
+        {
+          "name": "Black",
+          "finish": "matte",
+          "hex": "000000"
+        },
+        {
+          "name": "Dark Grey",
+          "finish": "matte",
+          "hex": "3D3935"
+        },
+        {
+          "name": "Grey",
+          "finish": "matte",
+          "hex": "888B8D"
+        },
+        {
+          "name": "Light Grey",
+          "finish": "matte",
+          "hex": "C8C9C7"
+        },
+        {
+          "name": "Smoked Grey",
+          "finish": "matte",
+          "hex": "8C857B"
+        },
+        {
+          "name": "Tin Grey",
+          "finish": "matte",
+          "hex": "717C7D"
+        },
+        {
+          "name": "White",
+          "finish": "matte",
+          "hex": "FFFFFF"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA Metallic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Aluminium",
+          "hex": "E3E3E2"
+        },
+        {
+          "name": "Antique Gold",
+          "hex": "D6B084"
+        },
+        {
+          "name": "Brass",
+          "hex": "B8860B"
+        },
+        {
+          "name": "Bronze",
+          "hex": "C88050"
+        },
+        {
+          "name": "Cor-Ten",
+          "hex": "AA4225"
+        },
+        {
+          "name": "Gold",
+          "hex": "DEC78A"
+        },
+        {
+          "name": "Blue",
+          "hex": "5E829A"
+        },
+        {
+          "name": "Dark Antique Pink",
+          "hex": "A5717E"
+        },
+        {
+          "name": "Green",
+          "hex": "809479"
+        },
+        {
+          "name": "Sand Yellow",
+          "hex": "CCCC99"
+        },
+        {
+          "name": "Silver Gray",
+          "hex": "B1B1B1"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Multicolor Basic",
+          "hexes": [
+            "F6EB61",
+            "EF3340",
+            "0085CA",
+            "00B51A"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Multicolor Fluorescent",
+          "hexes": [
+            "E71280",
+            "FAE900",
+            "FDC600",
+            "6EB52C"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Multicolor Modern",
+          "hexes": [
+            "00BFB3",
+            "FFBF3F",
+            "CE0058",
+            "80276C"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Multicolor Neutral",
+          "hexes": [
+            "FFFFFF",
+            "000000",
+            "888B8D",
+            "D3BC8D"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Multicolor Pastel",
+          "hexes": [
+            "F1EB9C",
+            "FCAFC0",
+            "BBDDE6",
+            "C2E189"
+          ],
+          "multi_color_direction": "coaxial"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "multi_color_direction": "coaxial"
+    },
+    {
+      "name": "PLA Pearl {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Green",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Pink",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Stone {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Ceramic",
+          "hex": "F2EBE0"
+        },
+        {
+          "name": "Concrete",
+          "hex": "DEDAD8"
+        },
+        {
+          "name": "Marble",
+          "pattern": "marble",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Quartz",
+          "hex": "F3D4AD"
+        },
+        {
+          "name": "Travertine",
+          "hex": "F5E0BD"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA Transparent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "translucent": true,
+          "hex": "C8C9C7"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    },
+    {
+      "name": "PLA UV Reactive {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "translucent": true,
+          "glow": true,
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "glow": true
+    },
+    {
+      "name": "PLA Wood {color_name}",
+      "material": "PLA",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Fir Wood",
+          "hex": "CFB27E"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_MSDS_WOOD.pdf",
+      "extruder_temp_range": [
+        130,
+        155
+      ],
+      "extruder_temp": 200,
+      "bed_temp_range": [
+        30,
+        50
+      ],
+      "fill": "wood"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 600,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1100,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1800,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2200,
+          "spool_weight": 600,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 400,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 800,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Acid Green",
+          "hex": "D0DF00"
+        },
+        {
+          "name": "Antique Pink",
+          "hex": "FCAFC0"
+        },
+        {
+          "name": "Aquamarine",
+          "hex": "B9DCD2"
+        },
+        {
+          "name": "Beige",
+          "hex": "D3BC8D"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0085CA"
+        },
+        {
+          "name": "Blue Sugared Almond",
+          "hex": "9BCBEB"
+        },
+        {
+          "name": "Blueberry",
+          "hex": "485CC7"
+        },
+        {
+          "name": "Bordeaux",
+          "hex": "76232F"
+        },
+        {
+          "name": "Brown",
+          "hex": "9E652E"
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "FB637E"
+        },
+        {
+          "name": "Cerulean Blue",
+          "hex": "006272"
+        },
+        {
+          "name": "Champagne",
+          "hex": "FFAE62"
+        },
+        {
+          "name": "Cosmic Violet",
+          "hex": "5F4B8B"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "002A3A"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "623412"
+        },
+        {
+          "name": "Dark Cerulean Blue",
+          "hex": "004F59"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "2C5234"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "3D3935"
+        },
+        {
+          "name": "Dark Orange",
+          "hex": "CF4520"
+        },
+        {
+          "name": "Dark Violet",
+          "hex": "3C1053"
+        },
+        {
+          "name": "Doll Pink",
+          "hex": "E7B78A"
+        },
+        {
+          "name": "Evergreen",
+          "hex": "006F62"
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "CE0058"
+        },
+        {
+          "name": "Green",
+          "hex": "00B51A"
+        },
+        {
+          "name": "Green Fern",
+          "hex": "00AF66"
+        },
+        {
+          "name": "Green Leaf",
+          "hex": "78BE20"
+        },
+        {
+          "name": "Grey",
+          "hex": "888B8D"
+        },
+        {
+          "name": "Indigo",
+          "hex": "1E22AA"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "C8C9C7"
+        },
+        {
+          "name": "Magenta EUMAKERS",
+          "hex": "CE0F69"
+        },
+        {
+          "name": "Milk & Mint",
+          "hex": "80E0A7"
+        },
+        {
+          "name": "Mustard Yellow",
+          "hex": "C5A900"
+        },
+        {
+          "name": "Olive Yellow",
+          "hex": "897A27"
+        },
+        {
+          "name": "Orange",
+          "hex": "FE5000"
+        },
+        {
+          "name": "Orange Brick",
+          "hex": "963821"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "BBDDE6"
+        },
+        {
+          "name": "Pastel Green",
+          "hex": "78D64B"
+        },
+        {
+          "name": "Pastel Orange",
+          "hex": "FDD26E"
+        },
+        {
+          "name": "Petroleum Green",
+          "hex": "829778"
+        },
+        {
+          "name": "Red",
+          "hex": "EF3340"
+        },
+        {
+          "name": "Sage Green",
+          "hex": "719949"
+        },
+        {
+          "name": "Skin Pink",
+          "hex": "D3BBA8"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "69B3E7"
+        },
+        {
+          "name": "Smoked Grey",
+          "hex": "8C857B"
+        },
+        {
+          "name": "Straw Yellow",
+          "hex": "F6EB9C"
+        },
+        {
+          "name": "Tangerine Orange",
+          "hex": "FFBF3F"
+        },
+        {
+          "name": "Teal",
+          "hex": "00BFB3"
+        },
+        {
+          "name": "Tin Grey EUMAKERS",
+          "hex": "717C7D"
+        },
+        {
+          "name": "Violet",
+          "hex": "80276C"
+        },
+        {
+          "name": "Vivid Yellow",
+          "hex": "F6EB61"
+        },
+        {
+          "name": "Water Green",
+          "hex": "C2E189"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Wisteria Purple",
+          "hex": "C1A7E2"
+        },
+        {
+          "name": "Yellow Ochre",
+          "hex": "E4D77E"
+        }
+      ],
+      "country_of_origin": "Italy",
+      "tds_url": "https://www.eumakers.com/pub/media/technical_sheets/EUMAKERS_TDS_PLA_Filament_DataSheet.pdf",
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ]
+    }
+  ]
+}

--- a/filaments/eureka.json
+++ b/filaments/eureka.json
@@ -1,0 +1,447 @@
+{
+  "manufacturer": "Eureka",
+  "filaments": [
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Black",
+          "hex": "000001"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Marble White",
+          "hex": "c7c7c7",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "919191"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "6f5f46"
+        },
+        {
+          "name": "Coral",
+          "hex": "f47171"
+        },
+        {
+          "name": "Gold",
+          "hex": "d3b136"
+        },
+        {
+          "name": "Light Brown",
+          "hex": "855819"
+        },
+        {
+          "name": "Orange",
+          "hex": "f05f0e"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "76c3f9"
+        },
+        {
+          "name": "Pistachio",
+          "hex": "bcd558"
+        },
+        {
+          "name": "Silver",
+          "hex": "595c5d"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Premium {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "007965"
+        },
+        {
+          "name": "Army Green",
+          "hex": "46482e"
+        },
+        {
+          "name": "Bone White",
+          "hex": "d9be94"
+        },
+        {
+          "name": "Bronze",
+          "hex": "6f5f46"
+        },
+        {
+          "name": "CMYK Magenta",
+          "hex": "ff00ff"
+        },
+        {
+          "name": "Cyan",
+          "hex": "78b691"
+        },
+        {
+          "name": "CYMK Cyan",
+          "hex": "3581b8"
+        },
+        {
+          "name": "CYMK Yellow",
+          "hex": "f2c32d"
+        },
+        {
+          "name": "Dark Skin Tone",
+          "hex": "865a48"
+        },
+        {
+          "name": "Ghost White",
+          "hex": "eff1f6"
+        },
+        {
+          "name": "Gold",
+          "hex": "ac6c00"
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "b3223d"
+        },
+        {
+          "name": "Light Skin Tone",
+          "hex": "f3cfbb"
+        },
+        {
+          "name": "Maroon",
+          "hex": "ca1b1b"
+        },
+        {
+          "name": "Medium Skin Tone",
+          "hex": "a39383"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000053"
+        },
+        {
+          "name": "Peacock Blue",
+          "hex": "1b5f7e"
+        },
+        {
+          "name": "Rose Pink",
+          "hex": "c58297"
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "092b9c"
+        },
+        {
+          "name": "Royal Fuchsia",
+          "hex": "ae4479"
+        },
+        {
+          "name": "Violet",
+          "hex": "3d2d63"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Silk",
+          "hex": "2277aa"
+        },
+        {
+          "name": "Copper Silk",
+          "hex": "75584a"
+        },
+        {
+          "name": "Gold Silk",
+          "hex": "bd782b"
+        },
+        {
+          "name": "Purple Silk",
+          "hex": "845d92"
+        },
+        {
+          "name": "Red Silk",
+          "hex": "fc3742"
+        },
+        {
+          "name": "Silver Silk",
+          "hex": "595c5d"
+        },
+        {
+          "name": "White Silk",
+          "hex": "c7c7c7"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000001"
+        },
+        {
+          "name": "Blue",
+          "hex": "3581b8"
+        },
+        {
+          "name": "Brown",
+          "hex": "4c2f1c"
+        },
+        {
+          "name": "Candy Red",
+          "hex": "d44f36"
+        },
+        {
+          "name": "Coral",
+          "hex": "af5847"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "1e563a"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "5a5c5a"
+        },
+        {
+          "name": "Green",
+          "hex": "06632b"
+        },
+        {
+          "name": "Grey",
+          "hex": "787873"
+        },
+        {
+          "name": "Light Brown",
+          "hex": "a98163"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "f1cdc6"
+        },
+        {
+          "name": "Natural White",
+          "hex": "f0e3cf"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff531c"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "91cbdb"
+        },
+        {
+          "name": "Pastel Green",
+          "hex": "5ca265"
+        },
+        {
+          "name": "Pastel Pink",
+          "hex": "db687c"
+        },
+        {
+          "name": "Pastel Purple",
+          "hex": "917faa"
+        },
+        {
+          "name": "Pastel Yellow",
+          "hex": "f3cb5c"
+        },
+        {
+          "name": "Pink",
+          "hex": "df7577"
+        },
+        {
+          "name": "Pistachio",
+          "hex": "91a746"
+        },
+        {
+          "name": "Purple",
+          "hex": "8c76a6"
+        },
+        {
+          "name": "Red",
+          "hex": "ca1b1b"
+        },
+        {
+          "name": "White",
+          "hex": "ddd7c7"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f2c32d"
+        }
+      ]
+    },
+    {
+      "name": "Shimmer {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Pearl White",
+          "hex": "cdcec9"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/f3d.json
+++ b/filaments/f3d.json
@@ -1,0 +1,228 @@
+{
+  "manufacturer": "F3D",
+  "filaments": [
+    {
+      "name": "83A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        245
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Pink",
+          "hex": "f06292"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "8c4a1d"
+        }
+      ]
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Amarelo",
+          "hex": "ffb600"
+        },
+        {
+          "name": "Azul",
+          "hex": "0232a0"
+        },
+        {
+          "name": "Azul Bebê",
+          "hex": "80f2ff"
+        },
+        {
+          "name": "Azul Celeste",
+          "hex": "009bcc"
+        },
+        {
+          "name": "Bordô",
+          "hex": "502a45"
+        },
+        {
+          "name": "Cinza",
+          "hex": "4b4f54"
+        },
+        {
+          "name": "Cobre",
+          "hex": "8b6f4c"
+        },
+        {
+          "name": "Granito",
+          "hex": "9d9e9d"
+        },
+        {
+          "name": "Laranja",
+          "hex": "d8612e"
+        },
+        {
+          "name": "Lilás",
+          "hex": "ae96dc"
+        },
+        {
+          "name": "Marrom",
+          "hex": "796855"
+        },
+        {
+          "name": "NUDE",
+          "hex": "dedcd9"
+        },
+        {
+          "name": "Preto",
+          "hex": "000000"
+        },
+        {
+          "name": "Roxo",
+          "hex": "400186"
+        },
+        {
+          "name": "Verde",
+          "hex": "007c4b"
+        },
+        {
+          "name": "Verde Limão",
+          "hex": "96d702"
+        },
+        {
+          "name": "Verde Menta",
+          "hex": "80ff9c"
+        },
+        {
+          "name": "Verde Militar",
+          "hex": "14391d"
+        },
+        {
+          "name": "Verde Neon",
+          "hex": "6aff46"
+        },
+        {
+          "name": "Vermelho",
+          "hex": "c10c1e"
+        },
+        {
+          "name": "Vermelho Translúcido",
+          "hex": "ff3e3e"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "ff0059"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/factoryfilament.json
+++ b/filaments/factoryfilament.json
@@ -1,0 +1,146 @@
+{
+  "manufacturer": "Factory Filament",
+  "filaments": [
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black & Gold",
+          "hex": "000000"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "0767b0"
+        },
+        {
+          "name": "Silver",
+          "hex": "b8b7b7"
+        },
+        {
+          "name": "Ultra Violet",
+          "hex": "846ec6"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        225
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "a8ccc1"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Clay",
+          "hex": "bd4725"
+        },
+        {
+          "name": "Ice Blue",
+          "hex": "657986"
+        },
+        {
+          "name": "Lemon",
+          "hex": "fbea58"
+        },
+        {
+          "name": "Mint",
+          "hex": "97e5c1"
+        },
+        {
+          "name": "Pale Mauve",
+          "hex": "d9c1bd"
+        },
+        {
+          "name": "Peach",
+          "hex": "f16c4a"
+        },
+        {
+          "name": "Plant Green",
+          "hex": "64ae87"
+        },
+        {
+          "name": "Violet",
+          "hex": "6238c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood",
+          "hex": "dca963"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Infinite Void",
+          "hex": "5b85ae"
+        },
+        {
+          "name": "Wine & Infinite Void",
+          "hex": "6594c3"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ffsunsenkj.json
+++ b/filaments/ffsunsenkj.json
@@ -1,0 +1,252 @@
+{
+  "manufacturer": "FF SUNSENKJ",
+  "filaments": [
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue+Purple",
+          "hexes": [
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Bronze / Rose",
+          "hex": "c17453"
+        },
+        {
+          "name": "Dark Orange / Cyan",
+          "hex": "ac722f"
+        },
+        {
+          "name": "Gold / Green",
+          "hexes": [
+            "ffd700",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green Purple",
+          "hex": "005046"
+        },
+        {
+          "name": "Nebula Purple",
+          "hex": "3d385f"
+        },
+        {
+          "name": "Purple Nebula",
+          "hex": "3022fc"
+        },
+        {
+          "name": "Reddish Brown",
+          "hex": "b64225"
+        },
+        {
+          "name": "Royal Green",
+          "hex": "305a4f"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Red Green Blue",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0017ad"
+        },
+        {
+          "name": "Brown",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Red",
+          "hex": "e22400"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Red",
+          "hex": "0061fe"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold Blue Fuchsia",
+          "hex": "c8af00"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Starlight Purple",
+          "hex": "6c007f",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    }
+  ]
+}

--- a/filaments/fiberlogy.json
+++ b/filaments/fiberlogy.json
@@ -8,7 +8,7 @@
             "weights": [
                 {
                     "weight": 750,
-                    "spool_weight": 290
+                    "spool_weight": 260
                 }
             ],
             "diameters": [

--- a/filaments/fiberthree.json
+++ b/filaments/fiberthree.json
@@ -1,0 +1,180 @@
+{
+  "manufacturer": "FiberThree",
+  "filaments": [
+    {
+      "name": "F3 PA Pure Pro {color_name}",
+      "material": "PA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 407
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        280
+      ],
+      "bed_temp_range": [
+        0,
+        80
+      ],
+      "country_of_origin": "Germany",
+      "tds_url": "https://www.fiberthree.com/downloads/tdb/filaments/TDS_F3_PA_Pure_Pro_English_vers12_2024.pdf",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "F3 PA-CF Pro {color_name}",
+      "material": "PA-CF",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 407
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 361
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        285
+      ],
+      "bed_temp_range": [
+        0,
+        80
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte",
+      "country_of_origin": "Germany",
+      "tds_url": "https://www.fiberthree.com/downloads/tdb/filaments/TDS_F3_PA_CF_Pro_English_vers12_2024.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "F3-7050",
+            "F3-7059"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "F3 PA-GF Pro {color_name}",
+      "material": "PA-GF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 407
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        285
+      ],
+      "bed_temp_range": [
+        0,
+        80
+      ],
+      "fill": "glass fiber",
+      "finish": "matte",
+      "country_of_origin": "Germany",
+      "tds_url": "https://www.fiberthree.com/downloads/tdb/filaments/TDS_F3_PA_GF_Pro_English_vers12_2024.pdf",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "F3 PA-GF30 Pro {color_name}",
+      "material": "PA-GF30",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 407
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 361
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        285
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "fill": "glass fiber",
+      "finish": "matte",
+      "country_of_origin": "Germany",
+      "tds_url": "https://www.fiberthree.com/downloads/tdb/filaments/TDS_F3_PA_GF30_Pro_English_vers8_2024.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "F3-7089",
+            "F3-7090"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "F3 PA-ESD Safe {color_name}",
+      "material": "PA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 407
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        310
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "Germany",
+      "tds_url": "https://www.fiberthree.com/downloads/tdb/filaments/TDS_F3_PA_ESD_English_vers_12_2024.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "F3-PAESD-1KG"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filabees.json
+++ b/filaments/filabees.json
@@ -1,0 +1,324 @@
+{
+  "manufacturer": "FilaBees",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow Candy",
+          "hex": "00c7fc"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Dark Blue",
+          "hex": "131561"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ASA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Transparent Yellow",
+          "hex": "fed874"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "2d2c46"
+        }
+      ]
+    },
+    {
+      "name": "PETG Pro {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "610dfd"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "002e03"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "a7c7e7"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Burn Titanium",
+          "hex": "610dfd"
+        },
+        {
+          "name": "Fusion Blue Green",
+          "hex": "212887"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red Yellow Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marsala",
+          "hex": "591452",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Racing Green",
+          "hex": "046706",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sparkling White",
+          "hex": "ffffff",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    }
+  ]
+}

--- a/filaments/filacube.json
+++ b/filaments/filacube.json
@@ -1,0 +1,274 @@
+{
+  "manufacturer": "FilaCube",
+  "filaments": [
+    {
+      "name": "PLA 2 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 361
+        },
+        {
+          "weight": 2000,
+          "spool_weight": 722
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 629
+        },
+        {
+          "weight": 5000,
+          "spool_weight": 897
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA2-175-Black-1kg",
+            "PLA2-175-Black-2kg",
+            "PLA2-175-Black-3kg",
+            "PLA2-175-Black-5kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "PLA2-175-Brown-1kg"
+          ]
+        },
+        {
+          "name": "Burnt Orange",
+          "hex": "ff6a13",
+          "codes": [
+            "PLA2-175-Burnt-Orange-1kg"
+          ]
+        },
+        {
+          "name": "Classic Blue",
+          "hex": "0f4c81",
+          "codes": [
+            "PLA2-175-ClassicBlue"
+          ]
+        },
+        {
+          "name": "Engineering Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "PLA2-175-Englineering-Gray-1kg",
+            "PLA2-175-Englineering-Gray-2kg",
+            "PLA2-175-Englineering-Gray-3kg",
+            "PLA2-175-Englineering-Gray-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PLA2-175-Gray-1kg",
+            "PLA2-175-Gray-2kg",
+            "PLA2-175-Gray-3kg",
+            "PLA2-175-Gray-5kg"
+          ]
+        },
+        {
+          "name": "Grayish Brown",
+          "hex": "8b7355",
+          "codes": [
+            "PLA2-175-Grayish-Brown"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "008000",
+          "codes": [
+            "PLA2-175-Green-1kg"
+          ]
+        },
+        {
+          "name": "Greenery",
+          "hex": "88b04b",
+          "codes": [
+            "PLA2-175-Greenery-1kg",
+            "PLA2-175-Greenery-2kg",
+            "PLA2-175-Greenery-3kg",
+            "PLA2-175-Greenery-5kg"
+          ]
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "PLA2-175-Hot-Pink"
+          ]
+        },
+        {
+          "name": "Iced Coffee",
+          "hex": "d2b48c",
+          "codes": [
+            "PLA2-175-Iced-Coffee"
+          ]
+        },
+        {
+          "name": "International Harvester Red",
+          "hex": "c8102e",
+          "codes": [
+            "PLA2-175-IHRed"
+          ]
+        },
+        {
+          "name": "Ivory White",
+          "hex": "fffff0",
+          "codes": [
+            "PLA2-175-Ivory-White-1kg"
+          ]
+        },
+        {
+          "name": "John Deere Green",
+          "hex": "367c2b",
+          "codes": [
+            "PLA2-175-JDGreen"
+          ]
+        },
+        {
+          "name": "Leather Brown",
+          "hex": "964b00",
+          "codes": [
+            "PLA2-175-Leather-Brown"
+          ]
+        },
+        {
+          "name": "Living Coral",
+          "hex": "ff6f61",
+          "codes": [
+            "PLA2-175-Living-Coral"
+          ]
+        },
+        {
+          "name": "Maroon",
+          "hex": "800000",
+          "codes": [
+            "PLA2-175-Maroon-1kg"
+          ]
+        },
+        {
+          "name": "Mint Blue",
+          "hex": "7fffd4",
+          "codes": [
+            "PLA2-175-Mint-Blue-1kg"
+          ]
+        },
+        {
+          "name": "Mint Green",
+          "hex": "98fb98",
+          "codes": [
+            "PLA2-175-mint-green"
+          ]
+        },
+        {
+          "name": "Olive Green",
+          "hex": "556b2f",
+          "codes": [
+            "PLA2-175-Olive-Green"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500",
+          "codes": [
+            "PLA2-175-Orange-1kg"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb",
+          "codes": [
+            "PLA2-175-Pink-1kg"
+          ]
+        },
+        {
+          "name": "Process Cyan",
+          "hex": "00b5b8",
+          "codes": [
+            "PLA2-175-Process-Cyan"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "PLA2-175-Purple-1kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PLA2-175-Red-1kg"
+          ]
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "0f52ba"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PLA2-175-Silver-1kg"
+          ]
+        },
+        {
+          "name": "Skin/Flesh",
+          "hex": "e8beac",
+          "codes": [
+            "PLA2-175-Skin"
+          ]
+        },
+        {
+          "name": "Ultra Violet",
+          "hex": "5f4b8b",
+          "codes": [
+            "PLA2-175-Ultra-Violet-1kg",
+            "PLA2-175-Ultra-Violet-2kg",
+            "PLA2-175-Ultra-Violet-3kg",
+            "PLA2-175-Ultra-Violet-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA2-175-White-1kg",
+            "PLA2-175-White-2kg",
+            "PLA2-175-White-3kg",
+            "PLA2-175-White-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "PLA2-175-Yellow-1kg"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filaform.json
+++ b/filaments/filaform.json
@@ -1,0 +1,184 @@
+{
+  "manufacturer": "Filaform",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0042aa"
+        },
+        {
+          "name": "Clear",
+          "hex": "808080"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "669c35"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "Pink",
+          "hex": "f4a4c0"
+        },
+        {
+          "name": "Purple",
+          "hex": "874efe"
+        },
+        {
+          "name": "Red",
+          "hex": "b51a00"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "53d5fd"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue & Fuchsia",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filalab.json
+++ b/filaments/filalab.json
@@ -1,0 +1,302 @@
+{
+  "manufacturer": "Filalab",
+  "filaments": [
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Glitter Green",
+          "hex": "648a95",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "a1a1a1",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PCTG {color_name}",
+      "material": "PCTG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Orange",
+          "hex": "f27c22"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0606"
+        },
+        {
+          "name": "Transparent",
+          "hex": "f4f0ed"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Black",
+          "hex": "232225"
+        },
+        {
+          "name": "Glow In Dark",
+          "hex": "f1f4ee"
+        },
+        {
+          "name": "Green",
+          "hex": "0e9b3e"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "a4d03d"
+        },
+        {
+          "name": "Pink",
+          "hex": "dc53a0"
+        },
+        {
+          "name": "Violet",
+          "hex": "9164e4"
+        },
+        {
+          "name": "yellow",
+          "hex": "f5d400"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "234ca4"
+        },
+        {
+          "name": "Galaxy Blue",
+          "hex": "666faa"
+        },
+        {
+          "name": "Green",
+          "hex": "4a8356"
+        },
+        {
+          "name": "Grey",
+          "hex": "b5b8b1"
+        },
+        {
+          "name": "Orange",
+          "hex": "fe5810"
+        },
+        {
+          "name": "Red",
+          "hex": "d00a1b"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f5ec00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "efd7ae"
+        },
+        {
+          "name": "Brown",
+          "hex": "5f423c"
+        },
+        {
+          "name": "Turquoise Blue",
+          "hex": "4181af"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "583300"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/filamenthub.json
+++ b/filaments/filamenthub.json
@@ -1,0 +1,545 @@
+{
+  "manufacturer": "Filament Hub",
+  "filaments": [
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Burgundy Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Carnation",
+          "hex": "808080"
+        },
+        {
+          "name": "Chameleon - Black",
+          "hex": "022640"
+        },
+        {
+          "name": "Klein Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Leaf Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Nebula Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Polar Star Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Rose",
+          "hex": "808080"
+        },
+        {
+          "name": "Tiffany Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Tulip Yellow",
+          "hex": "808080"
+        },
+        {
+          "name": "Violets Purple",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Economy {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Luminous Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Luminous White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glitter Forest Rainbow",
+          "hex": "064b14"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "63a2cd"
+        }
+      ]
+    },
+    {
+      "name": "Matte Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue / Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Dark Blue / Yellow",
+          "hexes": [
+            "000080",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Dark Purple / Yellow",
+          "hexes": [
+            "7841c1",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Golden Harvest",
+          "hex": "3bc953"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brass",
+          "hex": "b5a642"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG Pro {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dark Blue",
+          "hex": "00357b"
+        },
+        {
+          "name": "Orange",
+          "hex": "bd531b"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "2a2a2a"
+        },
+        {
+          "name": "Dark Forest Green",
+          "hex": "3d5950"
+        },
+        {
+          "name": "Dark Wine Red",
+          "hex": "792c34"
+        },
+        {
+          "name": "Galaxy Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey",
+          "hex": "bcbfbf"
+        },
+        {
+          "name": "Muted Blue",
+          "hex": "556c79"
+        },
+        {
+          "name": "Orange",
+          "hex": "e3996c"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "79b0c8"
+        },
+        {
+          "name": "Pastel Green",
+          "hex": "b1d2c3"
+        },
+        {
+          "name": "Pastel Pink",
+          "hex": "dfafbf"
+        },
+        {
+          "name": "Pastel Purple",
+          "hex": "c2aace"
+        },
+        {
+          "name": "Pastel Yellow",
+          "hex": "d7d692"
+        },
+        {
+          "name": "SKIN",
+          "hex": "f1ccb2"
+        },
+        {
+          "name": "Sunny Yellow",
+          "hex": "e5be47"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Pink",
+          "hex": "ef8dad"
+        },
+        {
+          "name": "Skin",
+          "hex": "f1ccb2"
+        },
+        {
+          "name": "White",
+          "hex": "e1e4e4"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "c76f36"
+        }
+      ]
+    },
+    {
+      "name": "Silk Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Tri - Blue / Red / Green",
+          "hexes": [
+            "0000ff",
+            "ff0000",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Tri - Dark Red / Blue / Green",
+          "hexes": [
+            "8b0000",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Tri - Gold / Copper / Purple",
+          "hexes": [
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filamentive.json
+++ b/filaments/filamentive.json
@@ -1,0 +1,47 @@
+{
+  "manufacturer": "Filamentive",
+  "filaments": [
+    {
+      "name": "rPLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    },
+    {
+      "name": "rPETG {color_name}",
+      "material": "PETG",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [210, 250],
+      "bed_temp_range": [70, 80],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"}
+      ]
+    }
+  ]
+}

--- a/filaments/filamentone.json
+++ b/filaments/filamentone.json
@@ -1,0 +1,387 @@
+{
+  "manufacturer": "FilamentOne",
+  "filaments": [
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Galaxy Cinnamon",
+          "hex": "6a1b01"
+        },
+        {
+          "name": "Galaxy Denim Blue",
+          "hex": "015998"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "9c9c9c",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brass",
+          "hex": "5f510c"
+        },
+        {
+          "name": "Copper",
+          "hex": "7f5e48"
+        }
+      ]
+    },
+    {
+      "name": "PC+ABS {color_name}",
+      "material": "PC+ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        310
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00b3ff"
+        },
+        {
+          "name": "Red Stone",
+          "hex": "e42525"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG+PLUS Pro {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Desert Red",
+          "hex": "782907"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Emerald Pearl",
+          "hex": "6ef790"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "381d0b"
+        },
+        {
+          "name": "Matte Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Premium {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "4ccd4e"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "dc8204"
+        },
+        {
+          "name": "Silk Blue",
+          "hex": "0000a0"
+        },
+        {
+          "name": "Silk Yellow",
+          "hex": "fdf512"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "352517"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "4a4a4a"
+        },
+        {
+          "name": "Off White",
+          "hex": "dedede"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0074c7"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "69eef7"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filamentos3dbrasil.json
+++ b/filaments/filamentos3dbrasil.json
@@ -1,0 +1,127 @@
+{
+  "manufacturer": "Filamentos 3D Brasil",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        250
+      ],
+      "bed_temp_range": [
+        25,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Azul Bebê",
+          "hex": "6abcf6"
+        },
+        {
+          "name": "Branco",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Lilás",
+          "hex": "b680f6"
+        },
+        {
+          "name": "Marrom",
+          "hex": "4b271b"
+        },
+        {
+          "name": "Preto",
+          "hex": "000000"
+        },
+        {
+          "name": "Rosa Claro",
+          "hex": "fd9bff"
+        },
+        {
+          "name": "Transparente",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Verde Água",
+          "hex": "5eeef6"
+        }
+      ],
+      "country_of_origin": "Brazil"
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Granito",
+          "hex": "d7d7d7",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble",
+      "country_of_origin": "Brazil"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Cinza",
+          "hex": "898989"
+        },
+        {
+          "name": "Natural (Transparente)",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Preto",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "Brazil"
+    }
+  ]
+}

--- a/filaments/filamentpm.json
+++ b/filaments/filamentpm.json
@@ -1,0 +1,62 @@
+{
+  "manufacturer": "Filament PM",
+  "filaments": [
+    {
+      "name": "PM PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 380,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2000,
+          "spool_weight": 600,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [200, 220],
+      "bed_temp_range": [50, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"},
+        {"name": "Silver", "hex": "C0C0C0"}
+      ]
+    },
+    {
+      "name": "PM PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 216,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2000,
+          "spool_weight": 500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 250],
+      "bed_temp_range": [80, 90],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    }
+  ]
+}

--- a/filaments/filamentree.json
+++ b/filaments/filamentree.json
@@ -1,0 +1,721 @@
+{
+  "manufacturer": "Filamentree",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Anthracite Grey",
+          "hex": "383838",
+          "codes": [
+            "30410451",
+            "30410541"
+          ]
+        },
+        {
+          "name": "Blue Lagoon",
+          "hex": "00bfff",
+          "codes": [
+            "30410251"
+          ]
+        },
+        {
+          "name": "Bright Red",
+          "hex": "ff0000",
+          "codes": [
+            "30410361"
+          ]
+        },
+        {
+          "name": "Flame Red T",
+          "hex": "ff4500",
+          "translucent": true,
+          "codes": [
+            "30410261"
+          ]
+        },
+        {
+          "name": "Heather Violet",
+          "hex": "9b59b6",
+          "codes": [
+            "30410411"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "30410021",
+            "30450021"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "90ee90",
+          "codes": [
+            "30410231"
+          ]
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "39ff14",
+          "glow": true,
+          "codes": [
+            "30410311"
+          ]
+        },
+        {
+          "name": "Luminous Red",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "30410281"
+          ]
+        },
+        {
+          "name": "Luminous Yellow",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "30410391"
+          ]
+        },
+        {
+          "name": "Mint Green",
+          "hex": "98ff98",
+          "codes": [
+            "30410321"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "30410101"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500",
+          "codes": [
+            "30410111"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "30410031"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "30410271"
+          ]
+        },
+        {
+          "name": "Sky Blue T",
+          "hex": "87cefa",
+          "translucent": true,
+          "codes": [
+            "30410331"
+          ]
+        },
+        {
+          "name": "Turquoise Green Transparent",
+          "hex": "40e0d0",
+          "translucent": true,
+          "codes": [
+            "30410291"
+          ]
+        },
+        {
+          "name": "Violet Glass",
+          "hex": "8a2be2",
+          "translucent": true,
+          "codes": [
+            "30410091"
+          ]
+        },
+        {
+          "name": "Water Blue",
+          "hex": "0077be",
+          "codes": [
+            "30410341"
+          ]
+        },
+        {
+          "name": "Window Grey",
+          "hex": "808080",
+          "codes": [
+            "30410011"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "30410241"
+          ]
+        },
+        {
+          "name": "Zinc Yellow",
+          "hex": "f4c430",
+          "codes": [
+            "30410401"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Matt-5 {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "30410551"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "30410581"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG Matt-7 {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "30410571"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "30410591"
+          ]
+        },
+        {
+          "name": "Signal Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "30410561"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG-CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        65,
+        80
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "30610461"
+          ]
+        }
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte"
+    },
+    {
+      "name": "PLA Blaster {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "30310021"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "30310101"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "30310031",
+            "30350031"
+          ]
+        },
+        {
+          "name": "Window Grey",
+          "hex": "808080",
+          "codes": [
+            "30307011",
+            "30310011"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Plus {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "89cff0",
+          "codes": [
+            "30110131"
+          ]
+        },
+        {
+          "name": "Broom Yellow",
+          "hex": "e3a857",
+          "codes": [
+            "30110521"
+          ]
+        },
+        {
+          "name": "Candy Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "30110611"
+          ]
+        },
+        {
+          "name": "Grey Beige",
+          "hex": "c5b9a8",
+          "codes": [
+            "30110171"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "30110021"
+          ]
+        },
+        {
+          "name": "Lemonade",
+          "hex": "fffacd",
+          "codes": [
+            "30110621"
+          ]
+        },
+        {
+          "name": "Light Pink",
+          "hex": "ffb6c1",
+          "codes": [
+            "30110181"
+          ]
+        },
+        {
+          "name": "Lilac Snow",
+          "hex": "e6e6fa",
+          "codes": [
+            "30110631"
+          ]
+        },
+        {
+          "name": "Lime Cream",
+          "hex": "dfff00",
+          "codes": [
+            "30110641"
+          ]
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "39ff14",
+          "glow": true,
+          "codes": [
+            "30110311"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "4b5320",
+          "codes": [
+            "30110121"
+          ]
+        },
+        {
+          "name": "Mint Green",
+          "hex": "98ff98",
+          "codes": [
+            "30110321"
+          ]
+        },
+        {
+          "name": "Mint Turquoise",
+          "hex": "7fffd4",
+          "codes": [
+            "30110421"
+          ]
+        },
+        {
+          "name": "Moss Green",
+          "hex": "556b2f",
+          "codes": [
+            "30110161"
+          ]
+        },
+        {
+          "name": "Moss Grey",
+          "hex": "8a9a5b",
+          "codes": [
+            "30110481"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "ffff00",
+          "glow": true,
+          "codes": [
+            "30110431"
+          ]
+        },
+        {
+          "name": "Nut Brown",
+          "hex": "5c4033",
+          "codes": [
+            "30110661"
+          ]
+        },
+        {
+          "name": "Pale Peach",
+          "hex": "ffdab9",
+          "codes": [
+            "30110651"
+          ]
+        },
+        {
+          "name": "Pastel Orange",
+          "hex": "ffb347",
+          "codes": [
+            "30110041"
+          ]
+        },
+        {
+          "name": "Pearl Orange",
+          "hex": "ff8c42",
+          "codes": [
+            "30110531"
+          ]
+        },
+        {
+          "name": "Pool Blue",
+          "hex": "00bfff",
+          "codes": [
+            "30110201"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "30110031",
+            "30150031"
+          ]
+        },
+        {
+          "name": "Purple Violet",
+          "hex": "8b00ff",
+          "codes": [
+            "30110511"
+          ]
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "cc0000",
+          "codes": [
+            "30110061"
+          ]
+        },
+        {
+          "name": "Traffic Yellow",
+          "hex": "ffcc00",
+          "codes": [
+            "30110211"
+          ]
+        },
+        {
+          "name": "Ultramarine Blue",
+          "hex": "120a8f",
+          "codes": [
+            "30110071"
+          ]
+        },
+        {
+          "name": "White Aluminum",
+          "hex": "d3d3d3",
+          "codes": [
+            "30110141"
+          ]
+        },
+        {
+          "name": "Window Grey",
+          "hex": "808080",
+          "codes": [
+            "30110011",
+            "30150011"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "30210021",
+            "30250021"
+          ]
+        },
+        {
+          "name": "Pastel Orange",
+          "hex": "ffb347",
+          "codes": [
+            "30210041"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "30210031"
+          ]
+        },
+        {
+          "name": "Window Grey",
+          "hex": "808080",
+          "codes": [
+            "30210011"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Shimmering White",
+          "hex": "f8f8ff",
+          "codes": [
+            "30110010"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA-CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Slovakia",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "30710471"
+          ]
+        }
+      ],
+      "fill": "carbon fiber",
+      "finish": "matte"
+    }
+  ]
+}

--- a/filaments/filamentsca.json
+++ b/filaments/filamentsca.json
@@ -1,0 +1,153 @@
+{
+  "manufacturer": "Filaments.ca",
+  "filaments": [
+    {
+      "name": "EconoFil PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    },
+    {
+      "name": "EconoFil PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        }
+      ]
+    },
+    {
+      "name": "EconoFil ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        95,
+        110
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filamentsdepot.json
+++ b/filaments/filamentsdepot.json
@@ -1,0 +1,338 @@
+{
+  "manufacturer": "Filaments Depot",
+  "filaments": [
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "184168"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Camouflage",
+          "hex": "b5b372"
+        }
+      ]
+    },
+    {
+      "name": "PCTG {color_name}",
+      "material": "PCTG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Almond",
+          "hex": "ded3b0"
+        },
+        {
+          "name": "Black",
+          "hex": "212121"
+        },
+        {
+          "name": "Charcoal",
+          "hex": "36424a"
+        },
+        {
+          "name": "Gray",
+          "hex": "828a8f"
+        },
+        {
+          "name": "Stone Gray",
+          "hex": "c9bba0"
+        },
+        {
+          "name": "Stone Grey",
+          "hex": "5c5e61"
+        },
+        {
+          "name": "Teal",
+          "hex": "7cc4f8"
+        }
+      ]
+    },
+    {
+      "name": "PETG+PLUS {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Mystery White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Natural",
+          "hex": "e1e3e5"
+        }
+      ]
+    },
+    {
+      "name": "Recycled {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Grey/Black (inconsistent)",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Recycled {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Grey/Black (inconsistent)",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Flame (Gold-Red)",
+          "hex": "fea34a"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "c4c6c8"
+        },
+        {
+          "name": "Yellow",
+          "hex": "d0d256"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filamentworld.json
+++ b/filaments/filamentworld.json
@@ -1,0 +1,705 @@
+{
+  "manufacturer": "Filamentworld",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        90,
+        100
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "ABS175XBLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "ABS175XSBL"
+          ]
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "5c4033",
+          "codes": [
+            "ABS175XBRN"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "cc0000",
+          "codes": [
+            "ABS175XRED"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "codes": [
+            "ABS175XGLD"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "ABS175XGRY"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "ABS175XFGN",
+            "ABS175XGGN"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff",
+          "codes": [
+            "ABS175XMGA"
+          ]
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ff6600",
+          "codes": [
+            "ABS175XFOR"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "ccff00",
+          "codes": [
+            "ABS175XFYL"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "ABS175XORG"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "ABS175XSLV"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff80",
+          "translucent": true,
+          "codes": [
+            "ABS175XCLR"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "ABS175XWHT"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "ABS175XNYL"
+          ]
+        }
+      ],
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_ABS_Datenblatt.pdf"
+    },
+    {
+      "name": "Matte PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLAMTT175XBLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PLAMTT175XBLU"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PLAMTT175XGRY"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PLAMTT175XRED"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLAMTT175XWHT"
+          ]
+        }
+      ],
+      "finish": "matte",
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_PLA_Datenblatt.pdf"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        260
+      ],
+      "bed_temp_range": [
+        65,
+        75
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PETG175XBLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PETG175XBLU",
+            "PETG175XMBL"
+          ]
+        },
+        {
+          "name": "Bronze",
+          "hex": "cd7f32",
+          "codes": [
+            "PETG175XMBR"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "cc0000",
+          "codes": [
+            "PETG175XRED"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PETG175XGRY"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PETG175XGRN",
+            "PETG175XMGR"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PETG175XORG"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PETG175XMSL"
+          ]
+        },
+        {
+          "name": "Transparent Clear",
+          "hex": "ffffff66",
+          "translucent": true,
+          "codes": [
+            "PETG175XCLR"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PETG175XWHT"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PETG175XYLW"
+          ]
+        }
+      ],
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_PETG_Datenblatt.pdf"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Anthracite",
+          "hex": "383838",
+          "codes": [
+            "PLA175XLANT"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA175XBLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "MPLA175XBLGR",
+            "MPLA175XBLYE",
+            "PLA175XLNAV",
+            "PLA175XSBL"
+          ]
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "5c4033",
+          "codes": [
+            "PLA175XBRN"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "cc0000",
+          "codes": [
+            "PLA175XRED"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "codes": [
+            "MPLA175XREGO",
+            "PLA175XGLD",
+            "PLAXBASX175XGLD"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PLA175XGRY",
+            "PLA175XLGRY"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "MPLA175XREGR",
+            "PLA175XFGN",
+            "PLA175XGGN"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff",
+          "codes": [
+            "PLA175XMGA"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "PELXPLAXNAT"
+          ]
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ff6600",
+          "codes": [
+            "PLA175XFOR"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "ccff00",
+          "codes": [
+            "PLA175XFYL"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PLA175XORG",
+            "PLAXBASX175XORG"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PLA175XSLV",
+            "PLAXBASX175XSLV"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff80",
+          "translucent": true,
+          "codes": [
+            "PLA175XCLR"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "8b00ff",
+          "codes": [
+            "MPLA175XGOVI"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA175XWHT"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PLA175XNYL"
+          ]
+        }
+      ],
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_PLA_Datenblatt.pdf"
+    },
+    {
+      "name": "PLA Basic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Dark Blue",
+          "hex": "003366",
+          "codes": [
+            "PLAXBASX175XDBLU"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "codes": [
+            "PLAXBASX175XDGR"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "codes": [
+            "PLAXBASX175XGLD"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PLAXBASX175XORG"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "PLAXBASX175XPNK"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PLAXBASX175XSLV"
+          ]
+        },
+        {
+          "name": "Wintershine White",
+          "hex": "f5f5f5",
+          "codes": [
+            "PLAXBASX175WIN"
+          ]
+        },
+        {
+          "name": "Wondrous White",
+          "hex": "fafafa",
+          "codes": [
+            "PLAXBASX175WON"
+          ]
+        }
+      ],
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_PLA_Datenblatt.pdf"
+    },
+    {
+      "name": "PLA Plus {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        1,
+        75
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLAPLU175XBLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PLAPLU175XBLU"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PLAPLU175XGRY"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PLAPLU175XGRN"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "PLAPLU175XTRA"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PLAPLU175XRED"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLAPLU175XWHT"
+          ]
+        }
+      ],
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_PLA_Datenblatt.pdf"
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLASLK175XBLK"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "PLASLK175XCOP"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "003366",
+          "codes": [
+            "PLASLK175XDBLU"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "codes": [
+            "PLASLK175XGLD"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "PLASLK175XRED"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PLASLK175XGRY"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "8b00ff",
+          "codes": [
+            "PLASLK175XVIO"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLASLK175XWHT"
+          ]
+        }
+      ],
+      "finish": "glossy",
+      "tds_url": "https://filamentworld.de/fact-sheets/Filamentworld_PLA_Datenblatt.pdf"
+    }
+  ]
+}

--- a/filaments/filaprint.json
+++ b/filaments/filaprint.json
@@ -1,0 +1,424 @@
+{
+  "manufacturer": "Filaprint",
+  "filaments": [
+    {
+      "name": "95A Hf {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        245
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "BLACK",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ABS Premium {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "d3d3d3"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Lite {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "BLACK",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Lite {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "PASTEL WHITE",
+          "hex": "ffffff"
+        },
+        {
+          "name": "WHITE",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dark Blue",
+          "hex": "001d8f"
+        }
+      ]
+    },
+    {
+      "name": "PIPG {color_name}",
+      "material": "PIPG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Orange",
+          "hex": "e87121"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "SILVER",
+          "hex": "888888"
+        }
+      ]
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Dark Blue",
+          "hex": "00008b"
+        },
+        {
+          "name": "Glow in the Dark",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "c7c7c7"
+        },
+        {
+          "name": "Yellow Fluor",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        225
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Purple",
+          "hex": "49124a"
+        },
+        {
+          "name": "R&D ONE PLUS WHITE",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "f70820"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLACK/GREEN",
+          "hexes": [
+            "000000",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silver",
+          "hex": "7b838a"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "X Strong {color_name}",
+      "material": "ASA+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filatech.json
+++ b/filaments/filatech.json
@@ -1,0 +1,1274 @@
+{
+  "manufacturer": "Filatech",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "AB120200"
+          ]
+        },
+        {
+          "name": "Dark Blue Luminous",
+          "hex": "1e90ff",
+          "glow": true,
+          "codes": [
+            "AB110502",
+            "AB120502"
+          ]
+        },
+        {
+          "name": "Dark Green Luminous",
+          "hex": "39ff14",
+          "glow": true,
+          "codes": [
+            "AB110602",
+            "AB120602"
+          ]
+        },
+        {
+          "name": "Dark Orange (Luminous)",
+          "hex": "ff4500",
+          "glow": true,
+          "codes": [
+            "AB110702",
+            "AB120702"
+          ]
+        },
+        {
+          "name": "Dark Yellow Luminous",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "AB120402"
+          ]
+        },
+        {
+          "name": "Natural White",
+          "hex": "f5f5dc",
+          "codes": [
+            "AB120000"
+          ]
+        },
+        {
+          "name": "Raven Black",
+          "hex": "808080",
+          "codes": [
+            "AB120201"
+          ]
+        },
+        {
+          "name": "Red (Luminous)",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "AB120301"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "AB110100",
+            "AB120100"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "FilaCarbon {color_name}",
+      "material": "PLA-CF",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "AC110200",
+            "AC120200"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "FilaPLA {color_name}",
+      "material": "PLA",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PH120200"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PH120600"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080",
+          "codes": [
+            "PH121407"
+          ]
+        },
+        {
+          "name": "Natural White",
+          "hex": "f5f5dc",
+          "codes": [
+            "PH120000"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PH120900"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PH120100"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PH120400"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "FilaTough {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Natural White",
+          "hex": "f5f5dc",
+          "codes": [
+            "FT110000",
+            "FT120000"
+          ]
+        },
+        {
+          "name": "Yellow (Luminous)",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "FT120401"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        100
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "HP110200",
+            "HP120200"
+          ]
+        },
+        {
+          "name": "Dark Green Luminous",
+          "hex": "39ff14",
+          "glow": true,
+          "codes": [
+            "HP110602"
+          ]
+        },
+        {
+          "name": "Dark Orange (Luminous)",
+          "hex": "ff4500",
+          "glow": true,
+          "codes": [
+            "HP120702"
+          ]
+        },
+        {
+          "name": "Dark Red Luminous",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "HP110302"
+          ]
+        },
+        {
+          "name": "Dark Yellow Luminous",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "HP110402"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "808080",
+          "codes": [
+            "HP110000",
+            "HP120000"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "HP110100",
+            "HP120100"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Hyper ABS {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "HB120200"
+          ]
+        },
+        {
+          "name": "Dark Orange (Luminous)",
+          "hex": "ff4500",
+          "glow": true,
+          "codes": [
+            "HB120702"
+          ]
+        },
+        {
+          "name": "Dark Yellow Luminous",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "HB120402"
+          ]
+        },
+        {
+          "name": "Natural White",
+          "hex": "f5f5dc",
+          "codes": [
+            "HB120000"
+          ]
+        },
+        {
+          "name": "Raven Black",
+          "hex": "808080",
+          "codes": [
+            "HB120201"
+          ]
+        },
+        {
+          "name": "Red (Luminous)",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "HB120301"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "HB120100"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Hyper PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        90
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "HG120200"
+          ]
+        },
+        {
+          "name": "Natural Clear",
+          "hex": "ffffff66",
+          "translucent": true,
+          "codes": [
+            "HG120000"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "HG120100"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Hyper PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "HL120200"
+          ]
+        },
+        {
+          "name": "Bronze Gold",
+          "hex": "cd7f32",
+          "codes": [
+            "HL121104"
+          ]
+        },
+        {
+          "name": "Dark Yellow",
+          "hex": "cccc00",
+          "codes": [
+            "HL120403"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "HL120800"
+          ]
+        },
+        {
+          "name": "Natural Transparent",
+          "hex": "ffffff80",
+          "translucent": true,
+          "codes": [
+            "HL120001"
+          ]
+        },
+        {
+          "name": "Natural White",
+          "hex": "f5f5dc",
+          "codes": [
+            "HL120000"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "fffafa",
+          "codes": [
+            "HL120103"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "HL120400"
+          ]
+        },
+        {
+          "name": "Yellow (Luminous)",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "HL120401"
+          ]
+        }
+      ],
+      "tds_url": "https://fila-tech.store/wp-content/uploads/2021/11/PLA-Datasheet.pdf"
+    },
+    {
+      "name": "PA {color_name}",
+      "material": "NYLON",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PA110200"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "808080",
+          "codes": [
+            "PA110000",
+            "PA120000"
+          ]
+        },
+        {
+          "name": "Red (Luminous)",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "PA110301"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PA110100",
+            "PA120100"
+          ]
+        },
+        {
+          "name": "Yellow (Luminous)",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "PA110401",
+            "PA120401"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        300
+      ],
+      "bed_temp_range": [
+        90,
+        120
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PC110200"
+          ]
+        },
+        {
+          "name": "Natural Clear",
+          "hex": "ffffff66",
+          "translucent": true,
+          "codes": [
+            "PC110000",
+            "PC120000"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "808080",
+          "codes": [
+            "PC110300",
+            "PC120300"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PC110100",
+            "PC120100"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PC110400"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        90
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PG120200"
+          ]
+        },
+        {
+          "name": "Choco Brown",
+          "hex": "5c4033",
+          "codes": [
+            "PG121402"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "003366",
+          "codes": [
+            "PG120503"
+          ]
+        },
+        {
+          "name": "Dark Metallic Grey",
+          "hex": "4a4a4a",
+          "codes": [
+            "PG120805"
+          ]
+        },
+        {
+          "name": "Dark Orange (Luminous)",
+          "hex": "ff4500",
+          "glow": true,
+          "codes": [
+            "PG120702"
+          ]
+        },
+        {
+          "name": "Dark Red Luminous",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "PG110302",
+            "PG120302"
+          ]
+        },
+        {
+          "name": "Dark Yellow Luminous",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "PG110402"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "codes": [
+            "PG121300"
+          ]
+        },
+        {
+          "name": "Natural Clear",
+          "hex": "ffffff66",
+          "translucent": true,
+          "codes": [
+            "PG120000"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PG120900"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PG120100"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PG120400"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 6000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PL120200",
+            "PL140200"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PL120500"
+          ]
+        },
+        {
+          "name": "Choco Brown",
+          "hex": "5c4033",
+          "codes": [
+            "PL121402"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "codes": [
+            "PL120603"
+          ]
+        },
+        {
+          "name": "Dark Metallic Grey",
+          "hex": "4a4a4a",
+          "codes": [
+            "PL120805"
+          ]
+        },
+        {
+          "name": "Dark Orange (Luminous)",
+          "hex": "ff4500",
+          "glow": true,
+          "codes": [
+            "PL120702"
+          ]
+        },
+        {
+          "name": "Dark Sky Blue",
+          "hex": "4169e1",
+          "codes": [
+            "PL120514"
+          ]
+        },
+        {
+          "name": "Dark Yellow",
+          "hex": "cccc00",
+          "codes": [
+            "PL120403"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PL120800"
+          ]
+        },
+        {
+          "name": "Green (Luminous)",
+          "hex": "39ff14",
+          "glow": true,
+          "codes": [
+            "PL120601"
+          ]
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "PL121501"
+          ]
+        },
+        {
+          "name": "Natural White",
+          "hex": "f5f5dc",
+          "codes": [
+            "PL120000"
+          ]
+        },
+        {
+          "name": "Olive Gold",
+          "hex": "bdb76b",
+          "codes": [
+            "PL121308"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb",
+          "codes": [
+            "PL121500"
+          ]
+        },
+        {
+          "name": "Red (Luminous)",
+          "hex": "ff1744",
+          "glow": true,
+          "codes": [
+            "PL120301",
+            "PL140301"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PL120901"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "fffafa",
+          "codes": [
+            "PL120103"
+          ]
+        },
+        {
+          "name": "Terracotta Brown",
+          "hex": "e2725b",
+          "codes": [
+            "PL121401"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PL120400"
+          ]
+        },
+        {
+          "name": "Yellow (Fluorescent)",
+          "hex": "ccff00",
+          "glow": true,
+          "codes": [
+            "PL120410"
+          ]
+        },
+        {
+          "name": "Yellow (Luminous)",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "PL120401"
+          ]
+        }
+      ],
+      "tds_url": "https://fila-tech.store/wp-content/uploads/2021/11/PLA-Datasheet.pdf"
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PU110200"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PU110500",
+            "PU120500"
+          ]
+        },
+        {
+          "name": "Orange (Luminous)",
+          "hex": "ff6600",
+          "glow": true,
+          "codes": [
+            "PU110701",
+            "PU120701"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PU110900",
+            "PU120900"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PU120100"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PU110400",
+            "PU120400"
+          ]
+        }
+      ],
+      "tds_url": "https://fila-tech.store/wp-content/uploads/2021/10/PLA-plus-Datasheet.pdf"
+    },
+    {
+      "name": "TPE {color_name}",
+      "material": "TPE",
+      "density": 1.06,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        55
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "TE110800"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "808080",
+          "codes": [
+            "TE110700"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "808080",
+          "codes": [
+            "TE110300"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "TE110900"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "TE110400"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TU110200"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "808080",
+          "codes": [
+            "TU110700"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "808080",
+          "codes": [
+            "TU110300"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "TU110100"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "TU110400"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TPU 2 {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TP120200"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "TP110100"
+          ]
+        },
+        {
+          "name": "Yellow (Luminous)",
+          "hex": "ffff33",
+          "glow": true,
+          "codes": [
+            "TP110401"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Wood PLA {color_name}",
+      "material": "PLA+WOOD",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "UAE",
+      "colors": [
+        {
+          "name": "Dark Ash",
+          "hex": "808080",
+          "codes": [
+            "PL121012"
+          ]
+        },
+        {
+          "name": "Mahogany",
+          "hex": "808080",
+          "codes": [
+            "PL121011"
+          ]
+        },
+        {
+          "name": "Natural Wood",
+          "hex": "808080",
+          "codes": [
+            "PL111000",
+            "PL121000"
+          ]
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/filaxix.json
+++ b/filaments/filaxix.json
@@ -1,0 +1,291 @@
+{
+  "manufacturer": "Filaxix",
+  "filaments": [
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        280
+      ],
+      "bed_temp_range": [
+        95,
+        95
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "d3d7cf"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PET-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0080ff"
+        },
+        {
+          "name": "Marble Grey",
+          "hex": "2c343a"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PETG-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3535ff"
+        },
+        {
+          "name": "Grey",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "High Speed Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "f7f8f8"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Metallic Blue",
+          "hex": "385b7d"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Silk Gold",
+          "hex": "b0d37c"
+        },
+        {
+          "name": "Silver",
+          "hex": "96a6a6"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "red green",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Red/Black",
+          "hexes": [
+            "ff0000",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/filkemp.json
+++ b/filaments/filkemp.json
@@ -1,0 +1,297 @@
+{
+  "manufacturer": "Filkemp",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Portugal",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.419C"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.7629U"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.361U"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "90ee90",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.7742C"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.001C"
+          ]
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ff6600",
+          "glow": true,
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.165U"
+          ]
+        },
+        {
+          "name": "Squirrel Grey",
+          "hex": "8b8680",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.430U"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "A.3DPLA0.175.B1KPTU.000C"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        250
+      ],
+      "bed_temp_range": [
+        20,
+        60
+      ],
+      "country_of_origin": "Portugal",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "A.3DPETG0.175.B1KTRU.419C"
+          ]
+        },
+        {
+          "name": "Graphite Black",
+          "hex": "2b2b2b",
+          "codes": [
+            "A.3DPETG0.175.B1KTRU.426U"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "A.3DPETG0.175.B1KTRU.001C"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "A.3DPETG0.175.B1KTRU.186U"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLN {color_name}",
+      "material": "PLN",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Portugal",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.419C"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.7742C"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.001C"
+          ]
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ff6600",
+          "glow": true,
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.165U"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.186U"
+          ]
+        },
+        {
+          "name": "Signal Yellow",
+          "hex": "ffd700",
+          "glow": true,
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.1365U"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.430U"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.285U"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "A.3DPLN0.175.B1KTRU.000C"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Nylon {color_name}",
+      "material": "NYLON",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        250
+      ],
+      "bed_temp_range": [
+        20,
+        60
+      ],
+      "country_of_origin": "Portugal",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "A.3DPA0.175.B1KTRU.419C"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "d8d0c0",
+          "codes": [
+            "A.3DPA0.175.B1KTRU.001C"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Nylon CF {color_name}",
+      "material": "NYLON-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        250
+      ],
+      "bed_temp_range": [
+        20,
+        60
+      ],
+      "country_of_origin": "Portugal",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "A.3DPA10CF1.175.B1KTRU.419C"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    }
+  ]
+}

--- a/filaments/fillamentum.json
+++ b/filaments/fillamentum.json
@@ -165,6 +165,10 @@
           {
             "name": "Everybody's Magenta",
             "hex": "E1337E"
+          },
+          {
+            "name": "Lilac",
+            "hex": "C8A2C8"
           }
         ]
       }

--- a/filaments/filoalfa.json
+++ b/filaments/filoalfa.json
@@ -1,0 +1,1613 @@
+{
+  "manufacturer": "FiloAlfa",
+  "filaments": [
+    {
+      "name": "10^8 ABS ANTISTATICO {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "extruder_temp_range": [
+        250,
+        290
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/TDS%20ABS%20Mar,%202019.pdf"
+    },
+    {
+      "name": "ABS FC by Elix {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20ABS%203D%20FC%20by%20ELIX%20ENG.pdf"
+    },
+    {
+      "name": "ABS GF {color_name}",
+      "material": "ABS-GF",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/N-ASA%20GF%20msds.pdf"
+    },
+    {
+      "name": "ABS HS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        },
+        {
+          "name": "Orange",
+          "hex": "f47c00"
+        }
+      ],
+      "extruder_temp_range": [
+        250,
+        290
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/ABS%20HIGH%20SPEED%20msds.pdf"
+    },
+    {
+      "name": "ABS V0 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        }
+      ],
+      "extruder_temp_range": [
+        250,
+        290
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-av0-october-2017.pdf"
+    },
+    {
+      "name": "ABSPECIALE {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Blue Night",
+          "hex": "002654"
+        },
+        {
+          "name": "Blue sky",
+          "hex": "6bc9db"
+        },
+        {
+          "name": "Change Color",
+          "hex": "ed2893"
+        },
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Green",
+          "hex": "007c59"
+        },
+        {
+          "name": "Orange",
+          "hex": "f47c00"
+        },
+        {
+          "name": "Red",
+          "hex": "ed1c24"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9e526"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-abspeciale-nov-2016.pdf"
+    },
+    {
+      "name": "ALFA TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/TDS%20FILOFlex%20Medium%20-%20Oct%202020.pdf"
+    },
+    {
+      "name": "ALFA TPU GF {color_name}",
+      "material": "TPU-GF",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        },
+        {
+          "name": "Orange",
+          "hex": "f47c00"
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/ALFATPU%20GF%20msds.pdf"
+    },
+    {
+      "name": "ALFALOY 31 {color_name}",
+      "material": "PC+ABS",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        90
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/ALFALOY%2031%20tds%20(E-%20021122).pdf"
+    },
+    {
+      "name": "ALFALOY 32 {color_name}",
+      "material": "PC+ABS",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 900
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        260,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        90
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/ALFALOY%2032%20msds.pdf"
+    },
+    {
+      "name": "ALFALOY 35 {color_name}",
+      "material": "PC+ABS",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 900
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        90
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/ALFALOY%2035%20msds%20eng.pdf"
+    },
+    {
+      "name": "ALFANYLON CF {color_name}",
+      "material": "PA-CF",
+      "density": 1.18,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 800
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/TDS%20ALFANYLON%20CF-2020.pdf"
+    },
+    {
+      "name": "ALFAOHM {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/TDS%20ALFAOHM%20Sept,%202019.pdf"
+    },
+    {
+      "name": "ALFAOMNIA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20ALFAOMNIA_15-09-2018_rev1-1.pdf"
+    },
+    {
+      "name": "ALFAPAK 3D {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "ECO GRAY",
+          "hex": "373737"
+        },
+        {
+          "name": "ECO GREEN",
+          "hex": "467600"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/ALFAPAK%20tds%20(E-%20040423).pdf"
+    },
+    {
+      "name": "ALFAPLUS {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "786518"
+        },
+        {
+          "name": "Copper",
+          "hex": "763c28"
+        },
+        {
+          "name": "Earth Brown",
+          "hex": "633826"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "e8112d"
+        },
+        {
+          "name": "Gold",
+          "hex": "e5be01"
+        },
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Matt Earthenware",
+          "hex": "bc4f07"
+        },
+        {
+          "name": "Metallic Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Phosphorescent",
+          "hex": "f4edaf"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ]
+    },
+    {
+      "name": "ALFAPRO {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "f9e4b5"
+        },
+        {
+          "name": "Blue Night",
+          "hex": "002654"
+        },
+        {
+          "name": "Electric Blue",
+          "hex": "0051ba"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "024930"
+        },
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        },
+        {
+          "name": "Metallic Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Orange",
+          "hex": "f47c00"
+        },
+        {
+          "name": "Red",
+          "hex": "ed1c24"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "9b111e"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9e526"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20ALFAPRO_07-10-2019_rev%202.pdf"
+    },
+    {
+      "name": "ALFATEIKO {color_name}",
+      "material": "PPS",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ],
+      "extruder_temp_range": [
+        300,
+        330
+      ],
+      "bed_temp_range": [
+        70,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-thermec-zed-may-2018.pdf"
+    },
+    {
+      "name": "ALFATEIKO CF {color_name}",
+      "material": "PPS-CF",
+      "density": 1.4,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        }
+      ],
+      "extruder_temp_range": [
+        300,
+        330
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/ALFATEIKO%20CF%20msds%20eng.pdf"
+    },
+    {
+      "name": "GESSO {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        }
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20-%20GESSO.pdf"
+    },
+    {
+      "name": "GRAFYLON 3D {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        }
+      ],
+      "extruder_temp_range": [
+        170,
+        210
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Blue",
+          "hex": "00467a"
+        },
+        {
+          "name": "Change Color",
+          "hex": "ed2893"
+        },
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20HIPS_%20Ita_26-06-2019_rev2.pdf"
+    },
+    {
+      "name": "N-ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00467a"
+        },
+        {
+          "name": "Change Color",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Red",
+          "hex": "ed1c24"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9e526"
+        }
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-n-asa-maggio-2017.pdf"
+    },
+    {
+      "name": "N-ASA GF {color_name}",
+      "material": "ASA-GF",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Dark Gray",
+          "hex": "60605b"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/N-ASA%20GF%20msds.pdf"
+    },
+    {
+      "name": "NYLON {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        }
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-nylon-aprile-2017.pdf"
+    },
+    {
+      "name": "PC/ABS {color_name}",
+      "material": "PC+ABS",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2300
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00467a"
+        },
+        {
+          "name": "Green",
+          "hex": "007c59"
+        },
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ],
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-pc-abs-april-2017.pdf"
+    },
+    {
+      "name": "PET-G {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Blue Night",
+          "hex": "002654"
+        },
+        {
+          "name": "Blue sky",
+          "hex": "6bc9db"
+        },
+        {
+          "name": "Change Color",
+          "hex": "60605b"
+        },
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Green",
+          "hex": "007c59"
+        },
+        {
+          "name": "Red",
+          "hex": "ed1c24"
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "75aadb"
+        },
+        {
+          "name": "Transparent Green",
+          "hex": "5bbf21"
+        },
+        {
+          "name": "Transparent Red",
+          "hex": "f95e59"
+        },
+        {
+          "name": "Transparent Yellow",
+          "hex": "f2ed6d"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9e526"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/TDS%20PET-G%20-%20Oct%202020.pdf"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Amber",
+          "hex": "8e4905"
+        },
+        {
+          "name": "Azur Water",
+          "hex": "008772"
+        },
+        {
+          "name": "Azure",
+          "hex": "0084c9"
+        },
+        {
+          "name": "Blue Christmas",
+          "hex": "112151"
+        },
+        {
+          "name": "Bronze",
+          "hex": "786518"
+        },
+        {
+          "name": "Brown",
+          "hex": "4a2900"
+        },
+        {
+          "name": "Corallo",
+          "hex": "e80068"
+        },
+        {
+          "name": "Electric Blue",
+          "hex": "0051ba"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "e8112d"
+        },
+        {
+          "name": "Glitter",
+          "hex": "eae2b7"
+        },
+        {
+          "name": "Gold",
+          "hex": "e5be01"
+        },
+        {
+          "name": "Gray Metallic",
+          "hex": "adafaa"
+        },
+        {
+          "name": "Green",
+          "hex": "007c59"
+        },
+        {
+          "name": "Green Christmas",
+          "hex": "024930"
+        },
+        {
+          "name": "Green Fluo",
+          "hex": "1cce28"
+        },
+        {
+          "name": "Grey",
+          "hex": "60605b"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "afaaa3"
+        },
+        {
+          "name": "Matt Earthenware",
+          "hex": "bc4f07"
+        },
+        {
+          "name": "Metallic Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Metallic Blue",
+          "hex": "53729f"
+        },
+        {
+          "name": "Orange",
+          "hex": "f47c00"
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "ff5416"
+        },
+        {
+          "name": "Pearl White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Pervinca",
+          "hex": "b25eff"
+        },
+        {
+          "name": "Phosphorescent",
+          "hex": "f4edaf"
+        },
+        {
+          "name": "Pink Fluo",
+          "hex": "ff0093"
+        },
+        {
+          "name": "Polished Brick",
+          "hex": "b46a55"
+        },
+        {
+          "name": "Red Christmas",
+          "hex": "af2626"
+        },
+        {
+          "name": "Sangria",
+          "hex": "a90061"
+        },
+        {
+          "name": "Tiger",
+          "hex": "bc5e1e"
+        },
+        {
+          "name": "Transparent Azur",
+          "hex": "bfd1e5"
+        },
+        {
+          "name": "Transparent Green",
+          "hex": "5bbf21"
+        },
+        {
+          "name": "Transparent Red",
+          "hex": "f95e59"
+        },
+        {
+          "name": "Verde foliage",
+          "hex": "2ad400"
+        },
+        {
+          "name": "Violet",
+          "hex": "cc00a0"
+        },
+        {
+          "name": "Violet Glitter",
+          "hex": "d60270"
+        },
+        {
+          "name": "White Porcelain",
+          "hex": "f8f6e9"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9e526"
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "dde00f"
+        }
+      ],
+      "extruder_temp_range": [
+        170,
+        210
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20EN%20-%20PLA%20English%2019-09-2018_rev02.pdf"
+    },
+    {
+      "name": "PLA CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Azure",
+          "hex": "0084c9"
+        },
+        {
+          "name": "Black",
+          "hex": "282821"
+        },
+        {
+          "name": "Red",
+          "hex": "ed1c24"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20EN%20-%20PLA%20English%2019-09-2018_rev02.pdf"
+    },
+    {
+      "name": "PP CF {color_name}",
+      "material": "PP-CF",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "282821"
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/PP%20CF%20msds.pdf"
+    },
+    {
+      "name": "PP GF {color_name}",
+      "material": "PP-GF",
+      "density": 0.94,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00467a"
+        },
+        {
+          "name": "Dark Gray",
+          "hex": "60605b"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f9f7e8"
+        },
+        {
+          "name": "Tortora",
+          "hex": "a8a490"
+        }
+      ],
+      "extruder_temp_range": [
+        225,
+        255
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/HIPRO%20H%20FV30H%20msds.pdf"
+    },
+    {
+      "name": "PUREPRINT PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Batch production",
+          "hex": "808080"
+        },
+        {
+          "name": "Rapid prototyping",
+          "hex": "808080"
+        },
+        {
+          "name": "Schools and labs",
+          "hex": "808080"
+        },
+        {
+          "name": "Print farms",
+          "hex": "808080"
+        },
+        {
+          "name": "Everyday printing",
+          "hex": "808080"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "tds_url": "https://www.filoalfa3d.com/img/cms/MSDS%20&%20TDS/MSDS%20EN%20-%20PLA%20English%2019-09-2018_rev02.pdf"
+    },
+    {
+      "name": "VETROALFA {color_name}",
+      "material": "PLA-GF",
+      "density": 1.28,
+      "weights": [
+        {
+          "weight": 700
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "country_of_origin": "Italy",
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "d8e8f0"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://www.filoalfa3d.com/upload/scheda/tds-vetroalfa-dec-2017.pdf"
+    }
+  ]
+}

--- a/filaments/filx.json
+++ b/filaments/filx.json
@@ -1,0 +1,157 @@
+{
+  "manufacturer": "Fil X",
+  "filaments": [
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "151c23"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "SBS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        265
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        245
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "111212"
+        },
+        {
+          "name": "Bone White",
+          "hex": "c1c5c8"
+        },
+        {
+          "name": "Grey",
+          "hex": "5f6467"
+        },
+        {
+          "name": "Kudu Valley Tan",
+          "hex": "b0ae73"
+        },
+        {
+          "name": "Orange",
+          "hex": "d27f57"
+        },
+        {
+          "name": "Red",
+          "hex": "b13e60"
+        },
+        {
+          "name": "Shamrock Green",
+          "hex": "00a828"
+        },
+        {
+          "name": "Tungsten",
+          "hex": "22262b"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "16a5d4"
+        },
+        {
+          "name": "White",
+          "hex": "ebeef0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/floreon3d.json
+++ b/filaments/floreon3d.json
@@ -1,0 +1,93 @@
+{
+  "manufacturer": "Floreon3D",
+  "filaments": [
+    {
+      "name": "Therma-Tech {color_name}",
+      "material": "PLA",
+      "density": 1.26,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "finish": "matte",
+      "country_of_origin": "United Kingdom",
+      "tds_url": "https://www.floreon.com/_files/ugd/a17df6_6592f0453b73476bb8b0d0ba249ff61f.pdf",
+      "colors": [
+        {
+          "name": "Industrial Grey",
+          "hex": "6e6e6e"
+        }
+      ]
+    },
+    {
+      "name": "Dura-Tech {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "United Kingdom",
+      "tds_url": "https://www.floreon.com/_files/ugd/a17df6_53fc64a5556c427b8a18a88c14179f5a.pdf",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "Bio-Tech {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "United Kingdom",
+      "tds_url": "https://www.floreon.com/_files/ugd/a17df6_4b60169dad264165bebc6db6f041e0ce.pdf",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/forshape.json
+++ b/filaments/forshape.json
@@ -1,0 +1,360 @@
+{
+  "manufacturer": "Forshape",
+  "filaments": [
+    {
+      "name": "Eco {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Café",
+          "hex": "804040"
+        }
+      ]
+    },
+    {
+      "name": "Eco {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Cherry Red",
+          "hex": "ff052b"
+        },
+        {
+          "name": "Coffee",
+          "hex": "2d221f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Economy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "d8ca89"
+        }
+      ]
+    },
+    {
+      "name": "PETG Premium {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Argent",
+          "hex": "858585"
+        },
+        {
+          "name": "Blanc",
+          "hex": "fafafa"
+        },
+        {
+          "name": "Bleu",
+          "hex": "0445dc"
+        },
+        {
+          "name": "Jaune",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Noir",
+          "hex": "000000"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "ecoPLA Mat Grey",
+          "hex": "696969"
+        },
+        {
+          "name": "EcoPLA Mat Red",
+          "hex": "c51111"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        215
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "ecoPLA silk argent",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Laiton",
+          "hex": "b04646"
+        },
+        {
+          "name": "Or",
+          "hex": "d4af37"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blanc",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Bleu",
+          "hex": "2743cf"
+        },
+        {
+          "name": "eco PLA White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "ecoPLA Grass Green",
+          "hex": "00818a"
+        },
+        {
+          "name": "ecoPLA Gris",
+          "hex": "808080"
+        },
+        {
+          "name": "ecoPLA Noir",
+          "hex": "000000"
+        },
+        {
+          "name": "Noir",
+          "hex": "000000"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Premium {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Green",
+          "hex": "0ab291"
+        },
+        {
+          "name": "Grey",
+          "hex": "b1b5b5"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "168bf2"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "ecoPLA Blue Gray",
+          "hex": "0077cc"
+        },
+        {
+          "name": "Orange",
+          "hex": "f78040"
+        },
+        {
+          "name": "Orange Red",
+          "hex": "c64524"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/fortisfilaments.json
+++ b/filaments/fortisfilaments.json
@@ -1,0 +1,414 @@
+{
+  "manufacturer": "Fortis Filaments",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "778899"
+        }
+      ]
+    },
+    {
+      "name": "ABS Pro {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "f0f0f0"
+        }
+      ]
+    },
+    {
+      "name": "ASA Pro {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Marble Brick Red",
+          "hex": "814f44",
+          "pattern": "marble"
+        },
+        {
+          "name": "Marble Light Grey",
+          "hex": "757879",
+          "pattern": "marble"
+        },
+        {
+          "name": "Marble Natural",
+          "hex": "b6b5b7",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PA {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "2d377e"
+        },
+        {
+          "name": "Lake Blue",
+          "hex": "86c6eb"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1e90ff"
+        },
+        {
+          "name": "Dark Military Green",
+          "hex": "556b2f"
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "ff00ff"
+        },
+        {
+          "name": "Skin",
+          "hex": "dfb368"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "778899"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "f0d314"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Pastello {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Matte Blue",
+          "hex": "a7ccdc"
+        },
+        {
+          "name": "Matte Green",
+          "hex": "b2d7c0"
+        },
+        {
+          "name": "Matte Pink",
+          "hex": "dca8a8"
+        },
+        {
+          "name": "Matte Purple",
+          "hex": "dcbae9"
+        },
+        {
+          "name": "Matte Yellow",
+          "hex": "d9dfaa"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Walnut",
+          "hex": "7e5c51"
+        },
+        {
+          "name": "Wooden Natural",
+          "hex": "a88c7e"
+        },
+        {
+          "name": "Wooden Red",
+          "hex": "734543"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/francofil.json
+++ b/filaments/francofil.json
@@ -1,0 +1,87 @@
+{
+  "manufacturer": "Francofil",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {"weight": 500, "spool_weight": 227},
+        {"weight": 750, "spool_weight": 246},
+        {"weight": 1000, "spool_weight": 246},
+        {"weight": 5000, "spool_weight": 1050},
+        {"weight": 10000, "spool_weight": 1050}
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [30, 70],
+      "country_of_origin": "France",
+      "tds_url": "https://francofil.fr/wp-content/uploads/2023/12/Fiche-technique-PLA.pdf",
+      "sds_url": "https://francofil.fr/wp-content/uploads/2023/12/Fiche-de-Securite-PLA.pdf",
+      "colors": [
+        {"name": "Black", "hex": "101010", "codes": ["PLA-NOI"]},
+        {"name": "White", "hex": "F6F6F6", "codes": ["PLA-BLA"]},
+        {"name": "Virgin", "hex": "E8E0C8", "codes": ["PLA-VIE"], "translucent": true},
+        {"name": "Blue RAL 5002", "hex": "20214F", "codes": ["PLA-5002"]},
+        {"name": "Blue RAL 5015", "hex": "007CB0", "codes": ["PLA-5015"]},
+        {"name": "Turquoise Blue", "hex": "00A9A5", "codes": ["PLA-BLT"]},
+        {"name": "Red RAL 3020", "hex": "CC0605", "codes": ["PLA-3020"]},
+        {"name": "Pink RAL 4003", "hex": "C63678", "codes": ["PLA-6019-1"]},
+        {"name": "Orange RAL 2003", "hex": "F67828", "codes": ["PLA-2003"]},
+        {"name": "Yellow RAL 1018", "hex": "F9A800", "codes": ["PLA-1018"]},
+        {"name": "Fluorescent Yellow RAL 1026", "hex": "FFFF00", "codes": ["PLA-JAU-1026"]},
+        {"name": "Green RAL 6000", "hex": "316650", "codes": ["PLA-6000"]},
+        {"name": "Green RAL 6018", "hex": "57A639", "codes": ["PLA-6018"]},
+        {"name": "Grey RAL 7001", "hex": "8A9597", "codes": ["PLA-7001"]},
+        {"name": "Grey RAL 7040", "hex": "9DA3A6", "codes": ["PLA-7040"]},
+        {"name": "Anthracite RAL 7016", "hex": "293133", "codes": ["PLA-7016"]},
+        {"name": "Phosphorescent Green", "hex": "8FD400", "codes": ["PLA-4003-2"], "glow": true},
+        {"name": "Violet Halloween", "hex": "5B2C8D", "eans": ["0117540050050"]}
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {"weight": 500, "spool_weight": 227},
+        {"weight": 1000, "spool_weight": 246}
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [220, 260],
+      "bed_temp_range": [70, 90],
+      "country_of_origin": "France",
+      "tds_url": "https://francofil.fr/wp-content/uploads/2023/12/Fiche-technique-PETG.pdf",
+      "sds_url": "https://francofil.fr/wp-content/uploads/2023/12/Fiche-de-Securite-PETG.pdf",
+      "colors": [
+        {"name": "Black", "hex": "101010", "codes": ["PETG-Noir"]},
+        {"name": "White", "hex": "F6F6F6", "codes": ["PETG-Blanc"]},
+        {"name": "Virgin", "hex": "E8E0C8", "codes": ["PETG-Vierge"], "translucent": true},
+        {"name": "Blue", "hex": "0066B3", "codes": ["PETG-Bleu"]},
+        {"name": "Gray", "hex": "808080", "codes": ["PETG-Gris"]},
+        {"name": "Red", "hex": "CC0605", "codes": ["PETG-Rouge"]}
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {"weight": 500, "spool_weight": 227},
+        {"weight": 750, "spool_weight": 246},
+        {"weight": 1000, "spool_weight": 246},
+        {"weight": 5000, "spool_weight": 1050},
+        {"weight": 10000, "spool_weight": 1050}
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [250, 270],
+      "bed_temp_range": [90, 110],
+      "country_of_origin": "France",
+      "colors": [
+        {"name": "Black", "hex": "101010", "codes": ["ABS-BLA-2"]},
+        {"name": "White", "hex": "F6F6F6", "codes": ["ABS-BLA"]},
+        {"name": "Virgin", "hex": "E8E0C8", "codes": ["ABS-VIE"], "translucent": true}
+      ]
+    }
+  ]
+}

--- a/filaments/fremover.json
+++ b/filaments/fremover.json
@@ -1,0 +1,272 @@
+{
+  "manufacturer": "Fremover",
+  "filaments": [
+    {
+      "name": "Crystal {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "6680ef"
+        },
+        {
+          "name": "Brown",
+          "hex": "a27345"
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "537f78"
+        },
+        {
+          "name": "Ivory Yellow",
+          "hex": "fee295"
+        },
+        {
+          "name": "Matte Cream Pink",
+          "hex": "ea8ae7"
+        },
+        {
+          "name": "Matte Dark Brown",
+          "hex": "978d55"
+        },
+        {
+          "name": "Matte Oats",
+          "hex": "e8d8ae"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wine Red",
+          "hex": "763f33"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f3ef67"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "7dbe46"
+        },
+        {
+          "name": "Army Green",
+          "hex": "48513e"
+        },
+        {
+          "name": "Azul profundo",
+          "hex": "0b2642"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3333ff"
+        },
+        {
+          "name": "Brown",
+          "hex": "935100"
+        },
+        {
+          "name": "Bubble Gum",
+          "hex": "e9aab5"
+        },
+        {
+          "name": "Cloud Blue",
+          "hex": "94e3fe"
+        },
+        {
+          "name": "Crystal",
+          "hex": "fbfdfe"
+        },
+        {
+          "name": "Dark Red",
+          "hex": "800020"
+        },
+        {
+          "name": "Fluorescent Green",
+          "hex": "46bd69"
+        },
+        {
+          "name": "Fluorescent Orange",
+          "hex": "e66d0a"
+        },
+        {
+          "name": "Fluorescent Yellow",
+          "hex": "eeff77"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "169bea"
+        },
+        {
+          "name": "Orange",
+          "hex": "f64e00"
+        },
+        {
+          "name": "Peacock",
+          "hex": "20606c"
+        },
+        {
+          "name": "Pink",
+          "hex": "b6355a"
+        },
+        {
+          "name": "Red",
+          "hex": "b80000"
+        },
+        {
+          "name": "Rojo",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "75787b"
+        },
+        {
+          "name": "Violet",
+          "hex": "6e3ca0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fff76b"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Crystal",
+          "hex": "f9fafb"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/fugacity.json
+++ b/filaments/fugacity.json
@@ -1,0 +1,149 @@
+{
+  "manufacturer": "Fugacity",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.28,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0061fe"
+        },
+        {
+          "name": "Brown",
+          "hex": "808080"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0061ff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0061ff"
+        },
+        {
+          "name": "Purple",
+          "hex": "8090ca"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f5ec00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/fusion.json
+++ b/filaments/fusion.json
@@ -3,19 +3,19 @@
     "filaments": 
 	[
         {
-            "name": "ABS 1.5 {color_name} (matte)",
+            "name": "ABS Matte {color_name}",
             "material": "ABS",
             "density": 1.05,
             "weights": [
                 {
                     "weight": 1000,
-                    "spool_weight": 162
+                    "spool_weight": 150
                 }
             ],
             "diameters": [
                 1.75
             ],
-            "extruder_temp": 280,
+            "extruder_temp": 265,
 			"bed_temp_range": [
 			90,
 			100
@@ -74,6 +74,10 @@
                     "hex": "676A6D"
                 },
 				{
+                    "name": "Mystery",
+                    "hex": "676A6D"
+                },
+				{
                     "name": "Natural",
                     "hex": "BFC4C7"
                 },
@@ -109,6 +113,10 @@
                     "name": "Seismic Red ",
                     "hex": "9D0115"
                 },
+				{
+                    "name": "Sunfire Helix",
+                    "hex": "b0661b"
+                },
                 {
                     "name": "Thorium Thilver",
                     "hex": "687074"
@@ -120,23 +128,23 @@
                 {
                     "name": "Uranium Yellow",
                     "hex": "DBDA45"
-          }
-        ]
-      },
-      {
-            "name": "ABS 2.0 {color_name} (gloss)",
+				}
+			]
+		},
+		{
+            "name": "ABS Gloss {color_name}",
             "material": "ABS",
             "density": 1.05,
             "weights": [
                 {
                     "weight": 1000,
-                    "spool_weight": 162
+                    "spool_weight": 150
                 }
             ],
             "diameters": [
                 1.75
             ],
-            "extruder_temp": 255,
+            "extruder_temp": 265,
 			"bed_temp_range": [
 			90,
 			100
@@ -186,9 +194,17 @@
                     "name": "Mushroom Cloud Grey",
                     "hex": "595C61"
                 },
+				{
+                    "name": "Mystery",
+                    "hex": "595C61"
+                },
                 {
                     "name": "Nano Tube Grey",
                     "hex": "5E6A7D"
+                },
+				{
+                    "name": "Natural",
+                    "hex": "BFC4C7"
                 },
                 {
                     "name": "Neutron Green",
@@ -214,6 +230,10 @@
                     "name": "Seismic Red",
                     "hex": "9D3026"
                 },
+				{
+                    "name": "Sunfire Helix",
+                    "hex": "b0661b"
+                },
                 {
                     "name": "Thorium Thilver",
                     "hex": "616971"
@@ -225,17 +245,17 @@
                 {
                     "name": "Uranium Yellow",
                     "hex": "A9C82F"
-          }
-        ]
-      },
-      {
+				}
+			]
+		},
+		{
             "name": "HTPLA+ {color_name}",
             "material": "PLA",
             "density": 1.22,
             "weights": [
                 {
                     "weight": 1000,
-                    "spool_weight": 162
+                    "spool_weight": 150
                 }
             ],
             "diameters": [
@@ -313,6 +333,10 @@
                 {
                     "name": "Nuclear Winter White 2.0",
                     "hex": "DEDDD8"
+                },
+				{
+                    "name": "Plasma Burst Orange",
+                    "hex": "FF6800"
                 },
                 {
                     "name": "Plutonic Purple",
@@ -415,9 +439,17 @@
                     "name": "Mushroom Cloud Grey",
                     "hex": "676A6D"
                 },
+				{
+                    "name": "Mystery",
+                    "hex": "676A6D"
+                },
                 {
                     "name": "Nano Tube Grey",
                     "hex": "5E6A7D"
+                },
+				{
+                    "name": "Plutonic Purple",
+                    "hex": "5F0073"
                 },
                 {
                     "name": "Radioactive Orange",
@@ -446,8 +478,314 @@
                 {
                     "name": "Uranium Yellow",
                     "hex": "DBDA45"
-          }
-        ]
-      }
+				}
+			]
+		},
+		{
+            "name": "EasyASA {color_name}",
+            "material": "ASA",
+            "density": 1.08,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 150
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 260,
+			"bed_temp_range": [
+			100,
+			110
+			],
+            "colors": [
+                {
+                    "name": "Carbon Rod Black",
+                    "hex": "262832"
+                },
+                {
+                    "name": "Cold Fusion Blue",
+                    "hex": "4B839B"
+                },
+                {
+                    "name": "Cosmic Ray Blue",
+                    "hex": "0B3D78"
+                },
+                {
+                    "name": "Electrolytic Deuterium",
+                    "hex": "29768F"
+                },
+                {
+                    "name": "Geomagnetic Mauve",
+                    "hex": "342364"
+                },
+                {
+                    "name": "Heavy Water Blue",
+                    "hex": "003671"
+                },
+                {
+                    "name": "Interstellar Emerald",
+                    "hex": "106F62"
+                },
+                {
+                    "name": "Ionized Cobalt Black",
+                    "hex": "212023"
+                },
+                {
+                    "name": "Mushroom Cloud Grey",
+                    "hex": "676A6D"
+                },
+				{
+                    "name": "Mystery",
+                    "hex": "676A6D"
+                },
+                {
+                    "name": "Nano Tube Grey",
+                    "hex": "5E6A7D"
+                },
+				{
+                    "name": "Plutonic Purple",
+                    "hex": "5F0073"
+                },
+                {
+                    "name": "Radioactive Orange",
+                    "hex": "FA8F2C"
+                },
+                {
+                    "name": "Radium Green 2.0",
+                    "hex": "40C91F"
+                },
+                {
+                    "name": "Red Dwarf",
+                    "hex": "8C1B18"
+                },
+                {
+                    "name": "Seismic Red ",
+                    "hex": "9D0115"
+                },
+                {
+                    "name": "Sievert Silver",
+                    "hex": "4F5358"
+                },
+                {
+                    "name": "Tritium Green",
+                    "hex": "1F8544"
+                },
+                {
+                    "name": "Uranium Yellow",
+                    "hex": "DBDA45"
+				}
+			]
+		},
+		{
+            "name": "HTPET+ {color_name}",
+            "material": "PET",
+            "density": 1.35,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 150
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+			275,
+			285
+			],
+			"bed_temp_range": [
+			100,
+			110
+			],
+            "colors": [
+                {
+                    "name": "Carbon Rod Black",
+                    "hex": "262832"
+                },
+                {
+                    "name": "Cold Fusion Blue",
+                    "hex": "4B839B"
+                },
+                {
+                    "name": "Cosmic Ray Blue",
+                    "hex": "0B3D78"
+                },
+				{
+                    "name": "Critical Mass Gold",
+                    "hex": "BE7A2D"
+                },
+                {
+                    "name": "Electrolytic Deuterium",
+                    "hex": "29768F"
+                },
+				{
+                    "name": "Gatekeeper Orange",
+                    "hex": "FA8F2C"
+                },
+                {
+                    "name": "Geomagnetic Mauve",
+                    "hex": "342364"
+                },
+                {
+                    "name": "Heavy Water Blue",
+                    "hex": "003671"
+                },
+                {
+                    "name": "Interstellar Emerald",
+                    "hex": "106F62"
+                },
+                {
+                    "name": "Ionized Cobalt Black",
+                    "hex": "212023"
+                },
+                {
+                    "name": "Mushroom Cloud Grey",
+                    "hex": "676A6D"
+                },
+				{
+                    "name": "Mystery",
+                    "hex": "676A6D"
+                },
+				{
+                    "name": "Natural",
+                    "hex": "DFC5AA"
+                },
+				{
+                    "name": "Neutron Green",
+                    "hex": "6BB293"
+                },
+                {
+                    "name": "Nuclear Winter White 2.0",
+                    "hex": "DEDDD8"
+                },
+				{
+                    "name": "Plutonic Purple",
+                    "hex": "5F0073"
+                },
+				{
+                    "name": "Proton Pink",
+                    "hex": "EB3A97"
+                },
+                {
+                    "name": "Radioactive Orange",
+                    "hex": "FA8F2C"
+                },
+                {
+                    "name": "Radium Green 2.0",
+                    "hex": "40C91F"
+                },
+				{
+                    "name": "Reactor Red",
+                    "hex": "750E0F"
+                },
+                {
+                    "name": "Red Dwarf",
+                    "hex": "8C1B18"
+                },
+                {
+                    "name": "Seismic Red ",
+                    "hex": "9D0115"
+                },
+                {
+                    "name": "Sievert Silver",
+                    "hex": "4F5358"
+                },
+                {
+                    "name": "Tritium Green",
+                    "hex": "1F8544"
+                }
+			]
+		},
+		{
+            "name": "PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 150
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+			"bed_temp_range": [
+			50,
+			60
+			],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "040302"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "496ce8"
+                },
+                {
+                    "name": "Breakfast Blue",
+                    "hex": "aff9f3"
+                },
+                {
+                    "name": "Bubblegum",
+                    "hex": "d3667e"
+                },
+                {
+                    "name": "Green",
+                    "hex": "84e86c"
+                },
+                {
+                    "name": "Hyper Orange",
+                    "hex": "d6680e"
+                },
+                {
+                    "name": "Moondust",
+                    "hex": "939693"
+                },
+                {
+                    "name": "Mystery",
+                    "hex": "676A6D"
+                },
+				{
+                    "name": "Pickle Juice",
+                    "hex": "e4f003"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "9f40e7"
+                },
+				{
+                    "name": "Quantum Blue",
+                    "hex": "6db5f0"
+                },
+                {
+                    "name": "Red",
+                    "hex": "e6534a"
+                },
+                {
+                    "name": "Sublime",
+                    "hex": "75cd00"
+                },
+                {
+                    "name": "Tangerine Dream",
+                    "hex": "de8419"
+                },
+                {
+                    "name": "Violet Surge",
+                    "hex": "8948de"
+                },
+                {
+                    "name": "White",
+                    "hex": "eff0ed"
+                },
+                {
+                    "name": "Yellow-Gold",
+                    "hex": "e2d610"
+				}
+			]
+		}
     ]
 }

--- a/filaments/fusionfilaments.json
+++ b/filaments/fusionfilaments.json
@@ -1,0 +1,447 @@
+{
+  "manufacturer": "Fusion Filaments",
+  "filaments": [
+    {
+      "name": "2 0 {color_name}",
+      "material": "ABS",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        255,
+        265
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Carbon Rod Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Interstellar Emerald",
+          "hex": "00714f"
+        },
+        {
+          "name": "Ionized Cobalt Black",
+          "hex": "2b2b26"
+        },
+        {
+          "name": "Plutonic Purple",
+          "hex": "2c0d64"
+        },
+        {
+          "name": "Seismic Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "ABS Matte {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        275
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Carbon Rod Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cosmic Ray Blue",
+          "hex": "040973"
+        },
+        {
+          "name": "Electrolytic Deuterium",
+          "hex": "5b9bd5"
+        },
+        {
+          "name": "Interstellar Emerald",
+          "hex": "54b891"
+        },
+        {
+          "name": "Ionized Cobalt Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Nano Tube Grey",
+          "hex": "383736"
+        },
+        {
+          "name": "Red Dwarf",
+          "hex": "d4151d"
+        },
+        {
+          "name": "Seismic Red",
+          "hex": "f12e4e"
+        },
+        {
+          "name": "Thorium Thilver",
+          "hex": "c4bdb7"
+        },
+        {
+          "name": "Tritium Green",
+          "hex": "00b14c"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        255,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Cold Fusion Blue",
+          "hex": "61bdff"
+        },
+        {
+          "name": "Interstellar Emerald",
+          "hex": "00714f"
+        }
+      ]
+    },
+    {
+      "name": "High Gloss {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Alpha Particle Orange",
+          "hex": "f85638"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PET",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Carbon Rod Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Natural",
+          "hex": "808080"
+        },
+        {
+          "name": "Radiated Fog",
+          "hex": "d8d5cc"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "HT+PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        245
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Plutonic Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Radioactive Orange",
+          "hex": "fb8b02"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Radioactive Orange",
+          "hex": "fb8b02"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        240
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Radium Green",
+          "hex": "00ff00"
+        }
+      ]
+    },
+    {
+      "name": "PCTG {color_name}",
+      "material": "PCTG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Geomagnetic Mauve",
+          "hex": "60379a"
+        },
+        {
+          "name": "Heavy Water Blue",
+          "hex": "4a21de"
+        },
+        {
+          "name": "Natural",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black (Freedom)",
+          "hex": "000000"
+        },
+        {
+          "name": "Breakfast Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Bubblegum",
+          "hex": "ff48a5"
+        },
+        {
+          "name": "Chocolate",
+          "hex": "5a1c00"
+        },
+        {
+          "name": "Desert Sand",
+          "hex": "eed9c4"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Moondust",
+          "hex": "474747"
+        },
+        {
+          "name": "OD Green",
+          "hex": "6b8e23"
+        },
+        {
+          "name": "Purple (Freedom)",
+          "hex": "800080"
+        },
+        {
+          "name": "Red",
+          "hex": "f40101"
+        },
+        {
+          "name": "White (Freedom)",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Tritium Green",
+          "hex": "32a04f",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Plutonic Purple",
+          "hex": "2215e6"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/g3dprogrossiste3d.json
+++ b/filaments/g3dprogrossiste3d.json
@@ -1,0 +1,277 @@
+{
+  "manufacturer": "G3D Pro (Grossiste 3D)",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.01,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "BLANC NEIGE",
+          "hex": "fdf4e3"
+        },
+        {
+          "name": "Blue",
+          "hex": "74a7fe"
+        },
+        {
+          "name": "Purple",
+          "hex": "6b00b3"
+        },
+        {
+          "name": "Red Scarlet",
+          "hex": "b51a00"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "04db00"
+        },
+        {
+          "name": "Yellow",
+          "hex": "eeff00"
+        }
+      ]
+    },
+    {
+      "name": "Luminous Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Luminescent Blue",
+          "hex": "5cbbff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blanc Pur",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silk Glossy Bronze",
+          "hex": "7f7a57"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        20,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Bleu",
+          "hex": "20214f"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "404a54"
+        },
+        {
+          "name": "Jaune",
+          "hex": "f8f32b"
+        },
+        {
+          "name": "Orange",
+          "hex": "f75e25"
+        },
+        {
+          "name": "Perle Blanc",
+          "hex": "f7f7f7"
+        },
+        {
+          "name": "Rouge",
+          "hex": "961f1c"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "61b0ff"
+        },
+        {
+          "name": "Snow White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Pastello {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Pastel Skin",
+          "hex": "f7dbbb"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        20,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Translucent Green",
+          "hex": "147a00"
+        },
+        {
+          "name": "Translucide Bleu",
+          "hex": "003efa"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/geeetech.json
+++ b/filaments/geeetech.json
@@ -195,6 +195,46 @@
                 { "name": "White", "hex": "fcfefb" },
                 { "name": "Yellow", "hex": "feea00" }
             ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ABS+",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                95,
+                110
+            ],
+            "colors": [
+                { "name": "Apple", "hex": "daeb2e" },
+                { "name": "Black", "hex": "000000" },
+                { "name": "Blue", "hex": "0067ea" },
+                { "name": "Brown", "hex": "b56b58" },
+                { "name": "Dark Gray", "hex": "484848" },
+                { "name": "Green", "hex": "1c8c04" },
+                { "name": "Orange", "hex": "f65d33" },
+                { "name": "Pink", "hex": "ec58b8" },
+                { "name": "Purple", "hex": "6a24b6" },
+                { "name": "Red", "hex": "e31f2b" },
+                { "name": "Silver", "hex": "e7ecf0" },           
+                { "name": "Skin", "hex": "ffc8a9" },
+                { "name": "Water Blue", "hex": "02b4f2" },
+                { "name": "White", "hex": "fcfefb" },
+                { "name": "Yellow", "hex": "feea00" } 
+            ]
         }
     ]
 }

--- a/filaments/geekfillament.json
+++ b/filaments/geekfillament.json
@@ -1,0 +1,198 @@
+{
+  "manufacturer": "Geek Fil/lament",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        225
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Ash",
+          "hex": "778899"
+        },
+        {
+          "name": "Beige",
+          "hex": "b19886"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue Moon",
+          "hex": "007fef"
+        },
+        {
+          "name": "Ivory",
+          "hex": "f6e8ca"
+        },
+        {
+          "name": "Just Green",
+          "hex": "5f963a"
+        },
+        {
+          "name": "Lilac",
+          "hex": "9370db"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "9b111e"
+        },
+        {
+          "name": "Sunflower",
+          "hex": "ffdb02"
+        },
+        {
+          "name": "Ultramarine",
+          "hex": "120a8f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Sunflower (Yellow)",
+          "hex": "fff700"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PLA-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        250
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Lilac",
+          "hex": "6326c0"
+        },
+        {
+          "name": "Orange",
+          "hex": "ec7c25"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Sunflower",
+          "hex": "ffc512"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Arabica",
+          "hex": "3c2020"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/generic.json
+++ b/filaments/generic.json
@@ -1,0 +1,1840 @@
+{
+  "manufacturer": "Generic",
+  "filaments": [
+    {
+      "name": "90A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Flexsolid Clear",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Kee Pang Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Kee Pang White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Bronze",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Mint",
+          "hex": "adf4dc"
+        },
+        {
+          "name": "orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Peak Green",
+          "hex": "16fe31"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff80ca"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f1fb65"
+        }
+      ]
+    },
+    {
+      "name": "ABS+PLUS {color_name}",
+      "material": "ABS+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Blend {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black & Red",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PA6-CF",
+      "density": 1.17,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ABS-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black to Red to Yellow",
+          "hex": "243f1d"
+        },
+        {
+          "name": "Purple to Pink",
+          "hex": "221f5c"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "2d494f"
+        }
+      ]
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Aqua blue / Fluo Green",
+          "hex": "4198be"
+        },
+        {
+          "name": "Clear to green",
+          "hex": "808080"
+        },
+        {
+          "name": "Glowing Yellow",
+          "hex": "0fe000"
+        }
+      ]
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Glowing Yellow",
+          "hex": "7ee600"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Crystal Mermaid Tears",
+          "hex": "84aefd",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Glitter Blue",
+          "hex": "4848ff",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Glitter Gold",
+          "hex": "242d31",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Luminous Star B",
+          "hex": "111a1a",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Shining Rainbow",
+          "hex": "e01b24",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "SILVER",
+          "hex": "858585",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Transparent Sea Blue",
+          "hex": "0606ff",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Twinkling Clear",
+          "hex": "ffffff",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Firefly Blue",
+          "hex": "62a5d5"
+        },
+        {
+          "name": "Glowing color",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "66ff44"
+        },
+        {
+          "name": "Multicolor",
+          "hex": "f6f5f4"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Glow in dark green",
+          "hex": "b1dd8b"
+        },
+        {
+          "name": "Glow in the dark Red",
+          "hex": "a70c0c"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue White",
+          "hex": "6ac6f7"
+        }
+      ]
+    },
+    {
+      "name": "Hf {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Christmas Green",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "High Gloss {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Gloss Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "KEE PANG Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Luminous Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "ebffff",
+          "pattern": "marble"
+        },
+        {
+          "name": "Marble White",
+          "hex": "ffffff",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "c0bfbc",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "372c6d"
+        }
+      ]
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        310
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        2,
+        70
+      ],
+      "colors": [
+        {
+          "name": "blue",
+          "hex": "052bc2"
+        },
+        {
+          "name": "Red",
+          "hex": "ec041b"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Bright Green",
+          "hex": "7adc6c"
+        },
+        {
+          "name": "Brown",
+          "hex": "702d11"
+        },
+        {
+          "name": "Burnt Titanium",
+          "hex": "011d57"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "183182"
+        },
+        {
+          "name": "Fluro Green",
+          "hex": "e0ffa0"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey Blue",
+          "hex": "92afc3"
+        },
+        {
+          "name": "Imitation Wood",
+          "hex": "83735a"
+        },
+        {
+          "name": "Khaki Green",
+          "hex": "999a7b"
+        },
+        {
+          "name": "Metalic Silver",
+          "hex": "505757"
+        },
+        {
+          "name": "Military Green",
+          "hex": "576d24"
+        },
+        {
+          "name": "Orange",
+          "hex": "f98501"
+        },
+        {
+          "name": "Pale Yellow",
+          "hex": "edca8b"
+        },
+        {
+          "name": "Pink",
+          "hex": "efb7c6"
+        },
+        {
+          "name": "Purple",
+          "hex": "715389"
+        },
+        {
+          "name": "RED iPrint3d",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Rose",
+          "hex": "c80181"
+        },
+        {
+          "name": "Transparent",
+          "hex": "d0c9d2"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "27ccc6"
+        },
+        {
+          "name": "white",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f7c344"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Green",
+          "hex": "a4f9dd"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "b3dd84"
+        },
+        {
+          "name": "Red Brown",
+          "hex": "4a2125"
+        },
+        {
+          "name": "Tan",
+          "hex": "d6b588"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Aluminium",
+          "hex": "95999d"
+        },
+        {
+          "name": "Ancien Copper",
+          "hex": "953a13"
+        },
+        {
+          "name": "Bicolor Blue & Green",
+          "hex": "0095ff"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue/Green Gradient",
+          "hexes": [
+            "0000ff",
+            "53c7a0"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Bronze",
+          "hex": "628464"
+        },
+        {
+          "name": "Candy Rainbow",
+          "hex": "8ce6c7"
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "Deep Aluminium",
+          "hex": "707070"
+        },
+        {
+          "name": "Forest Rainbow",
+          "hex": "86e293"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Gray",
+          "hex": "707070"
+        },
+        {
+          "name": "Green",
+          "hex": "41b52d"
+        },
+        {
+          "name": "Light gold",
+          "hex": "d1ba49"
+        },
+        {
+          "name": "Pink",
+          "hex": "b340bf"
+        },
+        {
+          "name": "Purple-Blue",
+          "hex": "2c0977"
+        },
+        {
+          "name": "RAINBOW",
+          "hex": "af4fe3"
+        },
+        {
+          "name": "Red",
+          "hex": "f40009"
+        },
+        {
+          "name": "RED YELLOW",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Red/Yellow/Blue",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose Red",
+          "hex": "f07198"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "052bc2"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Army OD Green",
+          "hex": "486941"
+        },
+        {
+          "name": "Beige",
+          "hex": "808080"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Bright Yellow",
+          "hex": "808080"
+        },
+        {
+          "name": "Cinza",
+          "hex": "9c9c9c"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "808080"
+        },
+        {
+          "name": "Dark Gray",
+          "hex": "4f4f4f"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "2e6f40"
+        },
+        {
+          "name": "Gold",
+          "hex": "efb44d"
+        },
+        {
+          "name": "Green",
+          "hex": "50c700"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Jade Green",
+          "hex": "00a86b"
+        },
+        {
+          "name": "nebula purple",
+          "hex": "7639f2"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "PINK",
+          "hex": "ed5a99"
+        },
+        {
+          "name": "Purple",
+          "hex": "c800ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ec041b"
+        },
+        {
+          "name": "Silver",
+          "hex": "b5b5b5"
+        },
+        {
+          "name": "Skin",
+          "hex": "ffffdf"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "57b9ff"
+        },
+        {
+          "name": "Super Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "6f7608"
+        },
+        {
+          "name": "Cotton Candy",
+          "hex": "f1c9fe"
+        },
+        {
+          "name": "Gold",
+          "hex": "fec700"
+        },
+        {
+          "name": "Grey",
+          "hex": "d4dde4"
+        },
+        {
+          "name": "Purple",
+          "hex": "874efe"
+        },
+        {
+          "name": "Red",
+          "hex": "f40009"
+        },
+        {
+          "name": "Red-Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Silver",
+          "hex": "aaaaaa"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "919191"
+        },
+        {
+          "name": "Grey",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Powertool Green",
+          "hex": "a5f76e"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Plasty Mladeč {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Plasty Mladeč - Desert Beige",
+          "hex": "d9ba8e"
+        }
+      ]
+    },
+    {
+      "name": "SMP {color_name}",
+      "material": "SMP",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        0,
+        0
+      ],
+      "bed_temp_range": [
+        0,
+        0
+      ],
+      "colors": [
+        {
+          "name": "delete this entry",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Bicolor Blue & Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Black Red",
+          "hex": "a3343c"
+        },
+        {
+          "name": "Blue Green",
+          "hex": "070783"
+        },
+        {
+          "name": "MAGENTA GOLD",
+          "hex": "fd43b7"
+        }
+      ]
+    },
+    {
+      "name": "Silk Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Yellow Fuchsia",
+          "hex": "2275c6"
+        },
+        {
+          "name": "Red Gold",
+          "hex": "ff685c"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "d87e76"
+        },
+        {
+          "name": "Rose Red + Sky Blue",
+          "hex": "b62e82"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "b51a00"
+        },
+        {
+          "name": "Rainbow Kingfisher",
+          "hex": "6abcf6"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Green Orange",
+          "hex": "6c37f7"
+        },
+        {
+          "name": "Gold Copper Black",
+          "hex": "e6c10a"
+        },
+        {
+          "name": "Gold Silver Copper",
+          "hex": "f7d348"
+        },
+        {
+          "name": "Green / Sky Blue / Rose Red",
+          "hexes": [
+            "008000",
+            "00de71"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Purple/Sky Blue/Yellow",
+          "hexes": [
+            "800080",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red Gold Purple",
+          "hex": "ff5353"
+        },
+        {
+          "name": "Rosey Red, Sky Blue, Green",
+          "hex": "000000"
+        },
+        {
+          "name": "Zebot Silk Gold Red Orange",
+          "hex": "f51414"
+        }
+      ]
+    },
+    {
+      "name": "Smart Print {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        65,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Smart Print - Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Smart Print - White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Smart Print {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Smart Print - Grey",
+          "hex": "858585"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Peacock Gold Sparkle",
+          "hex": "a63600",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Transparent Purple",
+          "hex": "6d56a4",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Light Cyan",
+          "hex": "b2ffff"
+        },
+        {
+          "name": "Purple",
+          "hex": "301934"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Antrovirens",
+          "hex": "007575"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Rose Gelb",
+          "hex": "eed273"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Light Blue",
+          "hex": "46c1fa"
+        },
+        {
+          "name": "Orange",
+          "hex": "e77d04"
+        },
+        {
+          "name": "Transparent",
+          "hex": "fdffff"
+        },
+        {
+          "name": "UV Green",
+          "hex": "8c9527"
+        },
+        {
+          "name": "violet transluent",
+          "hex": "fb14ff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Purple 95A",
+          "hex": "bc5bc2"
+        },
+        {
+          "name": "Transparent Green",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "clear",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "PLA Madeira Faia Clara (Ref. A12348)",
+          "hex": "f7ddc5"
+        },
+        {
+          "name": "White Pine Wood",
+          "hex": "ebb691"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/giantarm.json
+++ b/filaments/giantarm.json
@@ -1,0 +1,43 @@
+{
+    "manufacturer": "Giantarm",
+    "filaments": [
+        {
+            "name": "Giantarm PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/gizmodorks.json
+++ b/filaments/gizmodorks.json
@@ -1,0 +1,443 @@
+{
+  "manufacturer": "Gizmo Dorks",
+  "filaments": [
+    {
+      "name": "Gizmo Dorks PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp": 60,
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Blue (Translucent)",
+          "hex": "3399ff",
+          "translucent": true
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "654321"
+        },
+        {
+          "name": "Color Change Blue to White (Heat Activated)",
+          "hexes": [
+            "0066cc",
+            "ffffff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Color Change Green to Yellow (Heat Activated)",
+          "hexes": [
+            "228b22",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Color Change Grey to White (Heat Activated)",
+          "hexes": [
+            "808080",
+            "ffffff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Color Change Purple to Pink (Heat Activated)",
+          "hexes": [
+            "800080",
+            "ffc0cb"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Fluorescent Blue (Black Light Reactive)",
+          "hex": "00bfff"
+        },
+        {
+          "name": "Fluorescent Green (Black Light Reactive)",
+          "hex": "39ff14"
+        },
+        {
+          "name": "Fluorescent Orange (Black Light Reactive)",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Fluorescent Red (Black Light Reactive)",
+          "hex": "ff0040"
+        },
+        {
+          "name": "Fluorescent Yellow (Black Light Reactive)",
+          "hex": "ccff00"
+        },
+        {
+          "name": "Glow in the Dark",
+          "hex": "c8e6c9",
+          "glow": true
+        },
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Gradient Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "7cba3c"
+        },
+        {
+          "name": "Green",
+          "hex": "228b22"
+        },
+        {
+          "name": "Green (Translucent)",
+          "hex": "66cc66",
+          "translucent": true
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Orange (Translucent)",
+          "hex": "ffaa55",
+          "translucent": true
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Pink (Translucent)",
+          "hex": "ff99cc",
+          "translucent": true
+        },
+        {
+          "name": "Pink Rose",
+          "hex": "e75480"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Purple (Translucent)",
+          "hex": "bb66bb",
+          "translucent": true
+        },
+        {
+          "name": "Dark Purple",
+          "hex": "4b0082"
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000"
+        },
+        {
+          "name": "Red (Translucent)",
+          "hex": "ff4444",
+          "translucent": true
+        },
+        {
+          "name": "Red Lava",
+          "hex": "b22222"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Transparent",
+          "hex": "f0f8ff",
+          "translucent": true
+        },
+        {
+          "name": "Violet",
+          "hex": "8f00ff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Light Yellow",
+          "hex": "fffacd"
+        },
+        {
+          "name": "Light Yellow (Translucent)",
+          "hex": "ffffaa",
+          "translucent": true
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        }
+      ]
+    },
+    {
+      "name": "Gizmo Dorks PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp": 80,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Translucent Blue",
+          "hex": "3399ff",
+          "translucent": true
+        },
+        {
+          "name": "Translucent Green",
+          "hex": "66cc66",
+          "translucent": true
+        },
+        {
+          "name": "Translucent Red",
+          "hex": "ff4444",
+          "translucent": true
+        },
+        {
+          "name": "Transparent",
+          "hex": "f0f8ff",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Gizmo Dorks ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp": 110,
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513"
+        },
+        {
+          "name": "Color Change Blue to White (Heat Activated)",
+          "hexes": [
+            "0066cc",
+            "ffffff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Color Change Green to Yellow (Heat Activated)",
+          "hexes": [
+            "228b22",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Color Change Grey to White (Heat Activated)",
+          "hexes": [
+            "808080",
+            "ffffff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Color Change Purple to Pink (Heat Activated)",
+          "hexes": [
+            "800080",
+            "ffc0cb"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Conductive Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "00008b"
+        },
+        {
+          "name": "Dark Purple",
+          "hex": "4b0082"
+        },
+        {
+          "name": "Fluorescent Blue (Black Light Reactive)",
+          "hex": "00bfff"
+        },
+        {
+          "name": "Fluorescent Green (Black Light Reactive)",
+          "hex": "39ff14"
+        },
+        {
+          "name": "Fluorescent Hot Pink (Black Light Reactive)",
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Fluorescent Orange (Black Light Reactive)",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Fluorescent Yellow (Black Light Reactive)",
+          "hex": "ccff00"
+        },
+        {
+          "name": "Glow in the Dark",
+          "hex": "c8e6c9",
+          "glow": true
+        },
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Green",
+          "hex": "228b22"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "7cba3c"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Pink Rose",
+          "hex": "e75480"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000"
+        },
+        {
+          "name": "Red Lava",
+          "hex": "b22222"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Transparent",
+          "hex": "f0f8ff",
+          "translucent": true
+        },
+        {
+          "name": "Violet",
+          "hex": "8f00ff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Light Yellow",
+          "hex": "fffacd"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/gratkit.json
+++ b/filaments/gratkit.json
@@ -1,0 +1,79 @@
+{
+    "manufacturer": "GratKit",
+    "filaments": [
+        {
+            "name": "GratKit PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 155,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                }
+            ]
+        },
+        {
+            "name": "GratKit PETG {color_name}",
+            "material": "PETG",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 155,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 70,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/grauts.json
+++ b/filaments/grauts.json
@@ -1,0 +1,127 @@
+{
+  "manufacturer": "Grauts",
+  "filaments": [
+    {
+      "name": "Gf {color_name}",
+      "material": "PP-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "d1bc8a"
+        },
+        {
+          "name": "Chocolate brown",
+          "hex": "411900"
+        },
+        {
+          "name": "Green",
+          "hex": "086608"
+        },
+        {
+          "name": "Metallic Gold",
+          "hex": "d3af37"
+        },
+        {
+          "name": "Pastell Mintgrün",
+          "hex": "93cba4"
+        },
+        {
+          "name": "Pastell Pfirsich",
+          "hex": "ddb398"
+        },
+        {
+          "name": "Pastell Rosa",
+          "hex": "dea7ae"
+        },
+        {
+          "name": "pearl white",
+          "hex": "f6f4f5"
+        },
+        {
+          "name": "sky blue",
+          "hex": "87ceeb"
+        },
+        {
+          "name": "Sonderfarbe (Pink leicht Transparent)",
+          "hex": "fdd2fe"
+        },
+        {
+          "name": "yellow",
+          "hex": "f4c430"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/greengate3d.json
+++ b/filaments/greengate3d.json
@@ -1,0 +1,86 @@
+{
+  "manufacturer": "GreenGate3D",
+  "filaments": [
+    {
+      "name": "GreenGate3D Recycled PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        65
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "f0f0f0"
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        }
+      ]
+    },
+    {
+      "name": "GreenGate3D Recycled PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "translucent": true
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/grilon3.json
+++ b/filaments/grilon3.json
@@ -1,0 +1,196 @@
+{
+  "manufacturer": "Grilon3",
+  "filaments": [
+    {
+      "name": "Blend {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Boutique Carbón",
+          "hex": "212121"
+        },
+        {
+          "name": "Boutique Esmeralda",
+          "hex": "126768"
+        }
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        245
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Clear Azul",
+          "hex": "2e35ff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        175,
+        215
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Dorado/Gold",
+          "hexes": [
+            "edc244",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Amarillo",
+          "hex": "fedf00"
+        },
+        {
+          "name": "Amarillo Fluo",
+          "hex": "e0e721"
+        },
+        {
+          "name": "Azul",
+          "hex": "0035a0"
+        },
+        {
+          "name": "Blanco",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Butique Chocolate",
+          "hex": "6d462c"
+        },
+        {
+          "name": "Gris Espacial",
+          "hex": "e0e0e0"
+        },
+        {
+          "name": "Gris Plata",
+          "hex": "75787b"
+        },
+        {
+          "name": "Negro",
+          "hex": "000000"
+        },
+        {
+          "name": "Piel 162",
+          "hex": "ffbe9f"
+        },
+        {
+          "name": "Rojo",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Rosa",
+          "hex": "ff7aed"
+        },
+        {
+          "name": "Verde",
+          "hex": "009a49"
+        },
+        {
+          "name": "Verde Fluo",
+          "hex": "29f91a"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/gryddle.json
+++ b/filaments/gryddle.json
@@ -1,0 +1,639 @@
+{
+  "manufacturer": "Gryddle",
+  "filaments": [
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Blue / Silver",
+          "hexes": [
+            "0000ff",
+            "0395f8"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green White",
+          "hex": "80ff80"
+        },
+        {
+          "name": "Red Gold",
+          "hex": "ffd877"
+        },
+        {
+          "name": "Transparent blue-white",
+          "hex": "57b9ff"
+        }
+      ]
+    },
+    {
+      "name": "Matte Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink and Gold",
+          "hex": "ffd877"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "pink yellow blue",
+          "hex": "e600a8"
+        }
+      ]
+    },
+    {
+      "name": "PETG Pro {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Coffee Brown",
+          "hex": "674736"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "61b0ff"
+        },
+        {
+          "name": "Meteorite Ash",
+          "hex": "a4a4a4"
+        },
+        {
+          "name": "Off-White",
+          "hex": "ffffbb"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff81ba"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Misty Rose",
+          "hex": "ffcccc"
+        },
+        {
+          "name": "Purple",
+          "hex": "a600ff"
+        },
+        {
+          "name": "Red/Blue",
+          "hexes": [
+            "ff0000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "ff81ba"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        },
+        {
+          "name": "Red / Blue",
+          "hexes": [
+            "ff0000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red Yellow Green",
+          "hex": "6afa67"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        170,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        },
+        {
+          "name": "Silk Purple",
+          "hex": "89238b"
+        },
+        {
+          "name": "Terracotta",
+          "hex": "ff6a00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "c4cf20"
+        },
+        {
+          "name": "Pure Copper",
+          "hex": "dda96e"
+        },
+        {
+          "name": "red green blue",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silk white",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Silver",
+          "hex": "a5adb6"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue and white Jelly",
+          "hex": "b7cfe6"
+        },
+        {
+          "name": "lemon yellow",
+          "hex": "f8fb41"
+        },
+        {
+          "name": "Silk Blue",
+          "hex": "0057ad"
+        },
+        {
+          "name": "Silk Red",
+          "hex": "e15687"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black & Shiny Gold",
+          "hex": "b8a800"
+        },
+        {
+          "name": "Red & Copper",
+          "hex": "9a1c1c"
+        },
+        {
+          "name": "Yellow & Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow/Blue",
+          "hexes": [
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Silver",
+          "hex": "0395f8"
+        },
+        {
+          "name": "Green Gold",
+          "hex": "9dd062"
+        },
+        {
+          "name": "Pink Gold",
+          "hex": "f4a925"
+        },
+        {
+          "name": "Powder Gold",
+          "hex": "c4cf20"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Gold, Silver & Copper",
+          "hex": "ff8647"
+        },
+        {
+          "name": "Red Green Blue",
+          "hex": "e53d66"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "ff0080"
+        },
+        {
+          "name": "Red Yellow Green",
+          "hex": "e53d56"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red Green Gold",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Crystal Clear Jelly",
+          "hex": "c9bbee"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Crystal Gradient",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "ff7607"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/gtmax.json
+++ b/filaments/gtmax.json
@@ -1,0 +1,153 @@
+{
+  "manufacturer": "GTMax",
+  "filaments": [
+    {
+      "name": "ABS Premium {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "9ba5ab"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Azul Ciano",
+          "hex": "79ced6"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Branco",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Nude",
+          "hex": "edd2ce"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Branco",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "COBRE/COOPER",
+          "hex": "8f5f28"
+        },
+        {
+          "name": "MARROM/BROWN",
+          "hex": "60380b"
+        },
+        {
+          "name": "PRETO/BLACK",
+          "hex": "000000"
+        },
+        {
+          "name": "ROSA BEBE/PINK BABY",
+          "hex": "ffb8da"
+        },
+        {
+          "name": "ROXO/PURPLE",
+          "hexes": [
+            "6f027e",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "VERDE/GREEN",
+          "hexes": [
+            "0f620e",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/h3d.json
+++ b/filaments/h3d.json
@@ -1,0 +1,191 @@
+{
+  "manufacturer": "H3D",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff5900"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3581e3"
+        },
+        {
+          "name": "Bronze",
+          "hex": "b5844a"
+        },
+        {
+          "name": "Brown",
+          "hex": "ff9752"
+        },
+        {
+          "name": "Ceramic White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Coffee",
+          "hex": "9e7a6c"
+        },
+        {
+          "name": "Cream Yellow",
+          "hex": "ffdd9e"
+        },
+        {
+          "name": "Cyan",
+          "hex": "02d0e5"
+        },
+        {
+          "name": "Deep Blue",
+          "hex": "385a87"
+        },
+        {
+          "name": "Fluoro Green",
+          "hex": "a2fc8b"
+        },
+        {
+          "name": "Gold",
+          "hex": "eaa23e"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Imitated Wood",
+          "hex": "b6ab6b"
+        },
+        {
+          "name": "Khaki Green",
+          "hex": "b3c08a"
+        },
+        {
+          "name": "Khaki Grey",
+          "hex": "c5cea1"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "8fddff"
+        },
+        {
+          "name": "Military Green",
+          "hex": "48681d"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "84ead4"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7851"
+        },
+        {
+          "name": "Peach",
+          "hex": "fd86a6"
+        },
+        {
+          "name": "Pink",
+          "hex": "fdb6c6"
+        },
+        {
+          "name": "Purple",
+          "hex": "6f67ca"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2424"
+        },
+        {
+          "name": "Rose Red",
+          "hex": "ce0058"
+        },
+        {
+          "name": "Silver",
+          "hex": "9d9d9d"
+        },
+        {
+          "name": "Skin",
+          "hex": "ffdd9e"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "00a2e7"
+        },
+        {
+          "name": "Taro Purple",
+          "hex": "c4b4ff"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Watermelon Red",
+          "hex": "ff0077"
+        },
+        {
+          "name": "White",
+          "hex": "ecebe4"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffcd60"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/haosegd.json
+++ b/filaments/haosegd.json
@@ -1,0 +1,109 @@
+{
+  "manufacturer": "Haosegd",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2f60d0"
+        },
+        {
+          "name": "Green",
+          "hex": "80ff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c1a"
+        },
+        {
+          "name": "Yellow",
+          "hex": "dfd620"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Green",
+          "hex": "9ef0dc"
+        },
+        {
+          "name": "Orange",
+          "hex": "f05d38"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffe6de"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "808080"
+        }
+      ],
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/hellbot.json
+++ b/filaments/hellbot.json
@@ -1,0 +1,97 @@
+{
+  "manufacturer": "Hellbot",
+  "filaments": [
+    {
+      "name": "Ecofila PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "country_of_origin": "Argentina",
+      "colors": [
+        {
+          "name": "Agua",
+          "hex": "83ece0"
+        },
+        {
+          "name": "Amarillo",
+          "hex": "fbff00"
+        },
+        {
+          "name": "Blanco",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Celeste",
+          "hex": "00bfff"
+        },
+        {
+          "name": "Graphite Gray",
+          "hex": "383838"
+        },
+        {
+          "name": "Gray",
+          "hex": "b0b0b0"
+        },
+        {
+          "name": "Negro",
+          "hex": "000000"
+        },
+        {
+          "name": "Rojo",
+          "hex": "f00000"
+        },
+        {
+          "name": "Rosa/Pink",
+          "hex": "fe80ab"
+        },
+        {
+          "name": "Violeta/Violet",
+          "hex": "807dcc"
+        }
+      ]
+    },
+    {
+      "name": "Ecofila PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "country_of_origin": "Argentina",
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "165200"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/hello3d.json
+++ b/filaments/hello3d.json
@@ -1,0 +1,70 @@
+{
+    "manufacturer": "Hello3D",
+    "filaments": [
+        {
+            "name": "Hello3D PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                }
+            ]
+        },
+        {
+            "name": "Hello3D Silk PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 55,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                },
+                {
+                    "name": "Bronze",
+                    "hex": "CD7F32"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/hobbyking.json
+++ b/filaments/hobbyking.json
@@ -1,0 +1,195 @@
+{
+  "manufacturer": "Hobby King",
+  "filaments": [
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        235
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Purple to Pink",
+          "hex": "2e2947"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Purple-Pink-041",
+          "hex": "2e2947"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black-02",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "372015"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        235
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Dark Purple",
+          "hex": "471da7"
+        },
+        {
+          "name": "Light Green",
+          "hex": "54e75b"
+        },
+        {
+          "name": "Metallic Gold",
+          "hex": "b49741"
+        },
+        {
+          "name": "Metallic Silver",
+          "hex": "b7b7c0"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Purple",
+          "hex": "b61192"
+        },
+        {
+          "name": "Solid Red",
+          "hex": "fb2f24"
+        },
+        {
+          "name": "Water Blue",
+          "hex": "00d7d7"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/hobbylobby.json
+++ b/filaments/hobbylobby.json
@@ -1,0 +1,238 @@
+{
+  "manufacturer": "Hobby Lobby",
+  "filaments": [
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "White Marble",
+          "hex": "d6d6d6",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black/Pink",
+          "hexes": [
+            "000000",
+            "db1f79"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "d8d8d8"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.26,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3c39c6"
+        },
+        {
+          "name": "fire truck red",
+          "hex": "af0303"
+        },
+        {
+          "name": "Gray",
+          "hex": "7e8081"
+        },
+        {
+          "name": "Marble",
+          "hex": "d6d6d6"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8800"
+        },
+        {
+          "name": "Pink",
+          "hex": "eaa1b0"
+        },
+        {
+          "name": "Purple",
+          "hex": "4a2775"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Red (2589653)",
+          "hex": "500013"
+        },
+        {
+          "name": "Summer Reverie",
+          "hex": "ffff00"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood",
+          "hex": "887c7c"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red,Yellow,Blue,Green,Purple",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Beaver",
+          "hex": "836c46"
+        },
+        {
+          "name": "Wood",
+          "hex": "808080"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/hp3df.json
+++ b/filaments/hp3df.json
@@ -1,0 +1,462 @@
+{
+  "manufacturer": "HP 3DF",
+  "filaments": [
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Glitter White",
+          "hex": "ffffff",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Purple Silk",
+          "hex": "893fc6",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "63abf2"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow Blue",
+          "hex": "dddcd8"
+        },
+        {
+          "name": "Green",
+          "hex": "dac39d"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green (Army Green)",
+          "hex": "696a48"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7b00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "b87333"
+        },
+        {
+          "name": "Gold",
+          "hex": "efeb0c"
+        },
+        {
+          "name": "Green",
+          "hex": "1b5e08"
+        },
+        {
+          "name": "Silk Green",
+          "hex": "033d18"
+        },
+        {
+          "name": "Silk Red",
+          "hex": "d3102e"
+        },
+        {
+          "name": "Silver",
+          "hex": "97999b"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Shadow Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Skin Beige",
+          "hex": "ffe7da"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Matte Army Green",
+          "hex": "6d6e4c"
+        },
+        {
+          "name": "Matte Red",
+          "hex": "cf334a"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "058051"
+        },
+        {
+          "name": "Silk Purple",
+          "hex": "c22eb6"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "2dfd4f"
+        },
+        {
+          "name": "Pink",
+          "hex": "f787ce"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Red Gold",
+          "hex": "d3102e"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Red/Black",
+          "hexes": [
+            "ff0000",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        177,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Pink",
+          "hex": "da6084",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Glitter Pink Pla",
+          "hex": "ee719e",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Wood PLA",
+          "hex": "808080"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/hzst3d.json
+++ b/filaments/hzst3d.json
@@ -1,0 +1,169 @@
+{
+  "manufacturer": "HZST3D",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3d43a4"
+        },
+        {
+          "name": "Marble",
+          "hex": "b9b4b1"
+        },
+        {
+          "name": "Pink",
+          "hex": "f1a6f7"
+        },
+        {
+          "name": "Purple",
+          "hex": "362796"
+        },
+        {
+          "name": "Red",
+          "hex": "c50260"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffea00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gun Metal",
+          "hex": "818589"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Elixir Blue (Silver/Blue",
+          "hexes": [
+            "53aff4",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Purple",
+          "hex": "5a45ba"
+        },
+        {
+          "name": "Silk Bright Yellow",
+          "hex": "fee54f"
+        },
+        {
+          "name": "Silk Rose",
+          "hex": "cd0bba"
+        },
+        {
+          "name": "SPARKLE BLACK",
+          "hex": "070b0e"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Flame Orange",
+          "hex": "bf494b"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/i3dtested.json
+++ b/filaments/i3dtested.json
@@ -1,0 +1,237 @@
+{
+  "manufacturer": "I3D Tested",
+  "filaments": [
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Glitter Azul",
+          "hex": "24488f",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Glitter Negro",
+          "hex": "000000",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Glitter Verde",
+          "hex": "007a78",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Efecto Marmol",
+          "hex": "c1daec",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Carbon Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Oro Seda",
+          "hex": "fac80f"
+        },
+        {
+          "name": "Rosa Seda",
+          "hex": "eb4ada"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Amarillo",
+          "hex": "fcff38"
+        },
+        {
+          "name": "Azul Cielo",
+          "hex": "61bdff"
+        },
+        {
+          "name": "Blanco",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Gris",
+          "hex": "5e5c64"
+        },
+        {
+          "name": "Mandarina",
+          "hex": "ffae00"
+        },
+        {
+          "name": "Marrón",
+          "hex": "695454"
+        },
+        {
+          "name": "Naranja",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Negro",
+          "hex": "000000"
+        },
+        {
+          "name": "Piel",
+          "hex": "f3e2b4"
+        },
+        {
+          "name": "Purpura",
+          "hex": "8b2dd7"
+        },
+        {
+          "name": "Rojo",
+          "hex": "ff1a1a"
+        },
+        {
+          "name": "Rosa",
+          "hex": "f2b4f3"
+        },
+        {
+          "name": "Verde Filameno",
+          "hex": "00ff33"
+        },
+        {
+          "name": "Verde Oscuro",
+          "hex": "015b13"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "d6d6d7"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/iboss.json
+++ b/filaments/iboss.json
@@ -1,0 +1,958 @@
+{
+  "manufacturer": "iBOSS",
+  "filaments": [
+    {
+      "name": "Glitter {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Dot Purple",
+          "hex": "7556c7",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "19ae7f",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Purple",
+          "hex": "906edd",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Purple Red",
+          "hex": "5c2244",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "2884d4",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Water Blue",
+          "hex": "2cbbce",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent Glitter Purple",
+          "hex": "dbaeef",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White with Blue Glow",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White with Green Glow",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue White",
+          "hex": "dbf6fb"
+        },
+        {
+          "name": "Glitter Pink Blue Green",
+          "hex": "8fc9ef"
+        },
+        {
+          "name": "Glitter Rainbow",
+          "hex": "e09eb2"
+        },
+        {
+          "name": "Green White",
+          "hex": "51d981"
+        },
+        {
+          "name": "Orange White",
+          "hex": "e7936e"
+        },
+        {
+          "name": "Pink White",
+          "hex": "ffd4e6"
+        },
+        {
+          "name": "Purple White",
+          "hex": "9a79d6"
+        },
+        {
+          "name": "Transparent Blue Green",
+          "hex": "00b8ae"
+        },
+        {
+          "name": "Transparent Light Orange Green",
+          "hex": "f8bf5e"
+        },
+        {
+          "name": "Transparent Purple Blue",
+          "hex": "c0c9e4"
+        },
+        {
+          "name": "Transparent Red Blue Green",
+          "hex": "db8f95"
+        },
+        {
+          "name": "Transparent Rose Red Light Blue",
+          "hex": "fa8de9"
+        },
+        {
+          "name": "Transparent Rose Red Orange",
+          "hex": "fc994f"
+        },
+        {
+          "name": "White Purple Blue",
+          "hex": "92cefd"
+        },
+        {
+          "name": "Yellow Green White",
+          "hex": "ccdb81"
+        },
+        {
+          "name": "Yellow Orange White",
+          "hex": "f3e118"
+        },
+        {
+          "name": "Yellow White",
+          "hex": "f5efce"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent Purple Blue",
+          "hex": "941990"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b5bcc1",
+          "pattern": "marble"
+        },
+        {
+          "name": "Marble White",
+          "hex": "e9eded",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "Matte Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink Blue",
+          "hex": "e07b91"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 1194
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00ffff"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff5d29"
+        },
+        {
+          "name": "Pearlescent Gold",
+          "hex": "ffae00"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffbbe9"
+        },
+        {
+          "name": "Rose Pink",
+          "hex": "fd6ed8"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "blue",
+          "hex": "0056d6"
+        },
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Tri Color Gold Green Blue",
+          "hex": "c4bc00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Matte Dark Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "113dc0"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue & Purple Dual Color",
+          "hex": "3a58cf"
+        },
+        {
+          "name": "copper",
+          "hex": "f0ac19"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffe2a6"
+        },
+        {
+          "name": "Metalic Blue Silver Dual Color",
+          "hex": "283cd7"
+        },
+        {
+          "name": "Purple Silver Dual Color",
+          "hex": "b18cde"
+        },
+        {
+          "name": "Purple White Gradient",
+          "hex": "b18cde"
+        },
+        {
+          "name": "Red Blue Dual Color",
+          "hex": "cf3a49"
+        },
+        {
+          "name": "Sapphire Blue Line Green Dual Color",
+          "hex": "283cd7"
+        },
+        {
+          "name": "Silver",
+          "hex": "c4c4c4"
+        },
+        {
+          "name": "Tri Color (Silk Black, Red, Copper)",
+          "hex": "000000"
+        },
+        {
+          "name": "Violet",
+          "hex": "9b6af4"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White Purple Blue Gradient",
+          "hex": "b18cde"
+        },
+        {
+          "name": "Yellow and Green",
+          "hex": "d8e859"
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "fef25f"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "orange",
+          "hex": "ff8647"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00ffff"
+        },
+        {
+          "name": "Ebony Wood",
+          "hex": "808080"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "01bffe"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Skin tone",
+          "hex": "ffdfcc"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fefe81"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Candy Rainbow",
+          "hex": "7152a9"
+        },
+        {
+          "name": "transparent Rainbow",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black / Purple",
+          "hexes": [
+            "000000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / Gold",
+          "hexes": [
+            "0000ff",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / Silver",
+          "hexes": [
+            "0000ff",
+            "65b8f5"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue Green",
+          "hex": "0a99ff"
+        },
+        {
+          "name": "Blue Purple",
+          "hex": "00aaff"
+        },
+        {
+          "name": "Pink / Gold",
+          "hexes": [
+            "dba1c5",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / Black",
+          "hexes": [
+            "ff0000",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / Green",
+          "hexes": [
+            "ff0000",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red Green",
+          "hex": "66ff8c"
+        },
+        {
+          "name": "RedBlack",
+          "hex": "ff0000"
+        },
+        {
+          "name": "RedBlueGold",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow / Green",
+          "hexes": [
+            "ffff00",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Plus {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "SILK MACARON",
+          "hex": "ff80c0"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Rainbow Candy",
+          "hex": "f38bf2"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 1194
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue Green Purple",
+          "hex": "2c35e6"
+        },
+        {
+          "name": "Gold / Green / Purple",
+          "hexes": [
+            "ffd700",
+            "008000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold Green Blue",
+          "hex": "f0f1b7"
+        },
+        {
+          "name": "Red Blue Green",
+          "hex": "d42c73"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "c45685"
+        },
+        {
+          "name": "Tri-Color Black/Red/Copper",
+          "hexes": [
+            "0d0d0d",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Yellow/Orange/White",
+          "hexes": [
+            "ffff00",
+            "d7dbb8"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "47bc45"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Transparent Light Orange Green",
+          "hex": "ffba3a"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "b5eb98"
+        },
+        {
+          "name": "Purple Blue",
+          "hex": "e1519e"
+        },
+        {
+          "name": "Violet",
+          "hex": "c793fb"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ic3d.json
+++ b/filaments/ic3d.json
@@ -1,0 +1,104 @@
+{
+  "manufacturer": "IC3D",
+  "filaments": [
+    {
+      "name": "IC3D PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 600,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [200, 240],
+      "bed_temp_range": [0, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    },
+    {
+      "name": "IC3D PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 600,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [240, 270],
+      "bed_temp_range": [60, 80],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    },
+    {
+      "name": "IC3D ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 600,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 10000,
+          "spool_weight": 1500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [220, 260],
+      "bed_temp_range": [100, 110],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    }
+  ]
+}

--- a/filaments/ice.json
+++ b/filaments/ice.json
@@ -1,0 +1,263 @@
+{
+  "manufacturer": "ICE",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Flue Young Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Glamorous Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Naughty Natural",
+          "hex": "ebebeb"
+        },
+        {
+          "name": "Obstinate Orange",
+          "hex": "ff6a00"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Glow in the dark Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Glow-in-the-Dark (Fluorescent)",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PET {color_name}",
+      "material": "PET",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Cunning Clear",
+          "hex": "e5edf5"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        35,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Barbaric Brown",
+          "hex": "b35f00"
+        },
+        {
+          "name": "Brave Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Daring Darkgreen",
+          "hex": "0a9e6d"
+        },
+        {
+          "name": "Gentle Grey",
+          "hex": "c8c6c6"
+        },
+        {
+          "name": "Glamourous gold",
+          "hex": "c5ac0d"
+        },
+        {
+          "name": "Gracious Green",
+          "hex": "00f700"
+        },
+        {
+          "name": "Groovy Gold",
+          "hex": "785700"
+        },
+        {
+          "name": "Obstinate Orange",
+          "hex": "ff6a00"
+        },
+        {
+          "name": "Precious Pink",
+          "hex": "ff0084"
+        },
+        {
+          "name": "Romantic Red",
+          "hex": "bb1e10"
+        },
+        {
+          "name": "Sparkling sylver",
+          "hex": "697886"
+        },
+        {
+          "name": "Wintershine White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Young Yellow",
+          "hex": "f7b500"
+        }
+      ]
+    },
+    {
+      "name": "PVA {color_name}",
+      "material": "PVA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        210
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Naughty Natural",
+          "hex": "fff18c"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "27c480"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Original Oak",
+          "hex": "eaba15"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/iemai.json
+++ b/filaments/iemai.json
@@ -1,0 +1,61 @@
+{
+    "manufacturer": "IEMAI",
+    "filaments": [
+        {
+            "name": "IEMAI PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                }
+            ]
+        },
+        {
+            "name": "IEMAI PC {color_name}",
+            "material": "PC",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 260,
+            "bed_temp": 100,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "00000000"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/igus.json
+++ b/filaments/igus.json
@@ -1,0 +1,201 @@
+{
+  "manufacturer": "igus",
+  "filaments": [
+    {
+      "name": "iglide i150-PF {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "iglide i151-PF {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        }
+      ]
+    },
+    {
+      "name": "iglide i180-PF {color_name}",
+      "material": "PA",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 700
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "iglide i190-PF {color_name}",
+      "material": "PA",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "iglide J260-PF {color_name}",
+      "material": "PA",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "iglide A350-PF {color_name}",
+      "material": "PA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        340,
+        360
+      ],
+      "bed_temp_range": [
+        160,
+        180
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        }
+      ]
+    },
+    {
+      "name": "iglide RW370-PF {color_name}",
+      "material": "PA",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        350,
+        360
+      ],
+      "bed_temp_range": [
+        160,
+        180
+      ],
+      "country_of_origin": "Germany",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/iiidmax.json
+++ b/filaments/iiidmax.json
@@ -1,0 +1,1090 @@
+{
+  "manufacturer": "IIID MAX",
+  "filaments": [
+    {
+      "name": "Classic PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "8db600",
+          "codes": [
+            "APPLE-GREEN-PLA"
+          ]
+        },
+        {
+          "name": "Army Green",
+          "hex": "4b5320",
+          "codes": [
+            "NEW-ARMY-GREEN-PLA"
+          ]
+        },
+        {
+          "name": "Baby Blue",
+          "hex": "89cff0",
+          "codes": [
+            "BABY-BLUE-PLA"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "BLACK-PLA"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "BLUE-PLA"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "NEW-BROWN-PLA"
+          ]
+        },
+        {
+          "name": "Burnt Orange",
+          "hex": "cc5500",
+          "codes": [
+            "BURNT-ORANGE-PLA"
+          ]
+        },
+        {
+          "name": "Candy Red",
+          "hex": "ff0800",
+          "codes": [
+            "CANDY-RED-PLA"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "COPPER-PLA"
+          ]
+        },
+        {
+          "name": "Coyote Brown",
+          "hex": "81613c",
+          "codes": [
+            "COYOTE-BROWN-PLA"
+          ]
+        },
+        {
+          "name": "Crystal",
+          "hex": "ffffff80",
+          "translucent": true,
+          "codes": [
+            "CRYSTAL-PLA"
+          ]
+        },
+        {
+          "name": "Emerald",
+          "hex": "50c878",
+          "codes": [
+            "EMERALD-PLA"
+          ]
+        },
+        {
+          "name": "Fluo Yellow",
+          "hex": "ccff00",
+          "glow": true,
+          "codes": [
+            "FLUO-YELLOW-PLA"
+          ]
+        },
+        {
+          "name": "Forest Green",
+          "hex": "228b22",
+          "codes": [
+            "FOREST-GREEN-PLA"
+          ]
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "ff00ff",
+          "codes": [
+            "FUCHSIA-PLA"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700",
+          "codes": [
+            "GOLD-PLA"
+          ]
+        },
+        {
+          "name": "Key Lime",
+          "hex": "e8f48c",
+          "codes": [
+            "KEY-LIME-PLA"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "add8e6",
+          "codes": [
+            "LIGHT-BLUE-PLA"
+          ]
+        },
+        {
+          "name": "Light Orange",
+          "hex": "ffb347",
+          "codes": [
+            "LIGHT-ORANGE-PLA"
+          ]
+        },
+        {
+          "name": "Light Pink",
+          "hex": "ffb6c1",
+          "codes": [
+            "LIGHT-PINK-PLA"
+          ]
+        },
+        {
+          "name": "Mystic Purple",
+          "hex": "9b59b6",
+          "codes": [
+            "MYSTIC-PURPLE-PLA"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000080",
+          "codes": [
+            "NAVY-BLUE-PLA"
+          ]
+        },
+        {
+          "name": "Night Gray",
+          "hex": "404040",
+          "codes": [
+            "NIGHT-GRAY-PLA"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "NEW-ORANGE-PLA"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb",
+          "codes": [
+            "PINK-PLA"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "RED-PLA"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "SILVER-PLA"
+          ]
+        },
+        {
+          "name": "Space Gray",
+          "hex": "717378",
+          "codes": [
+            "SPACE-GRAY-PLA"
+          ]
+        },
+        {
+          "name": "Tan",
+          "hex": "d2b48c",
+          "codes": [
+            "TAN-PLA"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "008080",
+          "codes": [
+            "TEAL-PLA"
+          ]
+        },
+        {
+          "name": "Vanilla Cream",
+          "hex": "fffdd0",
+          "codes": [
+            "VANILLA-PLA"
+          ]
+        },
+        {
+          "name": "Vintage Rose",
+          "hex": "c08081",
+          "codes": [
+            "VINTAGE-ROSE-PLA"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "8b00ff",
+          "codes": [
+            "VIOLET-PLA"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "WHITE-PLA"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "YELLOW-PLA"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "High Speed PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320",
+          "codes": [
+            "IIID-HS-PETG-ARMY-GREEN"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "IIID-HS-PETG-BLACK"
+          ]
+        },
+        {
+          "name": "Crystal",
+          "hex": "ffffff80",
+          "translucent": true,
+          "codes": [
+            "IIID-HS-PETG-CLEAR-CRYSTAL"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PETG-DARK-BLUE"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PETG-GREY"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "IIID-HS-PETG-ORANGE"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PETG-PURPLE"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "IIID-HS-PETG-RED"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "IIID-HS-PETG-WHITE"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "IIID-HS-PETG-YELLOW"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "High Speed PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320",
+          "codes": [
+            "IIID-HS-PLA-ARMYGREEN"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "IIID-HS-PLA-BLACK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "IIID-HS-PLA-BLUE"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "IIID-HS-PLA-BROWN"
+          ]
+        },
+        {
+          "name": "Burgundy",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-BURGUNDY"
+          ]
+        },
+        {
+          "name": "Chocolate",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-CHOCOLATE"
+          ]
+        },
+        {
+          "name": "Cream Pink",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-CREAM-PINK"
+          ]
+        },
+        {
+          "name": "Crystal",
+          "hex": "ffffff80",
+          "translucent": true,
+          "codes": [
+            "IIID-HS-PLA-CRYSTAL"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-DARKGREEN"
+          ]
+        },
+        {
+          "name": "Deep Cyan",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-DEEPCYAN"
+          ]
+        },
+        {
+          "name": "Dove Grey",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-DOVE-GREY"
+          ]
+        },
+        {
+          "name": "Duvet Yellow",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-DUVETYELLOW"
+          ]
+        },
+        {
+          "name": "Ebony Color",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-EBONY"
+          ]
+        },
+        {
+          "name": "Emerald",
+          "hex": "50c878",
+          "codes": [
+            "IIID-HS-PLA-EMERALDGREEN"
+          ]
+        },
+        {
+          "name": "Faux Wood",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-FAUX-WOOD"
+          ]
+        },
+        {
+          "name": "Fluo Blue",
+          "hex": "808080",
+          "glow": true,
+          "codes": [
+            "IIID-HS-PLA-FLUOBLUE"
+          ]
+        },
+        {
+          "name": "Fluo Green",
+          "hex": "808080",
+          "glow": true,
+          "codes": [
+            "IIID-HS-PLA-FLUOGREEN"
+          ]
+        },
+        {
+          "name": "Fluo Orange",
+          "hex": "808080",
+          "glow": true,
+          "codes": [
+            "IIID-HS-PLA-FLUOORANGE"
+          ]
+        },
+        {
+          "name": "Fluo Red",
+          "hex": "808080",
+          "glow": true,
+          "codes": [
+            "IIID-HS-PLA-FLUORED"
+          ]
+        },
+        {
+          "name": "Frosty Desert Yellow",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-FROSTYYELLOW"
+          ]
+        },
+        {
+          "name": "Grayish Green",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-GRAYISHGREEN"
+          ]
+        },
+        {
+          "name": "Lavender",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-LAVENDER"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "add8e6",
+          "codes": [
+            "IIID-HS-PLA-LIGHTBLUE"
+          ]
+        },
+        {
+          "name": "Light Pink",
+          "hex": "ffb6c1",
+          "codes": [
+            "IIID-HS-PLA-LIGHTPINK"
+          ]
+        },
+        {
+          "name": "Lotus Pink",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-LOTUSSPINK"
+          ]
+        },
+        {
+          "name": "Mahogany",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MAHOGANY"
+          ]
+        },
+        {
+          "name": "Matte Black",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-BLACK"
+          ]
+        },
+        {
+          "name": "Matte Cold Grey",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-COLDGREY"
+          ]
+        },
+        {
+          "name": "Matte Glacier Blue",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-GLACIERBLUE"
+          ]
+        },
+        {
+          "name": "Matte Graphite",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-MATTE-GRAPHITE"
+          ]
+        },
+        {
+          "name": "Matte Green Plum",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-GREENPLUM"
+          ]
+        },
+        {
+          "name": "Matte Lavender",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-LAVENDER"
+          ]
+        },
+        {
+          "name": "Matte Mystic Purple",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-MYSTIC"
+          ]
+        },
+        {
+          "name": "Matte Oats",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-OATS"
+          ]
+        },
+        {
+          "name": "Matte Pumpkin",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-PUMPKIN"
+          ]
+        },
+        {
+          "name": "Matte Red",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-RED"
+          ]
+        },
+        {
+          "name": "Matte White",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-MATTE-WHITE"
+          ]
+        },
+        {
+          "name": "Ochre",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-OCHRE"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "IIID-HS-PLA-ORANGE"
+          ]
+        },
+        {
+          "name": "Peach",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-PEACH"
+          ]
+        },
+        {
+          "name": "Pine Green",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-PINEGREEN"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb",
+          "codes": [
+            "IIID-HS-PLA-PINK"
+          ]
+        },
+        {
+          "name": "Purplish Red",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-PURPLISHRED"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "IIID-HS-PLA-RED"
+          ]
+        },
+        {
+          "name": "Scallion Green",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-SCALGREEN"
+          ]
+        },
+        {
+          "name": "Skin",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-SKIN"
+          ]
+        },
+        {
+          "name": "Space Gray",
+          "hex": "717378",
+          "codes": [
+            "IIID-HS-PLA-SPACEGRAY"
+          ]
+        },
+        {
+          "name": "Turquoise",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-TURQUOISE"
+          ]
+        },
+        {
+          "name": "Vanilla",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-VANILLA"
+          ]
+        },
+        {
+          "name": "Vintage Brass",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-VINTAGE-BRASS"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "8b00ff",
+          "codes": [
+            "IIID-HS-PLA-VIOLET"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "IIID-HS-PLA-WHITE"
+          ]
+        },
+        {
+          "name": "White Oak",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-PLA-WHITE-OAK"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "IIID-HS-PLA-YELLOW"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "High Speed Silk PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Blue-Green-Orange",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-SILK-BLUEGREENORANGE"
+          ]
+        },
+        {
+          "name": "Dual Silk Lavender",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-LAVENDER"
+          ]
+        },
+        {
+          "name": "Gold-Green-Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-SILK-GOLDGREENFUCHSIA"
+          ]
+        },
+        {
+          "name": "Red-Gold-Black",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-SILK-REDGOLDBLACK"
+          ]
+        },
+        {
+          "name": "Red-Green-Blue",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-SILK-REDGREENBLUE"
+          ]
+        },
+        {
+          "name": "Silk Black",
+          "hex": "1a1a1a",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-BLACK"
+          ]
+        },
+        {
+          "name": "Silk Black-Purple",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-BLACKPURPLE"
+          ]
+        },
+        {
+          "name": "Silk Black-Red",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-BLACKRED"
+          ]
+        },
+        {
+          "name": "Silk Blue",
+          "hex": "4169e1",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-BLUE"
+          ]
+        },
+        {
+          "name": "Silk Blue-Green",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-BLUEGREEN"
+          ]
+        },
+        {
+          "name": "Silk Blue-Orange",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-BLUEORANGE"
+          ]
+        },
+        {
+          "name": "Silk Blue-Red",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-BLUERED"
+          ]
+        },
+        {
+          "name": "Silk Bronze",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-PLA-BRONZE"
+          ]
+        },
+        {
+          "name": "Silk Bronze-Orange",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-BRONZEORANGE"
+          ]
+        },
+        {
+          "name": "Silk Copper",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-PLA-COPPER"
+          ]
+        },
+        {
+          "name": "Silk Gold",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-PLA-GOLD"
+          ]
+        },
+        {
+          "name": "Silk Green-Orange",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-GREENORANGE"
+          ]
+        },
+        {
+          "name": "Silk Orange",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-ORANGE"
+          ]
+        },
+        {
+          "name": "Silk Pink",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-PINK"
+          ]
+        },
+        {
+          "name": "Silk Purple",
+          "hex": "800080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-PURPLE"
+          ]
+        },
+        {
+          "name": "Silk Purple-Blue",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-PURPLEBLUE"
+          ]
+        },
+        {
+          "name": "Silk Rainbow 1",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-RAINBOW-1"
+          ]
+        },
+        {
+          "name": "Silk Rainbow 2",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-RAINBOW-2"
+          ]
+        },
+        {
+          "name": "Silk Rainbow 3",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-RAINBOW-3"
+          ]
+        },
+        {
+          "name": "Silk Red",
+          "hex": "dc143c",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-RED"
+          ]
+        },
+        {
+          "name": "Silk Red-Green",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-REDGREEN"
+          ]
+        },
+        {
+          "name": "Silk RoseRed-Green",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-DUALSILK-ROSEGREEN"
+          ]
+        },
+        {
+          "name": "Silk Yellow",
+          "hex": "808080",
+          "finish": "glossy",
+          "codes": [
+            "IIID-HS-SILK-YELLOW"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "High Speed TPU {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Bamboo Green",
+          "hex": "7bb661",
+          "codes": [
+            "IIID-HS-TPU-BAMBOO-GREEN"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "IIID-HS-TPU-BLACK"
+          ]
+        },
+        {
+          "name": "Gemstone Blue",
+          "hex": "808080",
+          "codes": [
+            "IIID-HS-TPU-GEMSTONE-BLUE"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "IIID-HS-TPU-ORANGE"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": [
+            "IIID-HS-TPU-RED"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "IIID-HS-TPU-YELLOW"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/iksystem.json
+++ b/filaments/iksystem.json
@@ -1,0 +1,221 @@
+{
+  "manufacturer": "IkSystem",
+  "filaments": [
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Macaron Series",
+          "hex": "b0b0d9"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold & Purple",
+          "hex": "5d1584"
+        }
+      ]
+    },
+    {
+      "name": "Silk Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red Blue",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Red Blue Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Green",
+          "hex": "c600c6"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "f78a6e"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red/Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Purple Black",
+          "hex": "00006f"
+        },
+        {
+          "name": "Blue/Green/Orange",
+          "hexes": [
+            "0000ff",
+            "008000",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue/Yellow/Rose",
+          "hexes": [
+            "0000ff",
+            "ffff00",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold Blue Copper",
+          "hex": "f0be13"
+        },
+        {
+          "name": "Gold Blue Green",
+          "hex": "e09812"
+        },
+        {
+          "name": "Gold Fuchsia Black",
+          "hex": "ffb539"
+        },
+        {
+          "name": "Gold Green Black",
+          "hex": "ffb415"
+        },
+        {
+          "name": "Gold/Purple/Red",
+          "hexes": [
+            "ffd700",
+            "800080",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red Gold Blue",
+          "hex": "bb0000"
+        },
+        {
+          "name": "Red/Green/Blue",
+          "hexes": [
+            "ff0000",
+            "008000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Yellow/Blue",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/inkstation.json
+++ b/filaments/inkstation.json
@@ -1,0 +1,367 @@
+{
+  "manufacturer": "InkStation",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Grey",
+          "hex": "9e9e9e"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Uv {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "White to Blue",
+          "hex": "2238bf"
+        },
+        {
+          "name": "White to Purple",
+          "hex": "9222c4"
+        },
+        {
+          "name": "White to Red",
+          "hex": "ec2f83"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        245
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Fluorescent Yellow",
+          "hex": "eeff00"
+        },
+        {
+          "name": "Pink",
+          "hex": "e792ac"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "e4ff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brass",
+          "hex": "be8225"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Blue Grey",
+          "hex": "79a4dd"
+        },
+        {
+          "name": "Bone White",
+          "hex": "e5dbc5"
+        },
+        {
+          "name": "Cherry Red",
+          "hex": "dd2f50"
+        },
+        {
+          "name": "Chocolate",
+          "hex": "713600"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "22311c"
+        },
+        {
+          "name": "Fuschia",
+          "hex": "e900ee"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "2ba48c"
+        },
+        {
+          "name": "Jungle Green",
+          "hex": "29ab87"
+        },
+        {
+          "name": "Purple",
+          "hex": "bdb1f8"
+        },
+        {
+          "name": "Ryobi Green",
+          "hex": "aef755"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbd911"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow #01",
+          "hex": "eb2d66"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        235
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Wood Grain",
+          "hex": "9a6e23"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/inland.json
+++ b/filaments/inland.json
@@ -1,0 +1,665 @@
+{
+    "manufacturer": "Inland",
+    "filaments": [
+        {
+            "name": "PLA Basic {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "True Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "True Green",
+                    "hex": "00FF00"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "A52A2A"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFC0CB"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Neon Orange",
+                    "hex": "FF5F1F"
+                },
+                {
+                    "name": "Neon Yellow",
+                    "hex": "FFFF33"
+                }
+            ]
+        },
+        {
+            "name": "PLA+ {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "True Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "A52A2A"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                }
+            ]
+        },
+        {
+            "name": "PLA+ Spooless {color_name}",
+            "material": "PLA+",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "True Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "A52A2A"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                }
+            ]
+        },
+        {
+            "name": "PLA Matte {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 200.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000",
+                    "finish": "matte"
+                }
+            ]
+        },
+        {
+            "name": "PLA Glow in Dark {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 300.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Rainbow",
+                    "hex": "FFFFFF",
+                    "glow": true
+                }
+            ]
+        },
+        {
+            "name": "PLA Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 300.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Silk Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Silk Gold",
+                    "hex": "FFD700"
+                }
+            ]
+        },
+        {
+            "name": "PLA Dual Color Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 200.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Blue-Green",
+                    "hexes": ["0000FF", "008000"],
+                    "multi_color_direction": "coaxial"
+                }
+            ]
+        },
+        {
+            "name": "PLA Dual Color Matte {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 300.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "bed_temp": 70,
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Black-White",
+                    "hexes": ["000000", "FFFFFF"],
+                    "multi_color_direction": "coaxial"
+                },
+                {
+                    "name": "Blue-Light Blue",
+                    "hexes": ["0000FF", "ADD8E6"],
+                    "multi_color_direction": "coaxial"
+                },
+                {
+                    "name": "Blue-Red",
+                    "hexes": ["0000FF", "FF0000"],
+                    "multi_color_direction": "coaxial"
+                },
+                {
+                    "name": "Pink-Red",
+                    "hexes": ["FFC0CB", "FF0000"],
+                    "multi_color_direction": "coaxial"
+                }
+            ]
+        },
+        {
+            "name": "PETG+ {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Clear",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Blue",
+                    "hex": "ADD8E6",
+                    "translucent": true
+                },
+                {
+                    "name": "Translucent Purple",
+                    "hex": "DDA0DD",
+                    "translucent": true
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                }
+            ]
+        },
+        {
+            "name": "PETG {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Dark Gray",
+                    "hex": "404040"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "PETG High Speed {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                }
+            ]
+        },
+        {
+            "name": "PETG-CF {color_name}",
+            "material": "PETG-CF",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "fill": "carbon fiber",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Antique Brass",
+                    "hex": "CD7F32"
+                },
+                {
+                    "name": "Blackish Green",
+                    "hex": "006400"
+                },
+                {
+                    "name": "Blackish Red",
+                    "hex": "8B0000"
+                }
+            ]
+        },
+        {
+            "name": "PolyLite ASA {color_name}",
+            "material": "ASA",
+            "density": 1.07,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 100,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        },
+        {
+            "name": "TPU {color_name}",
+            "material": "TPU",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 230,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Red Color Change",
+                    "hexes": ["FF0000", "FFFFFF"],
+                    "multi_color_direction": "longitudinal"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        },
+        {
+            "name": "Nylon Carbon Fiber {color_name}",
+            "material": "PA-CF",
+            "density": 1.14,
+            "weights": [
+                {
+                    "weight": 500,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 270,
+            "bed_temp": 80,
+            "fill": "carbon fiber",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        },
+        {
+            "name": "PLA Twinkling {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "pattern": "sparkle",
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "FFD700",
+                    "pattern": "sparkle"
+                }
+            ]
+        },
+        {
+            "name": "PLA Tough Metallic {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Bronze",
+                    "hex": "CD7F32"
+                }
+            ]
+        },
+        {
+            "name": "PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 300,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black-Red",
+                    "hexes": ["000000", "FF0000"],
+                    "multi_color_direction": "longitudinal"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/innofil3d.json
+++ b/filaments/innofil3d.json
@@ -1,0 +1,556 @@
+{
+  "manufacturer": "Innofil3D",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.26,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "White",
+          "hex": "f2f2f2"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "c01010"
+        },
+        {
+          "name": "Blue",
+          "hex": "1010c0"
+        }
+      ]
+    },
+    {
+      "name": "PET {color_name}",
+      "material": "PET",
+      "density": 1.34,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        70,
+        75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Netherlands",
+      "tds_url": "https://cdn-reichelt.de/documents/datenblatt/E400/INNOFIL_ABS_DB-EN.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "White",
+          "hex": "f2f2f2"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "c01010"
+        },
+        {
+          "name": "Blue",
+          "hex": "1010c0"
+        },
+        {
+          "name": "Green",
+          "hex": "228b22"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "Flex45 {color_name}",
+      "material": "TPU-45A",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "Flex60 {color_name}",
+      "material": "TPU-60A",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "rPET {color_name}",
+      "material": "PET",
+      "density": 1.34,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        70,
+        75
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "PRO1 {color_name}",
+      "material": "PLA+",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "White",
+          "hex": "f2f2f2"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "ABS Fusion+ {color_name}",
+      "material": "ABS",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        120
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "White",
+          "hex": "f2f2f2"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.06,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        120
+      ],
+      "country_of_origin": "Netherlands",
+      "tds_url": "https://cdn-reichelt.de/documents/datenblatt/E400/INNOFIL_ASA_DB-EN.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "White",
+          "hex": "f2f2f2"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "f2f2f2"
+        },
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "PP {color_name}",
+      "material": "PP",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        },
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ]
+    },
+    {
+      "name": "PET CF15 {color_name}",
+      "material": "PET-CF15",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        75
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ]
+    },
+    {
+      "name": "PAHT CF15 {color_name}",
+      "material": "PA-CF15",
+      "density": 1.18,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        120
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "Netherlands",
+      "tds_url": "https://www.dim3nsions.ch/files/Diverse/TDS/Innofil3D_PAHT_CF15_TDS_EN_v2.0.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ]
+    },
+    {
+      "name": "PP GF30 {color_name}",
+      "material": "PP-GF30",
+      "density": 0.94,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        20,
+        40
+      ],
+      "fill": "glass fiber",
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ]
+    },
+    {
+      "name": "PA {color_name}",
+      "material": "PA",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        120
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    },
+    {
+      "name": "TPU 85A {color_name}",
+      "material": "TPU-85A",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        30,
+        40
+      ],
+      "country_of_origin": "Netherlands",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "Natural",
+          "hex": "f1dfb9"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/inslogic.json
+++ b/filaments/inslogic.json
@@ -1,0 +1,27 @@
+{
+  "manufacturer": "Inslogic",
+  "filaments": [
+    {
+      "name": "Inslogic PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 150,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [25, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    }
+  ]
+}

--- a/filaments/isanghu.json
+++ b/filaments/isanghu.json
@@ -1,0 +1,358 @@
+{
+    "manufacturer": "iSANGHU",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 4000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0888B8"
+                },
+                {
+                    "name": "Green",
+                    "hex": "49B864"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "9A9A98"
+                },
+                {
+                    "name": "Light Purple",
+                    "hex": "CEB0D1"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "E86848"
+                },
+                {
+                    "name": "Red",
+                    "hex": "C82848"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "918E90"
+                },
+                {
+                    "name": "Skin",
+                    "hex": "F8D8B8"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F8D858"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "965733"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "E8AE24"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                50,
+                80
+            ],
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "1B7AB8"
+                },
+                {
+                    "name": "Green",
+                    "hex": "0DA533"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "8A8889"
+                },
+                {
+                    "name": "Red",
+                    "hex": "D42E3A"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "E85A20"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E8C820"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "E8E8E8",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Red",
+                    "hex": "D83830",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Green",
+                    "hex": "2EAB58",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Blue",
+                    "hex": "3A7FD4",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "Translucent {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                250
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Transparent Clear",
+                    "hex": "DEEAEA",
+                    "translucent": true
+                },
+                {
+                    "name": "Teal Lily",
+                    "hex": "657DC5",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Fluorescent Green",
+                    "hex": "5FD456",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Light Purple",
+                    "hex": "C8A8E8",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Passionate Red",
+                    "hex": "E84858",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Sunset Orange",
+                    "hex": "F08848",
+                    "translucent": true
+                },
+                {
+                    "name": "Blue Purple Gradient",
+                    "hexes": [
+                        "4A7FD4",
+                        "9B7FD4"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "translucent": true
+                },
+                {
+                    "name": "Ocean Sunset Gradient",
+                    "hexes": [
+                        "F08040",
+                        "E85080",
+                        "8060C0"
+                    ],
+                    "multi_color_direction": "longitudinal",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG-CF",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                60,
+                75
+            ],
+            "fill": "carbon fiber",
+            "finish": "matte",
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "4A4947",
+                    "finish": "matte"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU-95A",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                240
+            ],
+            "bed_temp_range": [
+                35,
+                60
+            ],
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5"
+                },
+                {
+                    "name": "Transparent Blue",
+                    "hex": "1D54A4",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU-85A",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                },
+                {
+                    "weight": 2000.0,
+                    "spool_weight": 180,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                250
+            ],
+            "bed_temp_range": [
+                35,
+                50
+            ],
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/isanmate.json
+++ b/filaments/isanmate.json
@@ -1,0 +1,269 @@
+{
+    "manufacturer": "iSANMATE",
+    "filaments": [
+        {
+            "name": "PLA i5+ {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 350,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                220
+            ],
+            "bed_temp_range": [
+                35,
+                60
+            ],
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "262A2D"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FC2304"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "048FFC"
+                },
+                {
+                    "name": "Green",
+                    "hex": "07D65B"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E5B808"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "F8A102"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "8A8A8A"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFACB0"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "808A9B"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "E7B30E"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "EC7F2B"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 350,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                240,
+                260
+            ],
+            "bed_temp_range": [
+                60,
+                80
+            ],
+            "country_of_origin": "China",
+            "tds_url": "https://www.isanmate.com/wp-content/uploads/2025/08/PETG_TDS.pdf",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Red",
+                    "hex": "E31B0C"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0253F9"
+                },
+                {
+                    "name": "Green",
+                    "hex": "009E5F"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E7C100"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FC3605"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "A8A8A8"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "E8E8E8",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Red",
+                    "hex": "D21702",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Green",
+                    "hex": "09A743",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Blue",
+                    "hex": "1437E7",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 350,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                240
+            ],
+            "bed_temp": 50,
+            "country_of_origin": "China",
+            "tds_url": "https://www.isanmate.com/wp-content/uploads/2022/09/ABS_TDS.pdf",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "3C4249"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FA1C0A"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "145DD6"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00A17D"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "E0C400"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU-95A",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 350,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                250
+            ],
+            "bed_temp": 50,
+            "country_of_origin": "China",
+            "colors": [
+                {
+                    "name": "Orange",
+                    "hex": "DA4203"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF69B4"
+                },
+                {
+                    "name": "Red",
+                    "hex": "DB4004"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "D3110C"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "9E9E9E"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "1976D2"
+                },
+                {
+                    "name": "Green",
+                    "hex": "43A047"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "795548"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/jamghe.json
+++ b/filaments/jamghe.json
@@ -1,0 +1,164 @@
+{
+  "manufacturer": "Jamg He",
+  "filaments": [
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.28,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ],
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/jarees.json
+++ b/filaments/jarees.json
@@ -1,0 +1,438 @@
+{
+  "manufacturer": "Jarees",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Cyan",
+          "hex": "5fffff"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Magenta",
+          "hex": "d75c99"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Bronze",
+          "hex": "635849"
+        },
+        {
+          "name": "Bronze Gold",
+          "hex": "ac763f"
+        },
+        {
+          "name": "Metallic Silver",
+          "hex": "969694"
+        },
+        {
+          "name": "Red Green",
+          "hex": "59815b"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "5a6029"
+        },
+        {
+          "name": "Black",
+          "hex": "000019"
+        },
+        {
+          "name": "Light Brown",
+          "hex": "cabc8e"
+        }
+      ]
+    },
+    {
+      "name": "PETG Silk {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Metallic Bronze Gold",
+          "hex": "c49c48"
+        },
+        {
+          "name": "Metallic Red Copper",
+          "hex": "b87605"
+        },
+        {
+          "name": "Metallic Silver",
+          "hex": "bdbdbf"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Magenta Pink",
+          "hex": "d75c99"
+        },
+        {
+          "name": "Merlot Maroon",
+          "hex": "7f171f"
+        },
+        {
+          "name": "Red",
+          "hex": "e32400"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Dark Silver",
+          "hex": "646e8b"
+        },
+        {
+          "name": "Gold",
+          "hex": "c49c48"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "ad0000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "123518"
+        },
+        {
+          "name": "Blue Lagoon",
+          "hex": "00626f"
+        },
+        {
+          "name": "Brown",
+          "hex": "452928"
+        },
+        {
+          "name": "Racing Green",
+          "hex": "2b5757"
+        },
+        {
+          "name": "Sun Glare Lime Green",
+          "hex": "32cd32"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Cyan",
+          "hex": "5fffff"
+        },
+        {
+          "name": "Magenta Pink",
+          "hex": "e62de0"
+        },
+        {
+          "name": "Merlot Maroon",
+          "hex": "7f171f"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "b51a00"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Purple/Blue/Yellow/Red",
+          "hexes": [
+            "800080",
+            "0000ff",
+            "ffff00",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Purple",
+          "hex": "1c298d"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Jade Green",
+          "hex": "74efb6"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/jayo.json
+++ b/filaments/jayo.json
@@ -103,6 +103,10 @@
                 {
                     "name": "Matte Black",
                     "hex": "000000"
+                },
+                {
+                    "name": "Matte White",
+                    "hex": "FFFFFF"
                 }
             ]
         },
@@ -226,3 +230,4 @@
         }
     ]
 }
+

--- a/filaments/justmaker.json
+++ b/filaments/justmaker.json
@@ -1,0 +1,607 @@
+{
+  "manufacturer": "JUSTMAKER",
+  "filaments": [
+    {
+      "name": "64D {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        35,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Pantone 2735c",
+          "hex": "2e008b"
+        },
+        {
+          "name": "Rattan Purple 2655c",
+          "hex": "f8d3fd"
+        },
+        {
+          "name": "Shy Pink",
+          "hex": "ffb591"
+        },
+        {
+          "name": "Transparent White",
+          "hex": "ebebeb"
+        }
+      ]
+    },
+    {
+      "name": "68D {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Transparent White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        245
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Blue Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Dark Green",
+          "hex": "009483"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PETG-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Mgm",
+          "hex": "785800"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Glow In The Dark",
+          "hex": "ecf2f3"
+        }
+      ]
+    },
+    {
+      "name": "Gradient Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Baby Blue/White",
+          "hex": "8be6e6"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Blue 8203c",
+          "hex": "2fa5f9"
+        },
+        {
+          "name": "Champaign Gold",
+          "hex": "d4ccbe"
+        },
+        {
+          "name": "Coffee Gold",
+          "hex": "aa6443"
+        },
+        {
+          "name": "Rose Gold",
+          "hex": "9e6b66"
+        },
+        {
+          "name": "Space Gray",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "BROWN 731C",
+          "hex": "808080"
+        },
+        {
+          "name": "Forest Greent",
+          "hex": "22311d"
+        },
+        {
+          "name": "Yellow green",
+          "hex": "dffc03"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Coral Pink",
+          "hex": "e2a7e6"
+        },
+        {
+          "name": "Ice Blue",
+          "hex": "7fdef5"
+        },
+        {
+          "name": "Lavender",
+          "hex": "c1b1ed"
+        },
+        {
+          "name": "Milk Green",
+          "hex": "d9ebd3"
+        },
+        {
+          "name": "Rattan Purple",
+          "hex": "b589d2"
+        },
+        {
+          "name": "Slender Green",
+          "hex": "c1f0da"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "b08d57"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffa914"
+        },
+        {
+          "name": "Silk Silver",
+          "hex": "b5afaa"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "b08d57"
+        },
+        {
+          "name": "Brown",
+          "hex": "808080"
+        },
+        {
+          "name": "Copper",
+          "hex": "808080"
+        },
+        {
+          "name": "Dark Red",
+          "hex": "5c0700"
+        },
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Hot pink",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "cd001a"
+        },
+        {
+          "name": "Skin",
+          "hex": "ffdbac"
+        },
+        {
+          "name": "yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Chelsea Red",
+          "hex": "792123"
+        },
+        {
+          "name": "cherry red",
+          "hex": "bb4b53"
+        },
+        {
+          "name": "Clay",
+          "hex": "9a8765"
+        },
+        {
+          "name": "Ice Blue",
+          "hex": "70b8ff"
+        },
+        {
+          "name": "Kraft",
+          "hex": "d5c798"
+        },
+        {
+          "name": "Maple Red",
+          "hex": "c82d2d"
+        },
+        {
+          "name": "Mustard Green",
+          "hex": "a6a056"
+        },
+        {
+          "name": "Navy",
+          "hex": "020132"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "005787"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "426300"
+        },
+        {
+          "name": "Orange Red",
+          "hex": "d3693a"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9d624"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Burgundy Red (201c)",
+          "hex": "5c0700"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "bLACK",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/kaisertech.json
+++ b/filaments/kaisertech.json
@@ -1,0 +1,211 @@
+{
+  "manufacturer": "Kaisertech",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blau",
+          "hex": "0433ff"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Neon Green",
+          "hex": "4ee74b"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Red",
+          "hex": "ea0628"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "green",
+          "hex": "00ff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Forest green",
+          "hex": "213d3f"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "008080"
+        },
+        {
+          "name": "Grey",
+          "hex": "7a7575"
+        },
+        {
+          "name": "Orange",
+          "hex": "e4664b"
+        },
+        {
+          "name": "Red",
+          "hex": "eb0000"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Lila",
+          "hex": "d357fe"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "646464"
+        },
+        {
+          "name": "Orange",
+          "hex": "fcac65"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/keenevillageplastics.json
+++ b/filaments/keenevillageplastics.json
@@ -1,0 +1,352 @@
+{
+  "manufacturer": "Keene Village Plastics",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Battleship Gray",
+          "hex": "655f51"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Crimson",
+          "hex": "a6102d"
+        },
+        {
+          "name": "Fluorescent Green",
+          "hex": "5ec300"
+        },
+        {
+          "name": "Glow In The Dark Blue",
+          "hex": "51a3de"
+        },
+        {
+          "name": "Proper Purple",
+          "hex": "502d6d"
+        },
+        {
+          "name": "Stellar Black",
+          "hex": "3e393c"
+        },
+        {
+          "name": "Stellar Blue",
+          "hex": "004499"
+        },
+        {
+          "name": "Voron Red",
+          "hex": "ad2724"
+        }
+      ]
+    },
+    {
+      "name": "Crystal {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Glass",
+          "hex": "b5e8e4"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Stellar Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow in the Dark Green",
+          "hex": "74d96d"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Granite",
+          "hex": "bbc7d5"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Strawberry Pearl",
+          "hex": "861919"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        35,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Evergreen Pearl",
+          "hex": "0f3427"
+        },
+        {
+          "name": "Pearl Blueberry",
+          "hex": "00537f"
+        },
+        {
+          "name": "Bold Black",
+          "hex": "26272b"
+        },
+        {
+          "name": "Green",
+          "hex": "1b9a33"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "24ff27"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fff824"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Sparkle",
+          "hex": "2d2926"
+        },
+        {
+          "name": "Blue",
+          "hex": "b2b2b2"
+        },
+        {
+          "name": "Deep Blue",
+          "hex": "241160"
+        },
+        {
+          "name": "Deep Red",
+          "hex": "8a252d"
+        },
+        {
+          "name": "Purple",
+          "hex": "3f1f46"
+        },
+        {
+          "name": "Red",
+          "hex": "ba2328"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Yellow Edge Glow",
+          "hex": "c9c10a"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        210
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Tru Wood Cherry",
+          "hex": "906241"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/keleidi.json
+++ b/filaments/keleidi.json
@@ -1,0 +1,309 @@
+{
+  "manufacturer": "KELEIDI",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "7a7a7a"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glowing Green",
+          "hex": "d1f2d1"
+        },
+        {
+          "name": "Luminous Rainbow",
+          "hex": "a1e4af"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Blue",
+          "hex": "270fdb"
+        },
+        {
+          "name": "Brown",
+          "hex": "3f1d09"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "3ca47e"
+        },
+        {
+          "name": "Green",
+          "hex": "48eaac"
+        },
+        {
+          "name": "Metallic Copper",
+          "hex": "edd326"
+        },
+        {
+          "name": "Metallic Silver",
+          "hex": "e1eae9"
+        },
+        {
+          "name": "Orange",
+          "hex": "e9a52f"
+        },
+        {
+          "name": "Purple",
+          "hex": "61187c"
+        },
+        {
+          "name": "Red",
+          "hex": "e60a2b"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f8cb02"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        55
+      ],
+      "colors": [
+        {
+          "name": "black purple",
+          "hex": "000000"
+        },
+        {
+          "name": "Luminous Blue",
+          "hex": "999999"
+        },
+        {
+          "name": "Red Black",
+          "hex": "af2e3e"
+        },
+        {
+          "name": "ROSA PINK/PINK",
+          "hex": "ea9fcb"
+        },
+        {
+          "name": "Silver",
+          "hex": "c8d7ea"
+        },
+        {
+          "name": "SPARKLING BLUE",
+          "hex": "74c3fb"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "030305"
+        },
+        {
+          "name": "Pearly White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue Green",
+          "hex": "064ab7"
+        },
+        {
+          "name": "Red Black",
+          "hex": "af2e3e"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Candy",
+          "hex": "ff80c0"
+        },
+        {
+          "name": "CONJURE",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/kexcelled.json
+++ b/filaments/kexcelled.json
@@ -1,0 +1,126 @@
+{
+    "manufacturer": "Kexcelled",
+    "filaments": [
+        {
+            "name": "Kexcelled PLA K5 {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        },
+        {
+            "name": "Kexcelled PETG K5 {color_name}",
+            "material": "PETG",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 70,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "00000000"
+                }
+            ]
+        },
+        {
+            "name": "Kexcelled ABS K5 {color_name}",
+            "material": "ABS",
+            "density": 1.05,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 90,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "Kexcelled PLA K5 Matte {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Matte Black",
+                    "hex": "1C1C1C"
+                },
+                {
+                    "name": "Matte White",
+                    "hex": "F5F5F5"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/kimya.json
+++ b/filaments/kimya.json
@@ -1,0 +1,490 @@
+{
+  "manufacturer": "Kimya",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203250001",
+            "3203250002"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS-R {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 2200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203220015"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS-S {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 2200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203020003",
+            "3203020011"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS-R {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203210002"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PA6-CO {color_name}",
+      "material": "PA6",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203310004"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PC-FR {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        310
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203060003"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203130005"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG-R {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203120033",
+            "3203120036",
+            "3203120037",
+            "3203120038",
+            "3203120040"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG-S {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 2200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203120001",
+            "3203120004",
+            "3203120011",
+            "3203120017",
+            "3203120029"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA-R {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 2200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203010052"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PPSU-S {color_name}",
+      "material": "PPSU",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        360,
+        400
+      ],
+      "bed_temp_range": [
+        120,
+        150
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203260001"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TPC-91A {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203050004",
+            "3203050005",
+            "3203050007",
+            "3203050008",
+            "3203050009"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TPC-ESD {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203220005"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TPU-92A {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203050015"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "3203010022"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/kingroon.json
+++ b/filaments/kingroon.json
@@ -1,0 +1,73 @@
+{
+    "manufacturer": "Kingroon",
+    "filaments": [
+        {
+            "name": "Kingroon PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 150
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        },
+        {
+            "name": "Kingroon PETG {color_name}",
+            "material": "PETG",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 150
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 70,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/kiwifil.json
+++ b/filaments/kiwifil.json
@@ -1,0 +1,759 @@
+{
+  "manufacturer": "KiwiFil",
+  "filaments": [
+    {
+      "name": "rPLA pro {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "Blossom",
+          "hex": "FFB7C5"
+        },
+        {
+          "name": "Bone White",
+          "hex": "E8E0D0"
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "FF85C0"
+        },
+        {
+          "name": "Clear",
+          "hex": "E8F4F8",
+          "translucent": true
+        },
+        {
+          "name": "Cranberry",
+          "hex": "9B1B30"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "5C3317"
+        },
+        {
+          "name": "Dark Forest Green",
+          "hex": "1B4D3E"
+        },
+        {
+          "name": "Fluorescent Pink",
+          "hex": "FF1493"
+        },
+        {
+          "name": "Fluorescent Yellow",
+          "hex": "CCFF00"
+        },
+        {
+          "name": "Frosted",
+          "hex": "D8DEE6",
+          "translucent": true
+        },
+        {
+          "name": "Gold",
+          "hex": "D4AF37"
+        },
+        {
+          "name": "Green",
+          "hex": "228B22"
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "FF69B4"
+        },
+        {
+          "name": "Light Brown",
+          "hex": "C4A484"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "B0B0B0"
+        },
+        {
+          "name": "Light Marble",
+          "hex": "D8D0C8",
+          "pattern": "marble"
+        },
+        {
+          "name": "Lilac",
+          "hex": "C8A2C8"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "32CD32"
+        },
+        {
+          "name": "Machinery Grey",
+          "hex": "6E6E6E"
+        },
+        {
+          "name": "Mauve",
+          "hex": "B784A7"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "556B2F"
+        },
+        {
+          "name": "Orange",
+          "hex": "FF8C00"
+        },
+        {
+          "name": "Peachy Beige",
+          "hex": "E8C4A0"
+        },
+        {
+          "name": "Powertool Green",
+          "hex": "3D7C3F"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Race Car Red",
+          "hex": "CC0000"
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "1E3A8A"
+        },
+        {
+          "name": "Silver Grey",
+          "hex": "A8A8A8"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "4DA6FF"
+        },
+        {
+          "name": "Sparkly Black",
+          "hex": "1A1A1A",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sparkly Green",
+          "hex": "2E8B57",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sparkly Pink",
+          "hex": "FF69B4",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sparkly Purple",
+          "hex": "800080",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sparkly Red",
+          "hex": "C01010",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Teal",
+          "hex": "008080"
+        },
+        {
+          "name": "Terracotta",
+          "hex": "C06040"
+        },
+        {
+          "name": "Translucent Blue",
+          "hex": "4A90C8",
+          "translucent": true
+        },
+        {
+          "name": "Translucent White",
+          "hex": "F5F5F0",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "hex": "F2F2F2"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFD700"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "rPLA pro (Recycled 3D Prints) {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Recycled Black",
+          "hex": "101010"
+        },
+        {
+          "name": "Recycled Blue",
+          "hex": "2060C0"
+        },
+        {
+          "name": "Recycled Green",
+          "hex": "228B22"
+        },
+        {
+          "name": "Recycled Orange",
+          "hex": "FF8C00"
+        },
+        {
+          "name": "Recycled Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Recycled Red",
+          "hex": "C01010"
+        },
+        {
+          "name": "White-ish",
+          "hex": "E8E4DC"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "UFO Filament {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Matte Black",
+          "hex": "1A1A1A",
+          "finish": "matte"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "Silk rPLA {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2060C0",
+          "finish": "glossy"
+        },
+        {
+          "name": "Bronze",
+          "hex": "CD7F32",
+          "finish": "glossy"
+        },
+        {
+          "name": "Gold",
+          "hex": "D4AF37",
+          "finish": "glossy"
+        },
+        {
+          "name": "Green",
+          "hex": "228B22",
+          "finish": "glossy"
+        },
+        {
+          "name": "Pink",
+          "hex": "FF69B4",
+          "finish": "glossy"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "finish": "glossy"
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0",
+          "finish": "glossy"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "finish": "glossy",
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "Sparkly rPLA pro {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Sparkly Green Ocean",
+          "hex": "1E6B5C",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Sparkly Purple Galaxy",
+          "hex": "4A2C6A",
+          "pattern": "sparkle"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "pattern": "sparkle",
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "Rainbow rPLA pro {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Bubblegum Clouds",
+          "hexes": [
+            "FFB6C1",
+            "FF85C0",
+            "E8F4FF"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rustic Rainbow",
+          "hexes": [
+            "C06040",
+            "8B4513",
+            "D4AF37",
+            "556B2F",
+            "4A2C2A"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Sparkly Green Ocean",
+          "hexes": [
+            "1E6B5C",
+            "2E8B57",
+            "4DA6FF"
+          ],
+          "pattern": "sparkle",
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Sparkly Jungle",
+          "hexes": [
+            "2D5A27",
+            "3D7C3F",
+            "556B2F"
+          ],
+          "pattern": "sparkle",
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Sparkly Purple Galaxy",
+          "hexes": [
+            "4A2C6A",
+            "800080",
+            "1A1A2E"
+          ],
+          "pattern": "sparkle",
+          "multi_color_direction": "longitudinal"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "multi_color_direction": "longitudinal",
+      "pattern": "sparkle",
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "WoolyFil rPLA {color_name}",
+      "material": "PLA",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Green Marble",
+          "hex": "3D6B4F",
+          "pattern": "marble"
+        },
+        {
+          "name": "Riverstone",
+          "hex": "8B8680"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "density": 1.24,
+      "pattern": "marble",
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "rPETG {color_name}",
+      "material": "PETG",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        },
+        {
+          "name": "Blossom",
+          "hex": "FFB7C5"
+        },
+        {
+          "name": "Bone White",
+          "hex": "E8E0D0"
+        },
+        {
+          "name": "Bottle Green",
+          "hex": "1B5E20"
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "FF85C0"
+        },
+        {
+          "name": "Burnt Amber",
+          "hex": "B5651D"
+        },
+        {
+          "name": "Clear",
+          "hex": "E8F4F8",
+          "translucent": true
+        },
+        {
+          "name": "Cola Brown",
+          "hex": "4A2C2A"
+        },
+        {
+          "name": "Cranberry",
+          "hex": "9B1B30"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "5C3317"
+        },
+        {
+          "name": "Dark Purple",
+          "hex": "4B0082"
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "2E8B57"
+        },
+        {
+          "name": "Gold",
+          "hex": "D4AF37"
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "FF69B4"
+        },
+        {
+          "name": "Light Brown",
+          "hex": "C4A484"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "B0B0B0"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "32CD32"
+        },
+        {
+          "name": "Machinery Grey",
+          "hex": "6E6E6E"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "0B1F3A"
+        },
+        {
+          "name": "Orange",
+          "hex": "FF8C00"
+        },
+        {
+          "name": "Peachy Beige",
+          "hex": "E8C4A0"
+        },
+        {
+          "name": "Powertool Green",
+          "hex": "3D7C3F"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Race Car Red",
+          "hex": "CC0000"
+        },
+        {
+          "name": "Silver Grey",
+          "hex": "A8A8A8"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "4DA6FF"
+        },
+        {
+          "name": "Tail Light Red",
+          "hex": "B80000"
+        },
+        {
+          "name": "Terracotta",
+          "hex": "C06040"
+        },
+        {
+          "name": "Turn Signal Orange",
+          "hex": "FF6600"
+        },
+        {
+          "name": "White",
+          "hex": "F2F2F2"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFD700"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "density": 1.27,
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "Rainbow rPETG {color_name}",
+      "material": "PETG",
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Dark Green Ocean",
+          "hexes": [
+            "0F4C3A",
+            "1E6B5C",
+            "2060C0"
+          ],
+          "multi_color_direction": "longitudinal",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Dark Purple Galaxy",
+          "hexes": [
+            "2E1A47",
+            "4A2C6A",
+            "101010"
+          ],
+          "multi_color_direction": "longitudinal",
+          "pattern": "sparkle"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "density": 1.27,
+      "multi_color_direction": "longitudinal",
+      "pattern": "sparkle",
+      "country_of_origin": "New Zealand"
+    },
+    {
+      "name": "rPCTG-rPETG {color_name}",
+      "material": "PCTG+PETG",
+      "weights": [
+        {
+          "weight": 250,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ],
+      "extruder_temp_range": [
+        280,
+        300
+      ],
+      "bed_temp_range": [
+        75,
+        95
+      ],
+      "density": 1.27,
+      "country_of_origin": "New Zealand"
+    }
+  ]
+}

--- a/filaments/kodak.json
+++ b/filaments/kodak.json
@@ -1,0 +1,46 @@
+{
+  "manufacturer": "Kodak",
+  "filaments": [
+    {
+      "name": "Kodak PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [50, 70],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    },
+    {
+      "name": "Kodak PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [225, 250],
+      "bed_temp_range": [70, 90],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Red", "hex": "C01010"}
+      ]
+    }
+  ]
+}

--- a/filaments/kretrum.json
+++ b/filaments/kretrum.json
@@ -1,0 +1,216 @@
+{
+  "manufacturer": "Kretrum",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Purple",
+          "hex": "964bc8"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Blue/Green",
+          "hexes": [
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose/Blue",
+          "hexes": [
+            "d274c1",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Violet/Green",
+          "hexes": [
+            "45008a",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "yellow&green",
+          "hex": "d9cc44"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Light Purple",
+          "hex": "afb1f3"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Pink",
+          "hex": "e880ac"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "d2ff57"
+        }
+      ]
+    },
+    {
+      "name": "Rapid {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "001eff"
+        },
+        {
+          "name": "Blue - glow in dark",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Hyper Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Hyper White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "fa0000"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Magenta Green",
+          "hex": "0fa341"
+        },
+        {
+          "name": "Red Gold",
+          "hex": "eaa52e"
+        },
+        {
+          "name": "Royal Blue Leaf Green",
+          "hex": "141ac2"
+        },
+        {
+          "name": "Sky Blue Pink Flamingo",
+          "hex": "3991d0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/l3d.json
+++ b/filaments/l3d.json
@@ -1,0 +1,593 @@
+{
+  "manufacturer": "L3D",
+  "filaments": [
+    {
+      "name": "Glitter PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-G-BLACK-01"
+          ],
+          "eans": [
+            "5744006030795"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "PLA-G-Black-025"
+          ],
+          "eans": [
+            "5744006030764"
+          ]
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Matte PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 3000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PETG-MATT-BLACK-25"
+          ],
+          "eans": [
+            "5744006030955"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "Matte PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-MATT-BLACK-25"
+          ],
+          "eans": [
+            "5744006031136"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PETG-BLACK-01"
+          ],
+          "eans": [
+            "5744006030528"
+          ]
+        },
+        {
+          "name": "Dark Green",
+          "hex": "006400",
+          "codes": [
+            "PETG-Dark-Green-01"
+          ],
+          "eans": [
+            "5744006030641"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PETG-GREY-01",
+            "PLA-LIGHT-GRAY-01"
+          ],
+          "eans": [
+            "5744006030535",
+            "5744006030962"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "PETG-ORANGE-01"
+          ],
+          "eans": [
+            "5744006030603"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "PETG-RED-01"
+          ],
+          "eans": [
+            "5744006030559"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PETG-WHITE-01"
+          ],
+          "eans": [
+            "5744006030511"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PETG-YELLOW-01"
+          ],
+          "eans": [
+            "5744006030542"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 3000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PETG-BLACK-03"
+          ],
+          "eans": [
+            "5744006030689"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PETG-GREY-03"
+          ],
+          "eans": [
+            "5744006030696"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PETG-WHITE-03"
+          ],
+          "eans": [
+            "5744006030672"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "PLA-BLACK-01",
+            "SK-21568"
+          ],
+          "eans": [
+            "5744006030146",
+            "5744006030375"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "PLA-BLUE-01"
+          ],
+          "eans": [
+            "5744006030313"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "SK-215468"
+          ],
+          "eans": [
+            "5744006030320"
+          ]
+        },
+        {
+          "name": "Cyan",
+          "hex": "00ffff",
+          "codes": [
+            "PLA-CYAN-01"
+          ],
+          "eans": [
+            "5744006030276"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "PLA-Gold-01"
+          ],
+          "eans": [
+            "5744006030290"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "PLA-DARK-GRAY-01"
+          ],
+          "eans": [
+            "5744006030351"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "PLA-GREEN-01"
+          ],
+          "eans": [
+            "5744006030283"
+          ]
+        },
+        {
+          "name": "Khaki",
+          "hex": "c3b091",
+          "codes": [
+            "Khaki"
+          ],
+          "eans": [
+            "5744006031785"
+          ]
+        },
+        {
+          "name": "Light Wood",
+          "hex": "deb887",
+          "codes": [
+            "Light Wood"
+          ],
+          "eans": [
+            "5744006031778"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff",
+          "codes": [
+            "PLA-Magenta-01"
+          ],
+          "eans": [
+            "5744006030252"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "PLA-RED-01"
+          ],
+          "eans": [
+            "5744006030269"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-WHITE-01"
+          ],
+          "eans": [
+            "5744006030368"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "PLA-YELLOW-01"
+          ],
+          "eans": [
+            "5744006030337"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "PLA-WHITE-03"
+          ],
+          "eans": [
+            "5744006030382"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Denmark",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320",
+          "codes": [
+            "Silk-Army-Green-01"
+          ],
+          "eans": [
+            "5744006030917"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "Silk-copper-01"
+          ],
+          "eans": [
+            "5744006030948"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "Silk-Gold-01"
+          ],
+          "eans": [
+            "5744006030894"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "add8e6",
+          "codes": [
+            "Silk-Light-Blue-01"
+          ],
+          "eans": [
+            "5744006030856"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "90ee90",
+          "codes": [
+            "Silk-Light-Green-01"
+          ],
+          "eans": [
+            "5744006030887"
+          ]
+        },
+        {
+          "name": "Light Lilac",
+          "hex": "c8a2c8",
+          "codes": [
+            "Silk-Light-Lilla-01"
+          ],
+          "eans": [
+            "5744006030900"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "Silk-Red-01"
+          ],
+          "eans": [
+            "5744006030870"
+          ]
+        },
+        {
+          "name": "Rose",
+          "hex": "ff007f",
+          "codes": [
+            "Silk-Rose-01"
+          ],
+          "eans": [
+            "5744006030863"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "Silk-Silver-01"
+          ],
+          "eans": [
+            "5744006030931"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "Silk-White-01"
+          ],
+          "eans": [
+            "5744006030924"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    }
+  ]
+}

--- a/filaments/landu.json
+++ b/filaments/landu.json
@@ -1,0 +1,73 @@
+{
+  "manufacturer": "LANDU",
+  "filaments": [
+    {
+      "name": "LANDU PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 140,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [30, 60],
+      "colors": [
+        {"name": "Black", "hex": "0B0B0B"},
+        {"name": "White", "hex": "F5F5F5"},
+        {"name": "Grey", "hex": "8C8C8C"},
+        {"name": "Red", "hex": "D62222"},
+        {"name": "Blue", "hex": "1C52D6"},
+        {"name": "Green", "hex": "259E3F"},
+        {"name": "Yellow", "hex": "ECCB1C"},
+        {"name": "Orange", "hex": "E66E19"}
+      ]
+    },
+    {
+      "name": "LANDU PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 140,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [40, 60],
+      "colors": [
+        {"name": "Black", "hex": "0D0D0D"},
+        {"name": "White", "hex": "FAFAFA"},
+        {"name": "Grey", "hex": "7E7E7E"},
+        {"name": "Red", "hex": "C91A1A"},
+        {"name": "Blue", "hex": "1A4FC9"}
+      ]
+    },
+    {
+      "name": "LANDU PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 140,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 250],
+      "bed_temp_range": [70, 90],
+      "colors": [
+        {"name": "Black", "hex": "111111"},
+        {"name": "White", "hex": "FDFDFD"},
+        {"name": "Grey", "hex": "858585"},
+        {"name": "Clear", "hex": "FFFFFF80"}
+      ]
+    }
+  ]
+}

--- a/filaments/ldo.json
+++ b/filaments/ldo.json
@@ -14,7 +14,7 @@
             "diameters": [
                 1.75
             ],
-			"extruder_temp ": 260,
+			"extruder_temp": 260,
 			"bed_temp_range": [
 				90,
 				110
@@ -74,7 +74,7 @@
             "diameters": [
                 1.75
             ],
-			"extruder_temp ": 260,
+			"extruder_temp": 260,
 			"bed_temp_range": [
 				90,
 				110

--- a/filaments/likesilk.json
+++ b/filaments/likesilk.json
@@ -1,0 +1,463 @@
+{
+  "manufacturer": "Likesilk",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Orange",
+          "hex": "f54900"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "flesh color",
+          "hex": "fe967c"
+        },
+        {
+          "name": "Green",
+          "hex": "00b315"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        245,
+        265
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "257bde"
+        },
+        {
+          "name": "Brown",
+          "hex": "6b1919"
+        },
+        {
+          "name": "Flesh",
+          "hex": "fec9a9"
+        },
+        {
+          "name": "Green",
+          "hex": "00b315"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "d9caf4"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "ASA+PLUS {color_name}",
+      "material": "ASA+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        245,
+        265
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "0e730c"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Uv {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "LUMINOUS GREEN",
+          "hex": "00b612"
+        }
+      ]
+    },
+    {
+      "name": "F {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        235
+      ],
+      "bed_temp_range": [
+        55,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4d7028"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0656d5"
+        },
+        {
+          "name": "Cherry Wood",
+          "hex": "2b0409"
+        },
+        {
+          "name": "Christmas Green",
+          "hex": "0b7539"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "1512af"
+        },
+        {
+          "name": "Dream Rainbow",
+          "hex": "ef930f"
+        },
+        {
+          "name": "Flesh",
+          "hex": "a76852"
+        },
+        {
+          "name": "Glow Red",
+          "hex": "d44a47"
+        },
+        {
+          "name": "Glow Yellow",
+          "hex": "fde295"
+        },
+        {
+          "name": "Gray",
+          "hex": "d3d3d3"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "c9cbff"
+        },
+        {
+          "name": "Mocha Brown",
+          "hex": "583a1d"
+        },
+        {
+          "name": "Oak",
+          "hex": "c5902a"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffa8df"
+        },
+        {
+          "name": "Purple",
+          "hex": "512da4"
+        },
+        {
+          "name": "Red",
+          "hex": "ee3a3a"
+        },
+        {
+          "name": "Silver",
+          "hex": "a4a8ad"
+        },
+        {
+          "name": "Teak",
+          "hex": "724b14"
+        },
+        {
+          "name": "Teak Wood",
+          "hex": "724b14"
+        },
+        {
+          "name": "Walnut",
+          "hex": "2c200b"
+        },
+        {
+          "name": "White",
+          "hex": "f4e1ef"
+        },
+        {
+          "name": "Wood",
+          "hex": "624e32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Hs Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLACK AND GOLD",
+          "hex": "01080e"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        245
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black-Red",
+          "hex": "a21111"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Silk Blue-Green",
+          "hex": "3481a8"
+        },
+        {
+          "name": "Silk Silver",
+          "hex": "bababa"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        40,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Flesh",
+          "hex": "d3aa96"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "e2d7f7"
+        },
+        {
+          "name": "Wood",
+          "hex": "cdb793"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Back + Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Rose Red + Dark Blue",
+          "hexes": [
+            "981662",
+            "000080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Gold Red",
+          "hex": "fb1818"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/locyfens.json
+++ b/filaments/locyfens.json
@@ -1,0 +1,284 @@
+{
+  "manufacturer": "LOCYFENS",
+  "filaments": [
+    {
+      "name": "Silk PLA Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Black & Green",
+          "hexes": [
+            "000000",
+            "228b22"
+          ],
+          "codes": [
+            "B0BR91CMR6"
+          ]
+        },
+        {
+          "name": "Black & Purple",
+          "hexes": [
+            "000000",
+            "800080"
+          ],
+          "codes": [
+            "B0BKKXVHDY"
+          ]
+        },
+        {
+          "name": "Black & Red",
+          "hexes": [
+            "000000",
+            "cc0000"
+          ],
+          "codes": [
+            "B0BR8YPXV8"
+          ]
+        },
+        {
+          "name": "Green & Blue",
+          "hexes": [
+            "228b22",
+            "0066cc"
+          ],
+          "codes": [
+            "B09P16NPXC"
+          ]
+        },
+        {
+          "name": "Silver & Blue",
+          "hexes": [
+            "c0c0c0",
+            "0066cc"
+          ],
+          "codes": [
+            "B09P16HBS9"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA Tri {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Black-Purple-Blue",
+          "hexes": [
+            "000000",
+            "800080",
+            "0066cc"
+          ],
+          "codes": [
+            "B0BRD94DMK"
+          ]
+        },
+        {
+          "name": "Gold-Red-Black",
+          "hexes": [
+            "daa520",
+            "cc0000",
+            "000000"
+          ],
+          "codes": [
+            "B09P15RM22"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Rainbow Color Change",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "4b0082",
+            "8b00ff"
+          ],
+          "codes": [
+            "B09P17LT2P"
+          ]
+        },
+        {
+          "name": "Rainbow Shiny",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "4b0082",
+            "8b00ff"
+          ],
+          "codes": [
+            "B09TTMCYHF"
+          ]
+        },
+        {
+          "name": "Silk Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "4b0082",
+            "8b00ff"
+          ],
+          "codes": [
+            "B09P16QB32"
+          ]
+        },
+        {
+          "name": "Vintage Metal Rainbow",
+          "hexes": [
+            "b87333",
+            "c0c0c0",
+            "daa520",
+            "cd7f32",
+            "8b4513"
+          ],
+          "codes": [
+            "B09TTP1F4P"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA Rainbow Bundle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Tri-Color Rainbow 4-Pack",
+          "hexes": [
+            "ff0000",
+            "00ff00",
+            "0000ff"
+          ],
+          "codes": [
+            "B0BKKW518Z"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Transparent Bundle {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Red Green Blue Purple Orange",
+          "hexes": [
+            "cc0000",
+            "228b22",
+            "0066cc",
+            "800080",
+            "ff8c00"
+          ],
+          "translucent": true,
+          "codes": [
+            "B0B5YDRXXG"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/lostboyslab.json
+++ b/filaments/lostboyslab.json
@@ -1,0 +1,292 @@
+{
+  "manufacturer": "lostboyslab",
+  "filaments": [
+    {
+      "name": "Addnite P15R {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Sweden",
+      "colors": [
+        {
+          "name": "P15R",
+          "hex": "808080",
+          "codes": [
+            "3d-filament-addnite-p15r"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rPETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "finish": "matte",
+      "country_of_origin": "Sweden",
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "00ffff",
+          "codes": [
+            "blue-aqua-3d-printing-material-rpetg-recycled"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "copy-of-white-3d-printing-material-rpetg-recycled"
+          ]
+        },
+        {
+          "name": "Blizzard White",
+          "hex": "f5f5f5",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-blizzard-white"
+          ]
+        },
+        {
+          "name": "Eclipse Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-eclipse-black"
+          ]
+        },
+        {
+          "name": "Forest Green",
+          "hex": "228b22",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-forest-green"
+          ]
+        },
+        {
+          "name": "Light Wood",
+          "hex": "c4a574",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-light-wood"
+          ]
+        },
+        {
+          "name": "Misty Grey",
+          "hex": "b0b0b0",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-misty-grey"
+          ]
+        },
+        {
+          "name": "Moss Green",
+          "hex": "8a9a5b",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-moss-green"
+          ]
+        },
+        {
+          "name": "Muddy Brown",
+          "hex": "8b7355",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-muddy-brown"
+          ]
+        },
+        {
+          "name": "Mulberry Red",
+          "hex": "c71585",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-mulberry-red"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-sky-blue"
+          ]
+        },
+        {
+          "name": "Sunset Orange",
+          "hex": "ff7f50",
+          "codes": [
+            "3d-filament-rpetg-matte-ncs-sunset-orange"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rPLA HOME DECOR {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Sweden",
+      "colors": [
+        {
+          "name": "Ochre",
+          "hex": "cc7722",
+          "codes": [
+            "matte-recycled-pla-ochre"
+          ]
+        },
+        {
+          "name": "Terracotta",
+          "hex": "e2725b",
+          "codes": [
+            "matte-recycled-pla-terracotta"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rPLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "matte",
+      "country_of_origin": "Sweden",
+      "colors": [
+        {
+          "name": "Almost Black",
+          "hex": "2b2b2b",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-almost-black-ncs-s-8000-n"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "d4c4a8",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-beige-ncs-s-2005-y50r"
+          ]
+        },
+        {
+          "name": "Camel",
+          "hex": "c19a6b",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-camel-ncs-s-3020-y20r"
+          ]
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "696969",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-dark-grey-ncs-s-7000-n"
+          ]
+        },
+        {
+          "name": "Darkest Black",
+          "hex": "0a0a0a",
+          "codes": [
+            "3d-filament-matt-rpla-1-75-mm-darkest-black-ncs-s-9000-n-on-1-kg-spool"
+          ]
+        },
+        {
+          "name": "Earth",
+          "hex": "8b6914",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-earth-ncs-s-6005-y50r"
+          ]
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d3d3d3",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-light-grey-ncs-s-2500-n"
+          ]
+        },
+        {
+          "name": "Medium Grey",
+          "hex": "a9a9a9",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-medium-grey-ncs-s-4500-n"
+          ]
+        },
+        {
+          "name": "Porcelain",
+          "hex": "f5f0e8",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-porcelain-white-ncs-s-1000-n"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "ffffff",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-pure-white-ncs-s-0300-n"
+          ]
+        },
+        {
+          "name": "Sand",
+          "hex": "c2b280",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-sand-ncs-s-1505-y30r"
+          ]
+        },
+        {
+          "name": "Stone Grey",
+          "hex": "8b8b83",
+          "codes": [
+            "3d-filament-matte-rpla-1-75-mm-stone-greay-ncs-s-2002-r"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/lotactree.json
+++ b/filaments/lotactree.json
@@ -1,0 +1,327 @@
+{
+  "manufacturer": "Lotactree",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3b5dc2"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Blend {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        235
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Blend {color_name}",
+      "material": "PLA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "F {color_name}",
+      "material": "PLA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        20,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "b1dd8b"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Gold",
+          "hex": "d3ab25"
+        },
+        {
+          "name": "Green",
+          "hex": "45f262"
+        },
+        {
+          "name": "Orange",
+          "hex": "e58605"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff92c1"
+        },
+        {
+          "name": "RAINBOW (candy)",
+          "hex": "f66ba2"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Greenish Gold",
+          "hex": "afc63c"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "974c2d"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "ea7d33"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        245
+      ],
+      "bed_temp_range": [
+        55,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black-Red",
+          "hex": "000000"
+        },
+        {
+          "name": "Green Blue",
+          "hex": "1a16e3"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        225
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Candy",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        245
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Unicorn",
+          "hex": "f66ba2"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/lovoon.json
+++ b/filaments/lovoon.json
@@ -1,0 +1,468 @@
+{
+  "manufacturer": "Lovoon",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Luminous Rainbow-b",
+          "hex": "fbbbfd"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black/Blue/Purple",
+          "hexes": [
+            "000000",
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink Yellow Blue",
+          "hex": "de82d6"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red/Purple/Gold",
+          "hexes": [
+            "ff0000",
+            "800080",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Matt Rainbow",
+          "hex": "e58eff"
+        },
+        {
+          "name": "Triple - Purple Pink Yellow",
+          "hex": "faa1a6"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.286,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red, Green, Blue",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Teal/Coral",
+          "hex": "6eeef7"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black-Blue",
+          "hex": "021559"
+        },
+        {
+          "name": "Black-Green",
+          "hex": "1d4a15"
+        },
+        {
+          "name": "Black-Purple",
+          "hex": "110f3c"
+        },
+        {
+          "name": "Blue & Green",
+          "hex": "1563e2"
+        },
+        {
+          "name": "Gold/Red",
+          "hexes": [
+            "ffd700",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Sky Blue/Rose Red",
+          "hex": "e133cf"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silk Rainbow Gradient Green-Blue-Purple-Pink-Yellow",
+          "hex": "76bb40"
+        },
+        {
+          "name": "Silk Rainbow Green-Red-Blue",
+          "hex": "ed7ef3"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Green Red",
+          "hex": "38abfc"
+        },
+        {
+          "name": "Blue/Black/Purple",
+          "hexes": [
+            "0000ff",
+            "000000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold/Red/Purple",
+          "hexes": [
+            "ffd700",
+            "ff0000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green/Blue/Orange",
+          "hexes": [
+            "008000",
+            "0000ff",
+            "05ff16"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red Yellow Blue",
+          "hex": "ff2600"
+        },
+        {
+          "name": "Red-Purple-Blue",
+          "hex": "181841"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "13335e",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galaxy Green",
+          "hex": "528077",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galaxy Light Blue",
+          "hex": "58b0d0",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galaxy Purple Blue",
+          "hex": "353891",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galaxy Wine Red",
+          "hex": "ab88bb",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dark Mahogany / Walnut",
+          "hex": "941100"
+        },
+        {
+          "name": "Walnut",
+          "hex": "aa7942"
+        },
+        {
+          "name": "Walnut & Natural",
+          "hex": "ecd870"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/lume.json
+++ b/filaments/lume.json
@@ -1,0 +1,147 @@
+{
+  "manufacturer": "LUME",
+  "filaments": [
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        215
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Beige Marble",
+          "hex": "fff0db",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Grey Dark",
+          "hex": "333333"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "6bc1f5"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "d3d3d3"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Premium {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        215
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "400000"
+        },
+        {
+          "name": "Cytrynowy",
+          "hex": "ffff80"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "0946ff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dark Violet",
+          "hex": "8000ff"
+        },
+        {
+          "name": "Light Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d4d9db"
+        },
+        {
+          "name": "Magenta",
+          "hex": "f653a6"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/makerbot.json
+++ b/filaments/makerbot.json
@@ -1,0 +1,78 @@
+{
+  "manufacturer": "MakerBot",
+  "filaments": [
+    {
+      "name": "MakerBot PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 220,
+          "spool_weight": 100,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 900,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [210, 220],
+      "bed_temp_range": [0, 60],
+      "colors": [
+        {"name": "True Black", "hex": "101010"},
+        {"name": "True White", "hex": "F2F2F2"},
+        {"name": "True Gray", "hex": "808080"},
+        {"name": "True Red", "hex": "C01010"},
+        {"name": "True Blue", "hex": "1010C0"}
+      ]
+    },
+    {
+      "name": "MakerBot Tough PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [210, 225],
+      "bed_temp_range": [0, 60],
+      "colors": [
+        {"name": "Slate Gray", "hex": "708090"},
+        {"name": "Onyx Black", "hex": "0F0F0F"},
+        {"name": "Stone White", "hex": "EAE6DF"},
+        {"name": "Safety Orange", "hex": "FF6600"}
+      ]
+    },
+    {
+      "name": "MakerBot PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 250,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 240],
+      "bed_temp_range": [60, 80],
+      "colors": [
+        {"name": "True Black", "hex": "101010"},
+        {"name": "True White", "hex": "F2F2F2"},
+        {"name": "True Red", "hex": "C01010"}
+      ]
+    }
+  ]
+}

--- a/filaments/makergeeks.json
+++ b/filaments/makergeeks.json
@@ -1,0 +1,281 @@
+{
+  "manufacturer": "Maker Geeks",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "2a5a42"
+        }
+      ]
+    },
+    {
+      "name": "Crystal {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Crystal HD Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Crystal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Translucent Purple",
+          "hex": "543559"
+        },
+        {
+          "name": "Translucent Red",
+          "hex": "c3413d"
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "001ca8"
+        },
+        {
+          "name": "Transparent Green",
+          "hex": "167e01"
+        },
+        {
+          "name": "Transparent Red",
+          "hex": "952828"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dragon's Metallic Gold",
+          "hex": "ca9502"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        255,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "HD Clear Glass (transparent)",
+          "hex": "ffffff"
+        },
+        {
+          "name": "HD Red Glass",
+          "hex": "dd8888"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Maker Series Dark as Night Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Maker Series Nuclear Green",
+          "hex": "4cb62f"
+        },
+        {
+          "name": "Raptor Series HD Battleship Grey",
+          "hex": "848482"
+        },
+        {
+          "name": "Army Green",
+          "hex": "0e4e0d"
+        },
+        {
+          "name": "Charlie Brown",
+          "hex": "54463b"
+        },
+        {
+          "name": "Make Me Blush",
+          "hex": "d95959"
+        },
+        {
+          "name": "Pearl Starlight Blue",
+          "hex": "275d9a"
+        },
+        {
+          "name": "Tiger Orange",
+          "hex": "ff7300"
+        },
+        {
+          "name": "White HOT White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "008cf0"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0006c2"
+        },
+        {
+          "name": "Gray Matter",
+          "hex": "545454"
+        },
+        {
+          "name": "Green",
+          "hex": "116600"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/makerlab.json
+++ b/filaments/makerlab.json
@@ -1,0 +1,239 @@
+{
+  "manufacturer": "MakerLab",
+  "filaments": [
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Mystery Green",
+          "hex": "4d6b59"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Jelly Bean Rainbow",
+          "hex": "cfa98f"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Luminous Flashpoint",
+          "hex": "adb1a9"
+        },
+        {
+          "name": "Luminous Orange",
+          "hex": "ef9352"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Marble White",
+          "hex": "c3c4bf",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "fa8aee"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "c8744e"
+        },
+        {
+          "name": "Silver",
+          "hex": "939694"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0042db"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        34,
+        34
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Blue Green Orange",
+          "hex": "2d5c98"
+        },
+        {
+          "name": "Gold Copper Purple",
+          "hex": "c8ad9a"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/markforged.json
+++ b/filaments/markforged.json
@@ -1,0 +1,309 @@
+{
+  "manufacturer": "Markforged",
+  "filaments": [
+    {
+      "name": "Onyx {color_name}",
+      "material": "PA-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 960
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Onyx GF {color_name}",
+      "material": "PA-GF",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1040
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "fill": "glass fiber",
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Onyx FR {color_name}",
+      "material": "PA-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 960
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Onyx ESD {color_name}",
+      "material": "PA-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 960
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "fill": "carbon fiber",
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Vega {color_name}",
+      "material": "PPA",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        320
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "ULTEM 9085 {color_name}",
+      "material": "PEI",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 4064
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        340,
+        360
+      ],
+      "bed_temp_range": [
+        120,
+        160
+      ],
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Amber",
+          "hex": "c9892b"
+        }
+      ]
+    },
+    {
+      "name": "Smooth TPU 95A {color_name}",
+      "material": "TPU-95A",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 960
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Precise PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 744
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        }
+      ]
+    },
+    {
+      "name": "Nylon {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 912
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Nylon White FS {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 912
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "United States",
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/marswork.json
+++ b/filaments/marswork.json
@@ -1,0 +1,235 @@
+{
+  "manufacturer": "MarsWork",
+  "filaments": [
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "76cd26"
+        },
+        {
+          "name": "Ash Grey",
+          "hex": "7b7c80"
+        },
+        {
+          "name": "Ash Purple",
+          "hex": "b29794"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Burgundy",
+          "hex": "800020"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "000040"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "7d6556"
+        },
+        {
+          "name": "Dark Chocolate",
+          "hex": "3e1f00"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "545e3b"
+        },
+        {
+          "name": "Desert Tan",
+          "hex": "e8dbb7"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "61c680"
+        },
+        {
+          "name": "Ice Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Lemon Yellow",
+          "hex": "f7d959"
+        },
+        {
+          "name": "Lilac Purple",
+          "hex": "ae96d4"
+        },
+        {
+          "name": "Marina Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Marine Blue",
+          "hex": "346eb2"
+        },
+        {
+          "name": "Nardo Gray",
+          "hex": "757575"
+        },
+        {
+          "name": "Orange",
+          "hex": "f99963"
+        },
+        {
+          "name": "Orange Red",
+          "hex": "db764e"
+        },
+        {
+          "name": "Pastel Teal",
+          "hex": "40e0d0"
+        },
+        {
+          "name": "Plum",
+          "hex": "950051"
+        },
+        {
+          "name": "Red",
+          "hex": "ff6652"
+        },
+        {
+          "name": "Red (Corrected)",
+          "hex": "be3231"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "ffb7c5"
+        },
+        {
+          "name": "White",
+          "hex": "fffff1"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Ash Grey",
+          "hex": "7b7c80"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Bright Green",
+          "hex": "d6ed0d"
+        },
+        {
+          "name": "Cocoa Brown",
+          "hex": "35281e"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00adff"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "012f7b"
+        },
+        {
+          "name": "Dark Yellow",
+          "hex": "ffc433"
+        },
+        {
+          "name": "Fire Engine Red",
+          "hex": "690000"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "96d35f"
+        },
+        {
+          "name": "Green",
+          "hex": "32c759"
+        },
+        {
+          "name": "Indigo Purple",
+          "hex": "21003f"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7d00"
+        },
+        {
+          "name": "Pink",
+          "hex": "c54b8c"
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "f9af10"
+        },
+        {
+          "name": "Purple",
+          "hex": "4d22b2"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "65bcff"
+        },
+        {
+          "name": "Sunflower Yellow",
+          "hex": "ffda03"
+        },
+        {
+          "name": "turquoise",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/material4print.json
+++ b/filaments/material4print.json
@@ -1,0 +1,260 @@
+{
+  "manufacturer": "Material4Print",
+  "filaments": [
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Telegrau 4",
+          "hex": "cbcbcb"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "colors": [
+        {
+          "name": "PETG Tiefschwarz",
+          "hex": "000000"
+        },
+        {
+          "name": "Staub-Grau",
+          "hex": "727374"
+        },
+        {
+          "name": "Signal red",
+          "hex": "ff4242"
+        },
+        {
+          "name": "Signalrot",
+          "hex": "ff4242"
+        },
+        {
+          "name": "Signalweiß",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Anthracite Silver",
+          "hex": "353c40"
+        },
+        {
+          "name": "Bright Green (Leuchtgrün)",
+          "hex": "14ac11"
+        },
+        {
+          "name": "Bright Orange (Leuchtorange)",
+          "hex": "ff4d06"
+        },
+        {
+          "name": "Bright Red (Leuchtrot)",
+          "hex": "ff2d21"
+        },
+        {
+          "name": "Deep Black (Tiefschwarz)",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Dusty gray",
+          "hex": "7a7b7a"
+        },
+        {
+          "name": "Gipsy Color",
+          "hex": "c0d9f2"
+        },
+        {
+          "name": "Gray aluminium",
+          "hex": "8f8f8f"
+        },
+        {
+          "name": "Iron gray",
+          "hex": "52595d"
+        },
+        {
+          "name": "Ivory",
+          "hex": "e6d2b5"
+        },
+        {
+          "name": "Natural/Clear",
+          "hex": "f0f0f0"
+        },
+        {
+          "name": "Perl Blue",
+          "hex": "0e88e2"
+        },
+        {
+          "name": "Perlviolett",
+          "hex": "6700ce"
+        },
+        {
+          "name": "Pure Red (Reinrot)",
+          "hex": "cc2c24"
+        },
+        {
+          "name": "Red",
+          "hex": "cc2c24"
+        },
+        {
+          "name": "Signal Blue",
+          "hex": "134a85"
+        },
+        {
+          "name": "Signal White",
+          "hex": "ecece7"
+        },
+        {
+          "name": "Sky Blue (Himmelblau)",
+          "hex": "2874b2"
+        },
+        {
+          "name": "Telemagenta",
+          "hex": "bc4077"
+        },
+        {
+          "name": "Traffic Yellow",
+          "hex": "f0ca00"
+        },
+        {
+          "name": "Yellow green",
+          "hex": "fffb00"
+        }
+      ]
+    },
+    {
+      "name": "PMMA {color_name}",
+      "material": "PMMA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transp.",
+          "hex": "9d8080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Anthrazitsilber",
+          "hex": "434750"
+        },
+        {
+          "name": "Reinrot",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Signalblau",
+          "hex": "0033ff"
+        },
+        {
+          "name": "Staubgrau",
+          "hex": "999999"
+        },
+        {
+          "name": "Tiefschwarz",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/matter3d.json
+++ b/filaments/matter3d.json
@@ -1,0 +1,583 @@
+{
+  "manufacturer": "Matter3D",
+  "filaments": [
+    {
+      "name": "ASA Pro {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000b3"
+        },
+        {
+          "name": "Red",
+          "hex": "f80000"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Hf {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Volant Light Blue",
+          "hex": "81e4fd"
+        }
+      ]
+    },
+    {
+      "name": "Hf {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000b3"
+        },
+        {
+          "name": "Cayman Blue",
+          "hex": "009cde"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "7b3f00"
+        },
+        {
+          "name": "Dark/Forest Green",
+          "hex": "44693d"
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "hex": "023862"
+        },
+        {
+          "name": "Fuchsia/Magenta",
+          "hexes": [
+            "ff00ff",
+            "c20078"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "0f1314"
+        },
+        {
+          "name": "Lavender",
+          "hex": "845cd6"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d9d9d6"
+        },
+        {
+          "name": "Natural",
+          "hex": "e0e0e0"
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0056f9"
+        },
+        {
+          "name": "Red",
+          "hex": "f80000"
+        },
+        {
+          "name": "Royal Purple",
+          "hex": "34114b"
+        },
+        {
+          "name": "Safety Orange",
+          "hex": "fe5000"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87cefa"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090"
+        },
+        {
+          "name": "Sunshine Yellow",
+          "hex": "ffe900"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Gunmetal Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG Pro {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000b3"
+        },
+        {
+          "name": "Dark / Forest Green",
+          "hex": "44693d"
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0056f9"
+        },
+        {
+          "name": "Red",
+          "hex": "f80000"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Natural (Clear)",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 100
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Dark / Forest Green",
+          "hex": "44693d"
+        },
+        {
+          "name": "Desert Sand",
+          "hex": "c7a654"
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "hex": "023862"
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "0f1314"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Aqua",
+          "hex": "74e5ea"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000b3"
+        },
+        {
+          "name": "Bone White",
+          "hex": "d7d0c0"
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "e87191"
+        },
+        {
+          "name": "Caterpillar Yellow",
+          "hex": "ffcc00"
+        },
+        {
+          "name": "Cayman Blue",
+          "hex": "009cde"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "7b3f00"
+        },
+        {
+          "name": "Clay / Brick Red",
+          "hex": "853523"
+        },
+        {
+          "name": "Dark / Forest Green",
+          "hex": "44693d"
+        },
+        {
+          "name": "Egg Shell White",
+          "hex": "eeeae6"
+        },
+        {
+          "name": "Evergreen",
+          "hex": "0d5c54"
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "hex": "023862"
+        },
+        {
+          "name": "Fuchsia / Magenta",
+          "hexes": [
+            "ff00ff",
+            "c20078"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Grape Drink Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "009925"
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "0f1314"
+        },
+        {
+          "name": "Industrial Blue",
+          "hex": "006777"
+        },
+        {
+          "name": "Khaki / Desert Tan",
+          "hex": "faeaac"
+        },
+        {
+          "name": "Lavender",
+          "hex": "845cd6"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d9d9d6"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "ffb5c0"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "97d700"
+        },
+        {
+          "name": "Metallic red",
+          "hex": "c8291e"
+        },
+        {
+          "name": "Mocha Brown",
+          "hex": "b76a20"
+        },
+        {
+          "name": "Natural",
+          "hex": "e0e0e0"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "73d700"
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0056f9"
+        },
+        {
+          "name": "Peach",
+          "hex": "ffc3a0"
+        },
+        {
+          "name": "Recycled",
+          "hex": "140012"
+        },
+        {
+          "name": "Red",
+          "hex": "f80000"
+        },
+        {
+          "name": "Royal Purple",
+          "hex": "34114b"
+        },
+        {
+          "name": "Safety Orange",
+          "hex": "fe5000"
+        },
+        {
+          "name": "Sandstone",
+          "hex": "be9b80"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87cefa"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090"
+        },
+        {
+          "name": "Snow White",
+          "hex": "f9fdfe"
+        },
+        {
+          "name": "Steel Wool",
+          "hex": "808080"
+        },
+        {
+          "name": "Sunshine Yellow",
+          "hex": "ffe900"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "8cffdb"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wine Red",
+          "hex": "7b0323"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Cedar Wood",
+          "hex": "583239"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/matter3dinc.json
+++ b/filaments/matter3dinc.json
@@ -1,0 +1,869 @@
+{
+  "manufacturer": "Matter3D Inc",
+  "filaments": [
+    {
+      "name": "Basics PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Antique Gold",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-42858278322353"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "7584310821041-44723039371441"
+          ]
+        },
+        {
+          "name": "CA",
+          "hex": "808080",
+          "codes": [
+            "FIL-1022-00-10-1-WOD"
+          ]
+        },
+        {
+          "name": "Glitter Blue",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-42643795607729"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "7460678336689-42858278289585"
+          ]
+        },
+        {
+          "name": "Metallic (Silk) Blue",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-43107658858673"
+          ]
+        },
+        {
+          "name": "Metallic (Silk) Orange",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-43107654402225"
+          ]
+        },
+        {
+          "name": "Metallic (Silk) Red",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-42642581946545"
+          ]
+        },
+        {
+          "name": "Pearl White",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-42642581881009"
+          ]
+        },
+        {
+          "name": "Silk Purple",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-44727024812209"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "7460678336689-42859906531505"
+          ]
+        },
+        {
+          "name": "Steel Wool",
+          "hex": "808080",
+          "codes": [
+            "7460678336689-42642581979313"
+          ]
+        },
+        {
+          "name": "US",
+          "hex": "808080",
+          "codes": [
+            "FIL-1022-00-10-1-WOD"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Basics PLA Bulk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 6300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "8798937579697-46216348369073"
+          ]
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "2c3539",
+          "codes": [
+            "8798937579697-46216348467377"
+          ]
+        },
+        {
+          "name": "Medium Grey",
+          "hex": "808080",
+          "codes": [
+            "8798937579697-46216348434609"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090",
+          "codes": [
+            "8798937579697-46216348500145"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "8798937579697-46216348401841"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Performance ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1200
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "7605500313777-43201123680433"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "7605500313777-43201123778737"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "7605500313777-43201123811505"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090",
+          "codes": [
+            "7605500313777-43201123745969"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "7605500313777-43201123713201"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Performance Matte PETG {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "FIL-1010-00-10-1-BLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "7333934137521-42215437041841"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513",
+          "codes": [
+            "7333934137521-42215437369521"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "7333934137521-42215437238449"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "7333934137521-42215436910769"
+          ]
+        },
+        {
+          "name": "Lavender",
+          "hex": "e6e6fa",
+          "codes": [
+            "7333934137521-42356848656561"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff",
+          "codes": [
+            "7333934137521-42356848591025"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "7333934137521-42215437303985"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "7333934137521-42215436976305"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "7333934137521-42215462174897"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "7333934137521-42215437107377"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "Performance Matte PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "8818436997297-46258194645169"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "8818436997297-46258194874545"
+          ]
+        },
+        {
+          "name": "Dark/Forest Green",
+          "hex": "228b22",
+          "codes": [
+            "8818436997297-46258195005617"
+          ]
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "2c3539",
+          "codes": [
+            "8818436997297-46258194710705"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "8818436997297-46258194809009"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090",
+          "codes": [
+            "8818436997297-46258194743473"
+          ]
+        },
+        {
+          "name": "Sunshine Yellow",
+          "hex": "ffda03",
+          "codes": [
+            "8818436997297-46258194841777"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "8818436997297-46258194677937"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "Performance Matte PETG {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "7506232443057-42858281468081",
+            "7506232443057-44947688915121"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "7506232443057-42858279698609",
+            "7506232443057-44947689144497"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "7b3f00",
+          "codes": [
+            "7506232443057-42858279862449",
+            "7506232443057-44947689308337"
+          ]
+        },
+        {
+          "name": "Dark/Forest Green",
+          "hex": "228b22",
+          "codes": [
+            "7506232443057-42858279764145",
+            "7506232443057-44947689210033"
+          ]
+        },
+        {
+          "name": "Evergreen",
+          "hex": "115740",
+          "codes": [
+            "7506232443057-42858279796913",
+            "7506232443057-44947689242801"
+          ]
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "hex": "1c2841",
+          "codes": [
+            "7506232443057-43107953770673",
+            "7506232443057-44947689373873"
+          ]
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "2c3539",
+          "codes": [
+            "7506232443057-42858279600305",
+            "7506232443057-44947689046193"
+          ]
+        },
+        {
+          "name": "Khaki/ Desert Tan",
+          "hex": "c3b091",
+          "codes": [
+            "7506232443057-42858279829681",
+            "7506232443057-44947689275569"
+          ]
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d3d3d3",
+          "codes": [
+            "7506232443057-42858279567537",
+            "7506232443057-44947689013425"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "ff00ff",
+          "codes": [
+            "7506232443057-42858279665841",
+            "7506232443057-44947689111729"
+          ]
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0077be",
+          "codes": [
+            "7506232443057-42858279731377",
+            "7506232443057-44947689177265"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "7506232443057-43107967959217",
+            "7506232443057-44947689406641"
+          ]
+        },
+        {
+          "name": "Royal Purple",
+          "hex": "7851a9",
+          "codes": [
+            "7506232443057-42858279633073",
+            "7506232443057-44947689078961"
+          ]
+        },
+        {
+          "name": "Safety Orange",
+          "hex": "ff6600",
+          "codes": [
+            "7506232443057-42858286842033",
+            "7506232443057-44947689341105"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090",
+          "codes": [
+            "7506232443057-42858279534769",
+            "7506232443057-44947688980657"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "7506232443057-42858279502001",
+            "7506232443057-44947688947889"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "Performance PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "FIL-1030-00-10-1-BLK",
+            "FIL-1030-00-50-1-BLK"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "FIL-1030-00-10-1-BLU"
+          ]
+        },
+        {
+          "name": "Cayman Blue",
+          "hex": "2e86ab",
+          "codes": [
+            "7130019463345-46216362950833"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "7b3f00",
+          "codes": [
+            "FIL-1030-00-10-1-BRN"
+          ]
+        },
+        {
+          "name": "Dark/Forest Green",
+          "hex": "228b22",
+          "codes": [
+            "FIL-1030-00-10-1-DGN"
+          ]
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "hex": "1c2841",
+          "codes": [
+            "FIL-1030-00-10-1-FJB"
+          ]
+        },
+        {
+          "name": "Fuchsia/Magenta",
+          "hex": "ff00ff",
+          "codes": [
+            "FIL-1030-00-10-1-FUC"
+          ]
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "2c3539",
+          "codes": [
+            "8201169371313-45001877618865",
+            "FIL-1030-00-10-1-GML"
+          ]
+        },
+        {
+          "name": "Lavender",
+          "hex": "e6e6fa",
+          "codes": [
+            "FIL-1030-00-10-1-LAV"
+          ]
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d3d3d3",
+          "codes": [
+            "8201169371313-45001877684401",
+            "FIL-1030-00-10-1-LGY"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "8201169371313-45001878110385",
+            "FIL-1030-00-10-1-NAT"
+          ]
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "0077be",
+          "codes": [
+            "FIL-1030-00-10-1-OBL"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "FIL-1030-00-10-1-RED"
+          ]
+        },
+        {
+          "name": "Royal Purple",
+          "hex": "7851a9",
+          "codes": [
+            "FIL-1030-00-10-1-PUR"
+          ]
+        },
+        {
+          "name": "Safety Orange",
+          "hex": "ff6600",
+          "codes": [
+            "FIL-1030-00-10-1-ORG"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "FIL-1030-00-10-1-SBL"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090",
+          "codes": [
+            "8201169371313-45001877651633",
+            "FIL-1030-00-10-1-GRY"
+          ]
+        },
+        {
+          "name": "Sunshine Yellow",
+          "hex": "ffda03",
+          "codes": [
+            "FIL-1030-00-10-1-YLW"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "8201169371313-45001877586097",
+            "FIL-1030-00-10-1-WHT"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Performance PETG Bulk {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 6300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "8798938267825-46216348565681"
+          ]
+        },
+        {
+          "name": "Gunmetal Grey",
+          "hex": "2c3539",
+          "codes": [
+            "8798938267825-46216348860593"
+          ]
+        },
+        {
+          "name": "Medium Grey",
+          "hex": "808080",
+          "codes": [
+            "8798938267825-46216348762289"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090",
+          "codes": [
+            "8798938267825-46216348958897"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "8798938267825-46216348663985"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Performance PETG HF Carbon Fiber {color_name}",
+      "material": "PETG-CF10",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        75,
+        90
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "10% - Prototyping",
+          "hex": "000000",
+          "codes": [
+            "FIL-1031-00-10-1-CPG"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Performance PETG HF Carbon Fiber {color_name}",
+      "material": "PETG-CF15",
+      "density": 1.32,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        75,
+        90
+      ],
+      "country_of_origin": "Canada",
+      "colors": [
+        {
+          "name": "15% - Functional Use",
+          "hex": "000000",
+          "codes": [
+            "6671027142833-42692098097329"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "7130394788017-41408171901105",
+            "FIL-1012-00-10-1-CAB"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    }
+  ]
+}

--- a/filaments/matterhackers.json
+++ b/filaments/matterhackers.json
@@ -1,0 +1,416 @@
+{
+  "manufacturer": "MatterHackers",
+  "filaments": [
+    {
+      "name": "MH Build Series PLA {color_name}",
+      "material": "PLA",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "044786"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a1b9a"
+        },
+        {
+          "name": "Pink",
+          "hex": "f48fb1"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    },
+    {
+      "name": "MH Build Series PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "044786"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "MH Build Series ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        95,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "044786"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    },
+    {
+      "name": "MH Build Series TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "MH Pro Series PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "044786"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a1b9a"
+        }
+      ]
+    },
+    {
+      "name": "MH Pro Series PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "044786"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "MH Pro Series Tough PLA {color_name}",
+      "material": "PLA",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "MH NylonX {color_name}",
+      "material": "PA-CF",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "MH NylonG {color_name}",
+      "material": "PA-GF",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 213,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        255,
+        275
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d8d0c0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/mecpow.json
+++ b/filaments/mecpow.json
@@ -1,0 +1,154 @@
+{
+  "manufacturer": "Mecpow",
+  "filaments": [
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "001eff"
+        },
+        {
+          "name": "Green",
+          "hex": "2bc700"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Pink",
+          "hex": "f358da"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Skin",
+          "hex": "ffb68f"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbff00"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2724ff"
+        },
+        {
+          "name": "Green",
+          "hex": "24ff2b"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff5900"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2424"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbff00"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1825e2"
+        },
+        {
+          "name": "Cyan",
+          "hex": "78eaf2"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "505ae7"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "fda0f5"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "b061ff"
+        },
+        {
+          "name": "Pink",
+          "hex": "e811c5"
+        },
+        {
+          "name": "Smoke Grey",
+          "hex": "8b9198"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/mika3d.json
+++ b/filaments/mika3d.json
@@ -1,0 +1,36 @@
+{
+    "manufacturer": "Mika3D",
+    "filaments": [
+        {
+            "name": "Mika3D Silk PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/mkoem.json
+++ b/filaments/mkoem.json
@@ -1,0 +1,252 @@
+{
+  "manufacturer": "MKOEM",
+  "filaments": [
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White to Sapphire Blue",
+          "hex": "56b9fc"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow in Dark Blue",
+          "hex": "8d9ea6"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        35,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Lime Green",
+          "hex": "b9ef55"
+        },
+        {
+          "name": "Peacock Blue",
+          "hex": "6dd2e9"
+        },
+        {
+          "name": "Red",
+          "hex": "da1b27"
+        },
+        {
+          "name": "Silver",
+          "hex": "878a8c"
+        },
+        {
+          "name": "White",
+          "hex": "f1f2f3"
+        },
+        {
+          "name": "Yellow",
+          "hex": "eef256"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1447e6"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00ffff"
+        },
+        {
+          "name": "Green",
+          "hex": "02a24c"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8904"
+        },
+        {
+          "name": "Purple",
+          "hex": "9035f8"
+        },
+        {
+          "name": "Red",
+          "hex": "e7180b"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fceb31"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black/Gold",
+          "hexes": [
+            "000000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/Purple",
+          "hexes": [
+            "000000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/White",
+          "hex": "000000"
+        },
+        {
+          "name": "Duasilk Blackgold",
+          "hex": "8d8907"
+        },
+        {
+          "name": "Lime Green/Blue",
+          "hexes": [
+            "77bb41",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Purple/Blue",
+          "hexes": [
+            "800080",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Silk Shiny Blue/White",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow/Pink",
+          "hexes": [
+            "ffff00",
+            "fff76b"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/monofilamentua.json
+++ b/filaments/monofilamentua.json
@@ -1,0 +1,248 @@
+{
+  "manufacturer": "Monofilament (UA)",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "030303"
+        },
+        {
+          "name": "Natural",
+          "hex": "c7c7c7"
+        }
+      ]
+    },
+    {
+      "name": "ABS+PLUS Pro {color_name}",
+      "material": "ABS+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        215
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black Gold",
+          "hex": "000000",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00ffff"
+        },
+        {
+          "name": "White/Blue",
+          "hexes": [
+            "52d6fc",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "White/Green",
+          "hexes": [
+            "b1dd8b",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Khaki",
+          "hex": "625431"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "8a8a8a"
+        },
+        {
+          "name": "White",
+          "hex": "fafffd"
+        },
+        {
+          "name": "White Pearl",
+          "hex": "edece9"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "ffc6c6"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0042a9"
+        },
+        {
+          "name": "Brown",
+          "hex": "563d00"
+        },
+        {
+          "name": "Khaki",
+          "hex": "625431"
+        },
+        {
+          "name": "Salad",
+          "hex": "adff2f"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/monoprice.json
+++ b/filaments/monoprice.json
@@ -1,0 +1,49 @@
+{
+  "manufacturer": "Monoprice",
+  "filaments": [
+    {
+      "name": "MP Select PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 210],
+      "bed_temp_range": [0, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    },
+    {
+      "name": "MP Select ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 240],
+      "bed_temp_range": [80, 100],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"}
+      ]
+    }
+  ]
+}

--- a/filaments/mosaic.json
+++ b/filaments/mosaic.json
@@ -1,0 +1,115 @@
+{
+  "manufacturer": "Mosaic",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.31,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 215,
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        }
+      ],
+      "country_of_origin": "Canada"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "Canada"
+    }
+  ]
+}

--- a/filaments/mxicomakers.json
+++ b/filaments/mxicomakers.json
@@ -1,0 +1,231 @@
+{
+  "manufacturer": "México Makers",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blanco",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Gris",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Negro",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Naranja Calabaza",
+          "hex": "ff9238"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Azul Real",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Blanco Perla",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Oro 24k",
+          "hex": "cccc00"
+        },
+        {
+          "name": "Rojo Cochinilla",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Rosa Peonia",
+          "hex": "ffd1fa"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Azul Cenote",
+          "hex": "31d3a5"
+        },
+        {
+          "name": "Blanco Calavera",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Negro Carbón",
+          "hex": "000000"
+        },
+        {
+          "name": "Negro Xolo",
+          "hex": "000000"
+        },
+        {
+          "name": "Piel",
+          "hex": "d2b48c"
+        },
+        {
+          "name": "Verde Menta",
+          "hex": "99ff99"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Creativa- Madera",
+          "hex": "deb887"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Amarillo Elote",
+          "hex": "f7fb04"
+        },
+        {
+          "name": "Azul Esperanza",
+          "hex": "00a3d7"
+        },
+        {
+          "name": "Lobo Gris",
+          "hex": "929292"
+        },
+        {
+          "name": "Morado Bugambilia",
+          "hex": "b674ec"
+        },
+        {
+          "name": "Rojo Nochebuena",
+          "hex": "ff0033"
+        },
+        {
+          "name": "Rosa Cora",
+          "hex": "ff99cc"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/naga.json
+++ b/filaments/naga.json
@@ -1,0 +1,204 @@
+{
+  "manufacturer": "NAGA",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Chocolate",
+          "hex": "808080"
+        },
+        {
+          "name": "Clear",
+          "hex": "808080"
+        },
+        {
+          "name": "Galaxy Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "59331f"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Coffee",
+          "hex": "cc9169"
+        },
+        {
+          "name": "Orange",
+          "hex": "f77c08"
+        },
+        {
+          "name": "Purple",
+          "hex": "a225d0"
+        },
+        {
+          "name": "teal",
+          "hex": "9efcff"
+        },
+        {
+          "name": "White",
+          "hex": "e5f2ff"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/nanovia.json
+++ b/filaments/nanovia.json
@@ -1,0 +1,43 @@
+{
+  "manufacturer": "Nanovia",
+  "filaments": [
+    {
+      "name": "PETG CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [220, 240],
+      "bed_temp_range": [80, 90],
+      "fill": "carbon fiber",
+      "colors": [
+        {"name": "Black", "hex": "101010"}
+      ]
+    },
+    {
+      "name": "ABS CF {color_name}",
+      "material": "ABS-CF",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [240, 260],
+      "bed_temp_range": [100, 110],
+      "fill": "carbon fiber",
+      "colors": [
+        {"name": "Black", "hex": "101010"}
+      ]
+    }
+  ]
+}

--- a/filaments/national3d.json
+++ b/filaments/national3d.json
@@ -1,0 +1,134 @@
+{
+  "manufacturer": "National3d",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "PRETO",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ABS Premium {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "LARANJA TRATOR",
+          "hex": "ff8200"
+        },
+        {
+          "name": "PRETO PIANO",
+          "hex": "000000"
+        },
+        {
+          "name": "VERDE KAWASAKI",
+          "hex": "66ff00"
+        }
+      ]
+    },
+    {
+      "name": "Max {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Amarelo Girassol",
+          "hex": "ccac15"
+        },
+        {
+          "name": "Azul Perolado",
+          "hex": "1b31cb"
+        },
+        {
+          "name": "Bege Areia",
+          "hex": "decba3"
+        },
+        {
+          "name": "Cinza Claro",
+          "hex": "a5b8bd"
+        },
+        {
+          "name": "Cobre",
+          "hex": "a97550"
+        },
+        {
+          "name": "Marrom Mogno",
+          "hex": "613f31"
+        },
+        {
+          "name": "Rosa Perolado",
+          "hex": "f544a4"
+        },
+        {
+          "name": "Verde Cítrico",
+          "hex": "c6ff54"
+        },
+        {
+          "name": "Verde Floresta",
+          "hex": "005126"
+        },
+        {
+          "name": "Vermelho Coração",
+          "hex": "a12c34"
+        },
+        {
+          "name": "Violet",
+          "hex": "6500ca"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/nebula.json
+++ b/filaments/nebula.json
@@ -1,0 +1,7611 @@
+{
+  "manufacturer": "Nebula",
+  "filaments": [
+    {
+      "name": "ABS Art Glowing {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-blue-1-75mm-0-5kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-green-1-75mm-0-5kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "ABS Art Glowing {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-blue-1-75mm-1kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-green-1-75mm-1kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "ABS Art Glowing {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-blue-1-75mm-2-5kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-green-1-75mm-2-5kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "ABS Art Glowing {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-blue-1-75mm-4kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-green-1-75mm-4kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "ABS Art Glowing {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-blue-1-75mm-8kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-abs-glowing-glowing-green-1-75mm-8kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "ABS Art Marble Gray {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-abs-marble-gray-marble-gray-1-75mm-0-5kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "ABS Art Marble Gray {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-abs-marble-gray-marble-gray-1-75mm-1kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "ABS Art Marble Gray {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-abs-marble-gray-marble-gray-1-75mm-2-5kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "ABS Art Marble Gray {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-abs-marble-gray-marble-gray-1-75mm-4kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "ABS Art Marble Gray {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-abs-marble-gray-marble-gray-1-75mm-8kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "ABS Art Thermo {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-red-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Art Thermo {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-red-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Art Thermo {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-blue-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-red-1-75mm-2-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Art Thermo {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-blue-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-red-1-75mm-4kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Art Thermo {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-blue-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-abs-thermo-thermo-red-1-75mm-8kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Tech 702 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aquamarine Blue",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-aquamarine-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-abs-702-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "tech-abs-702-copper-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Hay Yellow",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-hay-yellow-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Metalic Gold",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-metalic-gold-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-military-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-abs-702-natural-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-orange-fluo-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-abs-702-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Spring Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-spring-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-traffic-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-abs-702-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-yellow-fluo-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Tech 702 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aquamarine Blue",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-aquamarine-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-abs-702-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "tech-abs-702-copper-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Hay Yellow",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-hay-yellow-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Metalic Gold",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-metalic-gold-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-military-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-abs-702-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-orange-fluo-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Sample Pack",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-sample-pack"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-abs-702-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Spring Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-spring-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-traffic-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-abs-702-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-yellow-fluo-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Tech 702 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aquamarine Blue",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-aquamarine-blue-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-abs-702-black-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "tech-abs-702-copper-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-gray-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Hay Yellow",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-hay-yellow-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Metalic Gold",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-metalic-gold-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-military-green-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-abs-702-natural-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-orange-fluo-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-abs-702-silver-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Spring Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-spring-green-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-traffic-red-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-abs-702-white-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-yellow-fluo-1-75mm-2-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Tech 702 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aquamarine Blue",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-aquamarine-blue-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-abs-702-black-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Cooper",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-cooper-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-gray-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Hay Yellow",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-hay-yellow-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Metalic Gold",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-metalic-gold-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-military-green-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-abs-702-natural-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-orange-fluo-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-abs-702-silver-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Spring Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-spring-green-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-traffic-red-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-abs-702-white-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-yellow-fluo-1-75mm-4kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ABS Tech 702 {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aquamarine Blue",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-aquamarine-blue-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-abs-702-black-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Cooper",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-cooper-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-gray-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Hay Yellow",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-hay-yellow-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Metalic Gold",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-metalic-gold-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-military-green-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-abs-702-natural-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-orange-fluo-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-abs-702-silver-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Spring Green",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-spring-green-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-traffic-red-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-abs-702-white-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "tech-abs-702-yellow-fluo-1-75mm-8kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA Kevlar {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "asa-kevlar-black-1-75mm-0-8kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "asa-kevlar-natural-1-75mm-0-8kg"
+          ]
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "ASA Tech 301 {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-asa-301-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-asa-301-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-asa-301-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-asa-301-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-asa-301-natural-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-asa-301-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-asa-301-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-asa-301-yellow-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA Tech 301 {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-asa-301-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-asa-301-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-asa-301-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-asa-301-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-asa-301-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-asa-301-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-asa-301-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-asa-301-yellow-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA Tech 301 {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-asa-301-black-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-asa-301-blue-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-asa-301-gray-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-asa-301-green-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-asa-301-natural-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-asa-301-red-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-asa-301-white-1-75mm-2-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-asa-301-yellow-1-75mm-2-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA Tech 301 {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-asa-301-black-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-asa-301-blue-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-asa-301-gray-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-asa-301-green-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-asa-301-natural-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-asa-301-red-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-asa-301-white-1-75mm-4kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-asa-301-yellow-1-75mm-4kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA Tech 301 {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-asa-301-black-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-asa-301-blue-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-asa-301-gray-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-asa-301-green-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-asa-301-natural-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-asa-301-red-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-asa-301-white-1-75mm-8kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-asa-301-yellow-1-75mm-8kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS Tech 404 {color_name}",
+      "material": "HIPS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-hips-404-natural-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS Tech 404 {color_name}",
+      "material": "HIPS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-hips-404-natural-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS Tech 404 {color_name}",
+      "material": "HIPS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-hips-404-natural-1-75mm-2-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS Tech 404 {color_name}",
+      "material": "HIPS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 4000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-hips-404-natural-1-75mm-4kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HIPS Tech 404 {color_name}",
+      "material": "HIPS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 8000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-hips-404-natural-1-75mm-8kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PA12 CF15 {color_name}",
+      "material": "PA12-CF15",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "nylon-pa12-cf15-black-1-75mm-0-8kg"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG Art Chameleon {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "art-pet-g-chameleon-black-1-75mm-0-5kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        },
+        {
+          "name": "Light",
+          "codes": [
+            "art-pet-g-chameleon-light-1-75mm-0-5kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Art Chameleon {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Light",
+          "codes": [
+            "pet-g-chameleon-light-1-75mm-1kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Art Chameleon {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "art-pet-g-chameleon-black-1-75mm-3kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        },
+        {
+          "name": "Light",
+          "codes": [
+            "pet-g-chameleon-light-1-75mm-3kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Art Chameleon {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "art-pet-g-chameleon-black-1-75mm-5kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        },
+        {
+          "name": "Light",
+          "codes": [
+            "pet-g-chameleon-light-1-75mm-5kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Art Chameleon {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "art-pet-g-chameleon-black-1-75mm-9kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        },
+        {
+          "name": "Light",
+          "codes": [
+            "art-pet-g-chameleon-light-1-75mm-9kg"
+          ],
+          "multi_color_direction": "coaxial",
+          "hexes": [
+            "008080",
+            "40e0d0",
+            "9370db",
+            "ff69b4"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG CF10 {color_name}",
+      "material": "PETG-CF10",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        75,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "pet-g-cf-10-black-1-75mm-0-8kg"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PLA Art Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Galaxy Cobalt",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-galaxy-cobalt-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Glamour Rose",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glamour-rose-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Glorious Anthracite",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glorious-anthracite-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Latte Beige",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-latte-beige-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Nautical Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-nautical-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Starlight Black",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-starlight-black-1-75mm-0-5kg"
+          ]
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Art Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Galaxy Cobalt",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-galaxy-cobalt-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Glamour Rose",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glamour-rose-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Glorious Anthracite",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glorious-anthracite-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Latte Beige",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-latte-beige-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Nautical Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-nautical-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Starlight Black",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-starlight-black-1-75mm-1kg"
+          ]
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Art Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Galaxy Cobalt",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-galaxy-cobalt-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Glamour Rose",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glamour-rose-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Glorious Anthracite",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glorious-anthracite-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Latte Beige",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-latte-beige-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Nautical Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-nautical-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Starlight Black",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-starlight-black-1-75mm-3kg"
+          ]
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Art Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Galaxy Cobalt",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-galaxy-cobalt-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Glamour Rose",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glamour-rose-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Glorious Anthracite",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glorious-anthracite-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Latte Beige",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-latte-beige-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Nautical Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-nautical-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Starlight Black",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-starlight-black-1-75mm-5kg"
+          ]
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Art Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Galaxy Cobalt",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-galaxy-cobalt-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Glamour Rose",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glamour-rose-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Glorious Anthracite",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-glorious-anthracite-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Latte Beige",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-latte-beige-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Nautical Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-nautical-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Starlight Black",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glitter-starlight-black-1-75mm-9kg"
+          ]
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Art Glowing {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-blue-1-75mm-0-5kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-green-1-75mm-0-5kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "PLA Art Glowing {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-blue-1-75mm-1kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-green-1-75mm-1kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "PLA Art Glowing {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-blue-1-75mm-3kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-green-1-75mm-3kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "PLA Art Glowing {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-blue-1-75mm-5kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-green-1-75mm-5kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "PLA Art Glowing {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Glowing Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-blue-1-75mm-9kg"
+          ],
+          "glow": true
+        },
+        {
+          "name": "Glowing Green",
+          "hex": "808080",
+          "codes": [
+            "art-pla-glowing-glowing-green-1-75mm-9kg"
+          ],
+          "glow": true
+        }
+      ],
+      "glow": true
+    },
+    {
+      "name": "PLA Art Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-pla-marble-marble-gray-1-75mm-0-5kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Art Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-pla-marble-marble-gray-1-75mm-1kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Art Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-pla-marble-marble-gray-1-75mm-3kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Art Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-pla-marble-marble-gray-1-75mm-5kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Art Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Marble Gray",
+          "hex": "b0b0b0",
+          "codes": [
+            "art-pla-marble-marble-gray-1-75mm-9kg"
+          ]
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Art Mystic Green {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Mystic Green",
+          "hex": "2e8b57",
+          "codes": [
+            "art-pla-mystic-green-mystic-green-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Mystic Green {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Mystic Green",
+          "hex": "2e8b57",
+          "codes": [
+            "art-pla-mystic-green-mystic-green-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Mystic Green {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Mystic Green",
+          "hex": "2e8b57",
+          "codes": [
+            "art-pla-mystic-green-mystic-green-1-75mm-3kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Mystic Green {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Mystic Green",
+          "hex": "2e8b57",
+          "codes": [
+            "art-pla-mystic-green-mystic-green-1-75mm-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Mystic Green {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Mystic Green",
+          "hex": "2e8b57",
+          "codes": [
+            "art-pla-mystic-green-mystic-green-1-75mm-9kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Thermo {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-red-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Thermo {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-red-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Thermo {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-red-1-75mm-3kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Thermo {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-red-1-75mm-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Art Thermo {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Thermo Blue",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Thermo Red",
+          "hex": "808080",
+          "codes": [
+            "art-pla-thermo-thermo-red-1-75mm-9kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 607 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-607-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-607-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-607-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-607-natural-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-607-orange-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-607-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-607-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-607-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-607-yellow-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 607 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-607-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-607-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-607-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-607-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-607-orange-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-607-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-607-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-607-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-607-yellow-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 607 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-607-black-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-607-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-gray-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-607-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-607-natural-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-607-orange-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-607-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-607-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-607-white-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-607-yellow-1-75mm-3kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 607 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-607-black-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-607-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-gray-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-607-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-607-natural-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-607-orange-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-607-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-607-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-607-white-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-607-yellow-1-75mm-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 607 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-607-black-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-607-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-607-gray-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-607-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-607-natural-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-607-orange-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-607-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-607-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-607-white-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-607-yellow-1-75mm-9kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 609 HD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-609-hd-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-609-hd-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-609-hd-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-609-hd-natural-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-609-hd-orange-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-609-hd-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-609-hd-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-609-hd-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-609-hd-yellow-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 609 HD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-609-hd-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-609-hd-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-609-hd-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-609-hd-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-609-hd-orange-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-609-hd-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-609-hd-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-609-hd-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-609-hd-yellow-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 609 HD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-609-hd-black-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-609-hd-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-gray-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-609-hd-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-609-hd-natural-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-609-hd-orange-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-609-hd-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-609-hd-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-609-hd-white-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-609-hd-yellow-1-75mm-3kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 609 HD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-609-hd-black-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-609-hd-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-gray-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-609-hd-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-609-hd-natural-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-609-hd-orange-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-609-hd-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-609-hd-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-609-hd-white-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-609-hd-yellow-1-75mm-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Tech 609 HD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "tech-pla-609-hd-black-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "tech-pla-609-hd-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Brown",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "tech-pla-609-hd-gray-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "tech-pla-609-hd-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "tech-pla-609-hd-natural-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "tech-pla-609-hd-orange-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "tech-pla-609-hd-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "tech-pla-609-hd-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": [
+            "tech-pla-609-hd-white-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "tech-pla-609-hd-yellow-1-75mm-9kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Arctic Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-arctic-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-blue-sky-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-carbon-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-chocolate-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-emerald-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Iron Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-iron-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-light-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Lime Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-lime-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-midnight-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-military-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pet-g-natural-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-navy-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-neon-yellow-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pet-g-orange-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-fluo-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange Peach",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-peach-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pearl White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pearl-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "premium-pet-g-pink-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pudding Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pudding-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pure-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pet-g-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Rubin Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-rubin-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Satin Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-satin-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Sunset Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-sunset-yellow-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Vanilia",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-vanilia-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Watercolor Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-watercolor-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "pet-g-yellow-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-gold-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Lemon",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-lemon-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Arctic Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-arctic-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-blue-sky-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-carbon-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-chocolate-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-emerald-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Iron Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-iron-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-light-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Lime Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-lime-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-midnight-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-military-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pet-g-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-navy-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-neon-yellow-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pet-g-orange-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-fluo-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange Peach",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-peach-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pearl White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pearl-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "premium-pet-g-pink-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pudding Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pudding-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pure-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pet-g-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Rubin Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-rubin-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Sample Pack",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-sample-pack"
+          ]
+        },
+        {
+          "name": "Satin Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-satin-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Sunset Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-sunset-yellow-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Transition",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-transition-1kg"
+          ]
+        },
+        {
+          "name": "V0 Fr Black",
+          "hex": "808080",
+          "codes": [
+            "pet-g-v0-fr-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "V0 Fr Natural",
+          "hex": "808080",
+          "codes": [
+            "pet-g-v0-fr-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Vanilia",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-vanilia-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Watercolor Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-watercolor-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "pet-g-yellow-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-gold-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Yellow Lemon",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-lemon-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Arctic Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-arctic-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-blue-sky-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-carbon-black-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-chocolate-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-emerald-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-gray-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Iron Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-iron-gray-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-light-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Lime Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-lime-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-midnight-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-military-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pet-g-natural-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-navy-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-neon-yellow-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pet-g-orange-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-fluo-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange Peach",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-peach-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pearl White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pearl-white-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "premium-pet-g-pink-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pudding Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pudding-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pure-white-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pet-g-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Rubin Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-rubin-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Satin Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-satin-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Sunset Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-sunset-yellow-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Vanilia",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-vanilia-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Watercolor Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-watercolor-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "pet-g-yellow-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-gold-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Yellow Lemon",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-lemon-1-75mm-3kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Arctic Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-arctic-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-blue-sky-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-carbon-black-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-chocolate-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-emerald-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-gray-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Iron Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-iron-gray-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-light-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Lime Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-lime-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-midnight-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-military-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pet-g-natural-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-navy-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-neon-yellow-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pet-g-orange-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-fluo-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange Peach",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-peach-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pearl White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pearl-white-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "premium-pet-g-pink-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pudding Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pudding-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pure-white-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pet-g-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Rubin Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-rubin-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Satin Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-satin-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Sunset Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-sunset-yellow-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Vanilia",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-vanilia-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Watercolor Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-watercolor-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "pet-g-yellow-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-gold-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Lemon",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-lemon-1-75mm-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Arctic Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-arctic-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-blue-sky-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-carbon-black-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-chocolate-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-emerald-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-gray-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Iron Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-iron-gray-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Light Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-light-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Lime Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-lime-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-midnight-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-military-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pet-g-natural-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-navy-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-neon-yellow-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pet-g-orange-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-fluo-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange Peach",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-orange-peach-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pearl White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pearl-white-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "premium-pet-g-pink-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pudding Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pudding-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-pure-white-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pet-g-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Rubin Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-rubin-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Satin Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-satin-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Sunset Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-sunset-yellow-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Vanilia",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-vanilia-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Watercolor Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-watercolor-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700",
+          "codes": [
+            "pet-g-yellow-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-gold-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Yellow Lemon",
+          "hex": "808080",
+          "codes": [
+            "premium-pet-g-yellow-lemon-1-75mm-9kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-aqua-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-beige-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-blue-sky-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Bright Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-bright-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-carbon-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-chocolate-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "premium-pla-copper-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-dark-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Fancy Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fancy-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fire-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Fresh Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fresh-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-gold-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-gray-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Green Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-fluo-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Green Grass",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-grass-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Green Pistachio",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-pistachio-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Latte Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-latte-brown-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Lavender Field",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lavender-field-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "808080",
+          "codes": [
+            "pla-light-blue-1-75mm-0-5kg",
+            "premium-pla-light-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-light-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Liliac Violet",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-liliac-violet-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Lolipop Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lolipop-pink-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Majestic Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-majestic-gold-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Mermaid Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mermaid-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Metalic Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-metalic-black-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Metalic Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-metalic-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-military-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Mountain Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mountain-fuchsia-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pla-natural-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Old Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-old-gold-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pla-orange-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-orange-fluo-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pearl Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pearl-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Plum",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-plum-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pumpkin-orange-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pure-white-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pla-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Red Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-red-fluo-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Satin Rose",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-satin-rose-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Scarlet Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-scarlet-red-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Storm Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-storm-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Sunny Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-sunny-yellow-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "808080",
+          "codes": [
+            "pla-teal-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-yellow-fluo-1-75mm-0-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-aqua-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-beige-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-blue-sky-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Bright Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-bright-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-carbon-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-chocolate-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "premium-pla-copper-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-dark-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Fancy Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fancy-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fire-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Fresh Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fresh-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-gold-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Green Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-fluo-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Green Grass",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-grass-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Green Pistachio",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-pistachio-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Hs Black",
+          "hex": "808080",
+          "codes": [
+            "pla-hs-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Hs Gray",
+          "hex": "808080",
+          "codes": [
+            "pla-hs-gray-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Hs White2",
+          "hex": "808080",
+          "codes": [
+            "pla-hs-white2-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Latte Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-latte-brown-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Lavender Field",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lavender-field-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-light-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-light-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Liliac Violet",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-liliac-violet-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Lolipop Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lolipop-pink-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Majestic Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-majestic-gold-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Mermaid Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mermaid-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Metalic Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-metalic-black-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Metalic Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-metalic-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-military-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Mountain Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mountain-fuchsia-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pla-natural-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Old Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-old-gold-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pla-orange-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-orange-fluo-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pearl Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pearl-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Plum",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-plum-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pumpkin-orange-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pure-white-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pla-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Red Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-red-fluo-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Sample Pack",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-sample-pack"
+          ]
+        },
+        {
+          "name": "Satin Rose",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-satin-rose-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Scarlet Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-scarlet-red-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Storm Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-storm-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Sunny Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-sunny-yellow-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "808080",
+          "codes": [
+            "pla-teal-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Transition",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-transition-1kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-yellow-fluo-1-75mm-1kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-aqua-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-beige-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-blue-sky-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Bright Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-bright-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-carbon-black-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-chocolate-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "premium-pla-copper-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-dark-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Fancy Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fancy-gray-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fire-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Fresh Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fresh-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-gold-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-gray-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Green Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-fluo-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Green Grass",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-grass-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Green Pistachio",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-pistachio-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Latte Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-latte-brown-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Lavender Field",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lavender-field-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "808080",
+          "codes": [
+            "pla-light-blue-1-75mm-3kg",
+            "premium-pla-light-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-light-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Liliac Violet",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-liliac-violet-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Lolipop Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lolipop-pink-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Majestic Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-majestic-gold-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Mermaid Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mermaid-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Metalic Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-metalic-black-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Metalic Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-metalic-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-military-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Mountain Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mountain-fuchsia-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pla-natural-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Old Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-old-gold-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pla-orange-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-orange-fluo-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pearl Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pearl-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Plum",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-plum-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pumpkin-orange-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pure-white-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pla-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Red Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-red-fluo-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Satin Rose",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-satin-rose-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Scarlet Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-scarlet-red-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Storm Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-storm-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Sunny Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-sunny-yellow-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "808080",
+          "codes": [
+            "pla-teal-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-yellow-fluo-1-75mm-3kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-aqua-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-beige-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-blue-sky-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Bright Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-bright-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-carbon-black-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-chocolate-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "premium-pla-copper-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-dark-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Fancy Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fancy-gray-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fire-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Fresh Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fresh-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-gold-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-gray-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Green Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-fluo-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Green Grass",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-grass-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Green Pistachio",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-pistachio-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Latte Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-latte-brown-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Lavender Field",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lavender-field-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "808080",
+          "codes": [
+            "pla-light-blue-1-75mm-5kg",
+            "premium-pla-light-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-light-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Liliac Violet",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-liliac-violet-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Lolipop Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lolipop-pink-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Majestic Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-majestic-gold-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Mermaid Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mermaid-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Metalic Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-metalic-black-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Metalic Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-metalic-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-military-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Mountain Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mountain-fuchsia-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pla-natural-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Old Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-old-gold-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pla-orange-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-orange-fluo-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pearl Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pearl-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Plum",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-plum-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pumpkin-orange-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pure-white-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pla-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Red Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-red-fluo-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Satin Rose",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-satin-rose-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Scarlet Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-scarlet-red-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Storm Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-storm-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Sunny Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-sunny-yellow-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "808080",
+          "codes": [
+            "pla-teal-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-yellow-fluo-1-75mm-5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-aqua-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-beige-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Blue Sky",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-blue-sky-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Bright Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-bright-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-carbon-black-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-chocolate-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "premium-pla-copper-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-dark-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Fancy Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fancy-gray-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fire-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Fresh Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-fresh-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-gold-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-gray-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Green Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-fluo-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Green Grass",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-grass-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Green Pistachio",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-green-pistachio-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Latte Brown",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-latte-brown-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Lavender Field",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lavender-field-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Light Blue",
+          "hex": "808080",
+          "codes": [
+            "pla-light-blue-1-75mm-9kg",
+            "premium-pla-light-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Light Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-light-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Liliac Violet",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-liliac-violet-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Lolipop Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-lolipop-pink-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Majestic Gold",
+          "hex": "daa520",
+          "codes": [
+            "premium-pla-majestic-gold-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Mermaid Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mermaid-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Metalic Black",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-metalic-black-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Metalic Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-metalic-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Military Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-military-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Mountain Fuchsia",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-mountain-fuchsia-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "f5deb3",
+          "codes": [
+            "premium-pla-natural-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Old Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-old-gold-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "premium-pla-orange-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-orange-fluo-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pearl Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pearl-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Plum",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-plum-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pumpkin-orange-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Pure White",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-pure-white-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "premium-pla-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Red Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-red-fluo-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Satin Rose",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-satin-rose-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Scarlet Red",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-scarlet-red-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "premium-pla-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Storm Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-storm-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Sunny Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-sunny-yellow-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Teal",
+          "hex": "808080",
+          "codes": [
+            "pla-teal-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Yellow Fluo",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-yellow-fluo-1-75mm-9kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Premium PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-baby-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Blue Crystal",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-blue-crystal-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Bottle Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bottle-green-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Brilliant Purple",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-brilliant-purple-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bubblegum-pink-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Citron Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-citron-yellow-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Lemon Lime",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-lemon-lime-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Peach Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-peach-pink-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Royal Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-royal-gold-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Sharp Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-sharp-blue-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Titanium Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-titanium-silver-1-75mm-0-5kg"
+          ]
+        },
+        {
+          "name": "Watermelon",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-watermelon-1-75mm-0-5kg"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Premium PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-baby-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Blue Crystal",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-blue-crystal-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Bottle Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bottle-green-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Brilliant Purple",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-brilliant-purple-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bubblegum-pink-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Citron Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-citron-yellow-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Lemon Lime",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-lemon-lime-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Peach Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-peach-pink-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Royal Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-royal-gold-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Sample Pack",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-sample-pack"
+          ]
+        },
+        {
+          "name": "Sharp Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-sharp-blue-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Titanium Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-titanium-silver-1-75mm-1kg"
+          ]
+        },
+        {
+          "name": "Watermelon",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-watermelon-1-75mm-1kg"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Premium PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-baby-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Blue Crystal",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-blue-crystal-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Bottle Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bottle-green-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Brilliant Purple",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-brilliant-purple-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bubblegum-pink-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Citron Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-citron-yellow-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Lemon Lime",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-lemon-lime-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Peach Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-peach-pink-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Royal Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-royal-gold-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Sharp Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-sharp-blue-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Titanium Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-titanium-silver-1-75mm-3kg"
+          ]
+        },
+        {
+          "name": "Watermelon",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-watermelon-1-75mm-3kg"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Premium PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-baby-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Blue Crystal",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-blue-crystal-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Bottle Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bottle-green-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Brilliant Purple",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-brilliant-purple-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bubblegum-pink-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Citron Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-citron-yellow-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Lemon Lime",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-lemon-lime-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Peach Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-peach-pink-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Royal Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-royal-gold-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Sharp Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-sharp-blue-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Titanium Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-titanium-silver-1-75mm-5kg"
+          ]
+        },
+        {
+          "name": "Watermelon",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-watermelon-1-75mm-5kg"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "Premium PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 9000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Baby Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-baby-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Blue Crystal",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-blue-crystal-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Bottle Green",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bottle-green-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Brilliant Purple",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-brilliant-purple-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-bubblegum-pink-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Citron Yellow",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-citron-yellow-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Lemon Lime",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-lemon-lime-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Peach Pink",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-peach-pink-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Royal Gold",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-royal-gold-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Sharp Blue",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-sharp-blue-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Titanium Silver",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-titanium-silver-1-75mm-9kg"
+          ]
+        },
+        {
+          "name": "Watermelon",
+          "hex": "808080",
+          "codes": [
+            "premium-pla-silk-watermelon-1-75mm-9kg"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    }
+  ]
+}

--- a/filaments/neofil3d.json
+++ b/filaments/neofil3d.json
@@ -1,0 +1,101 @@
+{
+  "manufacturer": "Neofil3D",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "30a8fd"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Magenta",
+          "hex": "d400ff"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "country_of_origin": "Spain"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cobalt Blue",
+          "hex": "0a7df0"
+        },
+        {
+          "name": "Deep Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Zöld RE-PLA",
+          "hex": "0ce425"
+        }
+      ],
+      "country_of_origin": "Spain"
+    }
+  ]
+}

--- a/filaments/nevsbye.json
+++ b/filaments/nevsbye.json
@@ -1,0 +1,375 @@
+{
+  "manufacturer": "NevsBye",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0037db"
+        },
+        {
+          "name": "Grey",
+          "hex": "9c9c9c"
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "1854de"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "00050a"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "dac32f"
+        },
+        {
+          "name": "Green",
+          "hex": "58a79a"
+        },
+        {
+          "name": "Orange",
+          "hex": "ca7344"
+        },
+        {
+          "name": "Starry Blue",
+          "hex": "2d639a"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdd00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "fae7da"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "80a4d0"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513"
+        },
+        {
+          "name": "Green",
+          "hex": "68ffbd"
+        },
+        {
+          "name": "Macaron",
+          "hex": "a9b8d8"
+        },
+        {
+          "name": "Pink",
+          "hex": "dc8add"
+        },
+        {
+          "name": "Purple",
+          "hex": "c6a5c6"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9f06b"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "2c2d2f"
+        },
+        {
+          "name": "Blue",
+          "hex": "49bafb"
+        },
+        {
+          "name": "Bronze",
+          "hex": "cd7f32"
+        },
+        {
+          "name": "Holly Green",
+          "hex": "5b6d51"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "bromn",
+          "hex": "6f0000"
+        },
+        {
+          "name": "Brown",
+          "hex": "2f1414"
+        },
+        {
+          "name": "Green",
+          "hex": "0d930b"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Purple",
+          "hex": "008bda"
+        },
+        {
+          "name": "Blue Red",
+          "hex": "308ce8"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Purple Black",
+          "hex": "008bda"
+        },
+        {
+          "name": "RedBlueGreen",
+          "hex": "2915c1"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "d6d6d6"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/nexaforge.json
+++ b/filaments/nexaforge.json
@@ -1,0 +1,170 @@
+{
+  "manufacturer": "Nexaforge",
+  "filaments": [
+    {
+      "name": "Air {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "fbbd04"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "172bb1"
+        },
+        {
+          "name": "Brown",
+          "hex": "321e01"
+        },
+        {
+          "name": "Gold",
+          "hex": "9f501f"
+        },
+        {
+          "name": "Gray",
+          "hex": "a09ea6"
+        },
+        {
+          "name": "Orange",
+          "hex": "a12222"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff36f7"
+        },
+        {
+          "name": "Purple",
+          "hex": "391787"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "4c4d53"
+        },
+        {
+          "name": "Skin",
+          "hex": "ba896f"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "c4bc00"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "400000"
+        },
+        {
+          "name": "Gold",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff8c8c"
+        },
+        {
+          "name": "Purple",
+          "hex": "ff6fff"
+        },
+        {
+          "name": "Silver",
+          "hex": "888888"
+        },
+        {
+          "name": "Skin",
+          "hex": "f7d9a8"
+        },
+        {
+          "name": "Transparent",
+          "hex": "000000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ninjatek.json
+++ b/filaments/ninjatek.json
@@ -1,0 +1,227 @@
+{
+  "manufacturer": "NinjaTek",
+  "filaments": [
+    {
+      "name": "NinjaFlex {color_name}",
+      "material": "TPU",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 329,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        225,
+        250
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "323239"
+        },
+        {
+          "name": "Snow White",
+          "hex": "f2f5f8"
+        },
+        {
+          "name": "Steel Gray",
+          "hex": "b7bab4"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "e13326"
+        },
+        {
+          "name": "Lava Orange",
+          "hex": "f85a22"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "1746a1"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "8bd25a"
+        },
+        {
+          "name": "Sun Yellow",
+          "hex": "fbca18"
+        },
+        {
+          "name": "Water Translucent",
+          "hex": "eaeaea",
+          "translucent": true
+        },
+        {
+          "name": "Flamingo Pink",
+          "hex": "fc8eac"
+        },
+        {
+          "name": "Neon Glow",
+          "hex": "e0f7d4",
+          "glow": true
+        }
+      ]
+    },
+    {
+      "name": "Cheetah {color_name}",
+      "material": "TPU",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 329,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "bed_temp_range": [
+        0,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "323239"
+        },
+        {
+          "name": "Snow White",
+          "hex": "f2f5f8"
+        },
+        {
+          "name": "Steel Gray",
+          "hex": "b7bab4"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "e13326"
+        },
+        {
+          "name": "Lava Orange",
+          "hex": "f85a22"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "1746a1"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "8bd25a"
+        },
+        {
+          "name": "Sun Yellow",
+          "hex": "fbca18"
+        },
+        {
+          "name": "Water Translucent",
+          "hex": "eaeaea",
+          "translucent": true
+        },
+        {
+          "name": "Flamingo Pink",
+          "hex": "fc8eac"
+        },
+        {
+          "name": "Neon Glow",
+          "hex": "e0f7d4",
+          "glow": true
+        }
+      ]
+    },
+    {
+      "name": "Armadillo {color_name}",
+      "material": "TPU",
+      "density": 1.18,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_weight": 329,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "323239"
+        },
+        {
+          "name": "Snow White",
+          "hex": "f2f5f8"
+        },
+        {
+          "name": "Steel Gray",
+          "hex": "b7bab4"
+        },
+        {
+          "name": "Fire Red",
+          "hex": "e13326"
+        },
+        {
+          "name": "Lava Orange",
+          "hex": "f85a22"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "1746a1"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "8bd25a"
+        },
+        {
+          "name": "Sun Yellow",
+          "hex": "fbca18"
+        },
+        {
+          "name": "Water Translucent",
+          "hex": "eaeaea",
+          "translucent": true
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/nobrand.json
+++ b/filaments/nobrand.json
@@ -1,0 +1,334 @@
+{
+  "manufacturer": "No Brand",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        205
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        110,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Purple",
+          "hex": "8000ff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "030303"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black+Red+Yellow",
+          "hexes": [
+            "000000",
+            "ff0000",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gray to White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Grafffite",
+          "hex": "505050"
+        },
+        {
+          "name": "Orange",
+          "hex": "ea8839"
+        },
+        {
+          "name": "Red Cupper",
+          "hex": "cc531e"
+        },
+        {
+          "name": "Silver",
+          "hex": "bbbbbb"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Bronze",
+          "hex": "924302"
+        },
+        {
+          "name": "Green",
+          "hex": "00a400"
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "a9ff99"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff80c0"
+        },
+        {
+          "name": "Purple",
+          "hex": "ad03c4"
+        },
+        {
+          "name": "red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Skin",
+          "hex": "e2b492"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "Watermelon Red",
+          "hex": "ff85a9"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Purple",
+          "hex": "9c51e6"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/nobufil.json
+++ b/filaments/nobufil.json
@@ -1,0 +1,132 @@
+{
+	"manufacturer": "Nobufil",
+	"filaments": [
+		{
+			"name": "{color_name}",
+			"material": "PETG",
+			"density": 1.27,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_weight": 234
+				}
+			],
+			"diameters": [
+				1.75
+			],
+			"extruder_temp": 235,
+			"bed_temp": 75,
+			"colors": [
+				{
+					"name": "Yellow",
+					"hex": "FFFF00"
+				},
+				{
+					"name": "Brown",
+					"hex": "A52A2A"
+				},
+				{
+					"name": "Black",
+					"hex": "000000"
+				},
+				{
+					"name": "White",
+					"hex": "FFFFFF"
+				},
+				{
+					"name": "Green",
+					"hex": "00FF00"
+				},
+				{
+					"name": "Blue",
+					"hex": "0000FF"
+				},
+				{
+					"name": "Classic Grey",
+					"hex": "e9e9e9"
+				},
+				{
+					"name": "Industrial Dark Grey",
+					"hex": "909090"
+				}
+			]
+		},
+		{
+			"name": "Matte {color_name}",
+			"material": "PLAX",
+			"density": 1.19,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_weight": 234
+				}
+			],
+			"diameters": [
+				1.75
+			],
+			"extruder_temp": 225,
+			"bed_temp": 65,
+			"finish": "matte",
+			"colors": [
+				{
+					"name": "White",
+					"hex": "FFFFFF"
+				},
+				{
+					"name": "Black",
+					"hex": "000000"
+				},
+				{
+					
+					"name": "Artist Grey",
+					"hex": "BAC3CD"
+				}
+			]
+		},
+		{
+			"name": "Matte {color_name}",
+			"material": "PETG",
+			"density": 1.27,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_weight": 234
+				}
+			],
+			"diameters": [
+				1.75
+			],
+			"extruder_temp": 235,
+			"bed_temp": 75,
+			"finish": "matte",
+			"colors": [
+				{
+					"name": "Black",
+					"hex": "000000"
+				}
+			]
+		},
+		{
+			"name": "{color_name}",
+			"material": "PLA-CF",
+			"density": 1.19,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_weight": 234
+				}
+			],
+			"diameters": [
+				1.75
+			],
+			"extruder_temp": 225,
+			"bed_temp": 65,
+			"colors": [
+				{
+					"name": "Black",
+					"hex": "000000"
+				}
+			]
+		}
+	]
+}

--- a/filaments/noulei.json
+++ b/filaments/noulei.json
@@ -1,0 +1,40 @@
+{
+    "manufacturer": "Noulei",
+    "filaments": [
+        {
+            "name": "Noulei Silk PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Antique Gold",
+                    "hex": "D4AF37"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                },
+                {
+                    "name": "Bronze",
+                    "hex": "CD7F32"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/novamaker.json
+++ b/filaments/novamaker.json
@@ -1,0 +1,51 @@
+{
+  "manufacturer": "NOVAMAKER",
+  "filaments": [
+    {
+      "name": "NOVAMAKER PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [25, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    },
+    {
+      "name": "NOVAMAKER PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [70, 80],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Gray", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"}
+      ]
+    }
+  ]
+}

--- a/filaments/nxtfab.json
+++ b/filaments/nxtfab.json
@@ -1,0 +1,130 @@
+{
+  "manufacturer": "NXTFAB",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "Silver",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent Red",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Green",
+          "hex": "0000a0"
+        },
+        {
+          "name": "Purple Blue",
+          "hex": "b000b0"
+        },
+        {
+          "name": "Red Blue",
+          "hex": "bd005f"
+        },
+        {
+          "name": "Red Green",
+          "hex": "c40000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ovv3d.json
+++ b/filaments/ovv3d.json
@@ -1,0 +1,490 @@
+{
+  "manufacturer": "OVV3D",
+  "filaments": [
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "B0BTT2TVKG"
+          ]
+        },
+        {
+          "name": "Gold Coffee",
+          "hex": "b8860b",
+          "codes": [
+            "B0BTT2QJ7G"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "B0BTT224RV"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "B0G6CWC8QY"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Black & Blue",
+          "hexes": [
+            "000000",
+            "0066cc"
+          ],
+          "codes": [
+            "B0B138D2JL"
+          ]
+        },
+        {
+          "name": "Black & Green",
+          "hexes": [
+            "000000",
+            "228b22"
+          ],
+          "pattern": "sparkle",
+          "codes": [
+            "B0B13N3JHL"
+          ]
+        },
+        {
+          "name": "Black & Purple",
+          "hexes": [
+            "000000",
+            "800080"
+          ],
+          "codes": [
+            "B0B136CDLF",
+            "B0GTTVNJ88"
+          ]
+        },
+        {
+          "name": "Blue & Green",
+          "hexes": [
+            "0066cc",
+            "228b22"
+          ],
+          "codes": [
+            "B0BP76FTBP"
+          ]
+        },
+        {
+          "name": "Purple & Sky Blue",
+          "hexes": [
+            "800080",
+            "87ceeb"
+          ],
+          "codes": [
+            "B0CZ469ZMT"
+          ]
+        },
+        {
+          "name": "Red & Gold",
+          "hexes": [
+            "cc0000",
+            "daa520"
+          ],
+          "codes": [
+            "B0D4553N1Q"
+          ]
+        },
+        {
+          "name": "Silver & Grey",
+          "hexes": [
+            "c0c0c0",
+            "808080"
+          ],
+          "codes": [
+            "B0D8132JTP"
+          ]
+        },
+        {
+          "name": "Sky Blue & Rose Red",
+          "hexes": [
+            "87ceeb",
+            "ff007f"
+          ],
+          "codes": [
+            "B0BKKYB44F"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA Tri {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Blue-Green-Orange",
+          "hexes": [
+            "0066cc",
+            "228b22",
+            "ff8c00"
+          ],
+          "codes": [
+            "B0B9824FXH"
+          ]
+        },
+        {
+          "name": "Blue-Red-Green",
+          "hexes": [
+            "0066cc",
+            "cc0000",
+            "228b22"
+          ],
+          "codes": [
+            "B0B3JV15XH"
+          ]
+        },
+        {
+          "name": "Red-Yellow-Blue",
+          "hexes": [
+            "cc0000",
+            "ffff00",
+            "0066cc"
+          ],
+          "codes": [
+            "B0B431Y8RJ"
+          ]
+        },
+        {
+          "name": "Sky Blue-Rose Red-Green",
+          "hexes": [
+            "87ceeb",
+            "ff007f",
+            "228b22"
+          ],
+          "codes": [
+            "B0CKR7FJ19"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Matte PLA Tri {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "matte",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Red-Yellow-Blue",
+          "hexes": [
+            "cc0000",
+            "ffff00",
+            "0066cc"
+          ],
+          "codes": [
+            "B0DBZQZBRV"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Tri {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Red-Yellow-Blue",
+          "hexes": [
+            "cc0000",
+            "ffff00",
+            "0066cc"
+          ],
+          "codes": [
+            "B0FPCRTTHF"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Rainbow {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Gradient Multi-Color",
+          "hexes": [
+            "ff0000",
+            "ff7f00",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "4b0082",
+            "8b00ff"
+          ],
+          "codes": [
+            "B0FRXPV5KZ"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Translucent PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Blue-Purple Gradient",
+          "hexes": [
+            "0066cc",
+            "800080"
+          ],
+          "translucent": true,
+          "codes": [
+            "B0FRXX4WZ5"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Marble PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "pattern": "marble",
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Stone Brown Gradient",
+          "hexes": [
+            "8b7355",
+            "d2b48c",
+            "a0522d"
+          ],
+          "codes": [
+            "B0FRXZ2DWP"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Wood PLA Bundle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "fill": "wood",
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Walnut Oak Cherry Teak",
+          "hexes": [
+            "5c4033",
+            "c19a6b",
+            "de3163",
+            "b8860b"
+          ],
+          "codes": [
+            "B0BZ8XWX5D"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA Dual Bundle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "multi_color_direction": "longitudinal",
+      "colors": [
+        {
+          "name": "Red Gold Blue Green Sky Blue",
+          "hexes": [
+            "cc0000",
+            "daa520",
+            "0066cc",
+            "228b22",
+            "87ceeb"
+          ],
+          "codes": [
+            "B0BKKX9N9T"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/owlfilament.json
+++ b/filaments/owlfilament.json
@@ -1,0 +1,352 @@
+{
+  "manufacturer": "OWL-Filament",
+  "filaments": [
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Aluminium White",
+          "hex": "c0c2c4"
+        },
+        {
+          "name": "Blau Metallic (Ray 5026)",
+          "hex": "0433ff"
+        },
+        {
+          "name": "Grün Metallic(RAL 6036)",
+          "hex": "4f7a28"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold Metallic",
+          "hex": "582d04"
+        },
+        {
+          "name": "Violett Metallic (RAL4007)",
+          "hex": "47243c"
+        }
+      ]
+    },
+    {
+      "name": "Neon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Neon green (RAL 6018)",
+          "hex": "599a39"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Azurblau (RAL 5009)",
+          "hex": "245878"
+        },
+        {
+          "name": "Beige (RAL 1014 Elfenbein)",
+          "hex": "e1cc4f"
+        },
+        {
+          "name": "Beige brown (RAL 8024)",
+          "hex": "79553c"
+        },
+        {
+          "name": "Blue (RAL 5005)",
+          "hex": "154889"
+        },
+        {
+          "name": "Bordeaux (RAL 3005)",
+          "hex": "5e2028"
+        },
+        {
+          "name": "Elfenbein (RAL 1014)",
+          "hex": "ece0a4"
+        },
+        {
+          "name": "Gelb (RAL 1003 Signalgelb)",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green (RAL 6029 Mintgreen)",
+          "hex": "007243"
+        },
+        {
+          "name": "Gruen (RAL 6029 Minzgruen)",
+          "hex": "20603d"
+        },
+        {
+          "name": "Neon Gruen",
+          "hex": "00f700"
+        },
+        {
+          "name": "Neon Orange (RAL 2005)",
+          "hex": "ff4d08"
+        },
+        {
+          "name": "orange",
+          "hex": "ffa600"
+        },
+        {
+          "name": "Orange (RAL2000)",
+          "hex": "da6e00"
+        },
+        {
+          "name": "Ozeanblau (RAL 5020)",
+          "hex": "1d334b"
+        },
+        {
+          "name": "Pink (RAL 4003 Erikaviolett)",
+          "hex": "de4c8a"
+        },
+        {
+          "name": "red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Rot (RAL 3001 Signalrot)",
+          "hex": "a52019"
+        },
+        {
+          "name": "Sapphire Blue (RAL 5003)",
+          "hex": "263855"
+        },
+        {
+          "name": "Schokoladen-braun (RAL 8017)",
+          "hex": "46322d"
+        },
+        {
+          "name": "Schwarz (RAL 9005 Tiefschwarz)",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Tuerkis (RAL 5018 Tuerkis)",
+          "hex": "21888f"
+        },
+        {
+          "name": "Verkehrsgrau A (RAL 7042)",
+          "hex": "949898"
+        },
+        {
+          "name": "Violett",
+          "hex": "7f00ff"
+        },
+        {
+          "name": "White (RAL 9016)",
+          "hex": "f1f1ea"
+        }
+      ]
+    },
+    {
+      "name": "RAL 2000 {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "RAL 2000 - orange",
+          "hex": "d56f00"
+        }
+      ]
+    },
+    {
+      "name": "RAL 3001 {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "RAL 3001 - red",
+          "hex": "982323"
+        }
+      ]
+    },
+    {
+      "name": "RAL 9005 {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "RAL 9005 - black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Transparent – Shore 58D",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/pancolour.json
+++ b/filaments/pancolour.json
@@ -1,0 +1,278 @@
+{
+  "manufacturer": "Pancolour",
+  "filaments": [
+    {
+      "name": "Build {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red/Yellow/Blue",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Brass",
+          "hex": "c3af60"
+        },
+        {
+          "name": "Copper",
+          "hex": "b78d6a"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "White Aluminum",
+          "hex": "d2d5e1"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Light Blue RAL5024",
+          "hex": "6a93b0"
+        },
+        {
+          "name": "Light Purple",
+          "hex": "d37fa7"
+        },
+        {
+          "name": "Sky Blue RAL5015",
+          "hex": "2874b2"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black RAL9011",
+          "hex": "000000"
+        },
+        {
+          "name": "Brown Latte RAL8003",
+          "hex": "44271e"
+        },
+        {
+          "name": "Light Green RAL6019",
+          "hex": "9ed7bb"
+        },
+        {
+          "name": "Light Orange",
+          "hex": "f49971"
+        },
+        {
+          "name": "Orange RAL2000",
+          "hex": "e25827"
+        },
+        {
+          "name": "Red RAL3000",
+          "hex": "a72920"
+        },
+        {
+          "name": "Sulfur Yellow RAL1016",
+          "hex": "f1dd38"
+        },
+        {
+          "name": "White RAL9010",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/pangda.json
+++ b/filaments/pangda.json
@@ -1,0 +1,173 @@
+{
+  "manufacturer": "Pangda",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Purple",
+          "hex": "a12756"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff33"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2d6d9b"
+        },
+        {
+          "name": "Coral",
+          "hex": "ff9690"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "fcb2cb"
+        },
+        {
+          "name": "Pastel Blue",
+          "hex": "a7c7e7"
+        },
+        {
+          "name": "Pastel Cyan",
+          "hex": "a4d8d8"
+        },
+        {
+          "name": "Pastel Green",
+          "hex": "dfeef0"
+        },
+        {
+          "name": "Pastel Lilac",
+          "hex": "a08dfa"
+        },
+        {
+          "name": "Pastel Peach",
+          "hex": "f2b67a"
+        },
+        {
+          "name": "Pastel Pink",
+          "hex": "ffd6f2"
+        },
+        {
+          "name": "Pastel Yellow",
+          "hex": "fdfd96"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Light Beige",
+          "hex": "e9d1ae"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "a2a3a0"
+        },
+        {
+          "name": "Pale Orange",
+          "hex": "ac7c6c"
+        },
+        {
+          "name": "Pastel Pink",
+          "hex": "e8afbb"
+        },
+        {
+          "name": "White",
+          "hex": "ebebe9"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pastel Green",
+          "hex": "dfeeec"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/paramount3d.json
+++ b/filaments/paramount3d.json
@@ -1,0 +1,993 @@
+{
+  "manufacturer": "Paramount 3D",
+  "filaments": [
+    {
+      "name": "Paramount 3D PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        210
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Autobot Blue",
+          "codes": [
+            "BRL50022118C"
+          ],
+          "hex": "005eb8"
+        },
+        {
+          "name": "Aztec Gold",
+          "codes": [
+            "GOCOP2SC"
+          ],
+          "hexes": [
+            "b87333",
+            "c5a028"
+          ],
+          "multi_color_direction": "longitudinal",
+          "finish": "glossy"
+        },
+        {
+          "name": "Battleship Gray",
+          "codes": [
+            "BGRL7031431C"
+          ],
+          "hex": "7f868c"
+        },
+        {
+          "name": "Black",
+          "hex": "101820"
+        },
+        {
+          "name": "Black Cherry",
+          "codes": [
+            "WMRL3005490C"
+          ],
+          "hex": "7a263a"
+        },
+        {
+          "name": "British Racing Green",
+          "codes": [
+            "GRL60053435C"
+          ],
+          "hex": "004225"
+        },
+        {
+          "name": "Cadet Blue",
+          "codes": [
+            "CBRL50235405C"
+          ],
+          "hex": "003b5c"
+        },
+        {
+          "name": "Caribbean Coral",
+          "codes": [
+            "CPRL30227416C"
+          ],
+          "hex": "e9897e"
+        },
+        {
+          "name": "Castle Limestone Gray",
+          "codes": [
+            "CGRL7023416C"
+          ],
+          "hex": "8e9089"
+        },
+        {
+          "name": "Chameleon",
+          "codes": [
+            "BLUGREN2SC"
+          ],
+          "hexes": [
+            "005eb8",
+            "2e8b57"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Colossus Copper",
+          "codes": [
+            "810031560561CC"
+          ],
+          "hex": "b87333",
+          "finish": "glossy"
+        },
+        {
+          "name": "Decepticon Purple",
+          "codes": [
+            "PRL40077449C"
+          ],
+          "hex": "6a6599"
+        },
+        {
+          "name": "Egg Yolk Yellow",
+          "codes": [
+            "SYRL1003137C"
+          ],
+          "hex": "f6a950"
+        },
+        {
+          "name": "Enzo Red",
+          "codes": [
+            "TRRL3020485C"
+          ],
+          "hex": "cc0605"
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "codes": [
+            "FBRL50087546C"
+          ],
+          "hex": "003b49"
+        },
+        {
+          "name": "Game Cartridge Gray",
+          "codes": [
+            "DGRL7042423C"
+          ],
+          "hex": "a7a8aa"
+        },
+        {
+          "name": "Geode Black",
+          "codes": [
+            "GEOBLACK"
+          ],
+          "hexes": [
+            "1a1a2e",
+            "4a4a6a"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Gold Krugerrand",
+          "hex": "c5a028",
+          "finish": "glossy"
+        },
+        {
+          "name": "Graphite Gray",
+          "codes": [
+            "BGRL7043425C"
+          ],
+          "hex": "494e53"
+        },
+        {
+          "name": "Great Depression Jadeite",
+          "codes": [
+            "JGRL60217494C"
+          ],
+          "hex": "6b7c3c"
+        },
+        {
+          "name": "Hannibal Red",
+          "codes": [
+            "BHRL3009181C"
+          ],
+          "hex": "7b292c"
+        },
+        {
+          "name": "Harajuku Pink",
+          "codes": [
+            "TMRL4010675C"
+          ],
+          "hex": "e45dbf"
+        },
+        {
+          "name": "Iron Red",
+          "codes": [
+            "IRRL30111815C"
+          ],
+          "hex": "8b2332"
+        },
+        {
+          "name": "Ivory",
+          "codes": [
+            "IRL10147501C"
+          ],
+          "hex": "e1cc4f"
+        },
+        {
+          "name": "Karnak Sandstone",
+          "codes": [
+            "GBRL10197530S"
+          ],
+          "hex": "a0957d"
+        },
+        {
+          "name": "Leviathan Blue Green",
+          "codes": [
+            "TBRL5020316C"
+          ],
+          "hex": "00594c"
+        },
+        {
+          "name": "Matte Black",
+          "hex": "0e0e10",
+          "finish": "matte"
+        },
+        {
+          "name": "McLaren Orange",
+          "codes": [
+            "ORL20112019C"
+          ],
+          "hex": "ff8000"
+        },
+        {
+          "name": "Medusa Stone Gray",
+          "codes": [
+            "CGRL7023416S"
+          ],
+          "hex": "8e9089"
+        },
+        {
+          "name": "Mid Century Teal",
+          "codes": [
+            "ATRL50217718C"
+          ],
+          "hex": "007377"
+        },
+        {
+          "name": "Military Green",
+          "codes": [
+            "OGRL60037764C"
+          ],
+          "hex": "4b5335"
+        },
+        {
+          "name": "Military Khaki",
+          "codes": [
+            "GBRL10197530C"
+          ],
+          "hex": "b59a6a"
+        },
+        {
+          "name": "Military MBT Brown",
+          "codes": [
+            "MGRL80007560C"
+          ],
+          "hex": "6b3e2e"
+        },
+        {
+          "name": "Primordial Earth",
+          "codes": [
+            "DERL7006G09C"
+          ],
+          "hex": "5c4033"
+        },
+        {
+          "name": "Prototype Gray",
+          "codes": [
+            "LGRL7035421C"
+          ],
+          "hex": "a7a8aa"
+        },
+        {
+          "name": "Silver Dollar",
+          "hex": "8d9093",
+          "finish": "glossy"
+        },
+        {
+          "name": "Simpson Yellow",
+          "codes": [
+            "YRL1018129C"
+          ],
+          "hex": "faca30"
+        },
+        {
+          "name": "Skin - Dark Complexion",
+          "codes": [
+            "BBRL1011729C"
+          ],
+          "hex": "a67c52"
+        },
+        {
+          "name": "Skin - Deep Complexion",
+          "codes": [
+            "EBRL80282322C"
+          ],
+          "hex": "7a4f3b"
+        },
+        {
+          "name": "Skin - Fair Complexion",
+          "codes": [
+            "LIRL1015468C"
+          ],
+          "hex": "d4b59a"
+        },
+        {
+          "name": "Skin - Universal Beige",
+          "codes": [
+            "UBRL10017502C"
+          ],
+          "hex": "d5b59a"
+        },
+        {
+          "name": "St Andrews Green",
+          "codes": [
+            "PGRL60107742C"
+          ],
+          "hex": "4a7729"
+        },
+        {
+          "name": "Stealth Gray",
+          "codes": [
+            "IGRL7021419C"
+          ],
+          "hex": "5c5f63"
+        },
+        {
+          "name": "Steel Gray",
+          "codes": [
+            "SGRL7000430C"
+          ],
+          "hex": "a8a9ad"
+        },
+        {
+          "name": "Terra Copper",
+          "codes": [
+            "CBRL8004484C"
+          ],
+          "hex": "b87333",
+          "finish": "glossy"
+        },
+        {
+          "name": "Terra Cotta",
+          "codes": [
+            "BRRL30127591C"
+          ],
+          "hex": "9f4d36"
+        },
+        {
+          "name": "Tuxedo Midnight Blue",
+          "codes": [
+            "NBRL5011296C"
+          ],
+          "hex": "003b5c"
+        },
+        {
+          "name": "Ultraviolet",
+          "codes": [
+            "BLURED2SC"
+          ],
+          "hexes": [
+            "6a0dad",
+            "005eb8"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Volcano Orange",
+          "codes": [
+            "VORL20027626C"
+          ],
+          "hex": "c74700"
+        },
+        {
+          "name": "White",
+          "hex": "f4f4f4"
+        }
+      ]
+    },
+    {
+      "name": "Paramount 3D PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Autobot Blue",
+          "codes": [
+            "BRL50022118G"
+          ],
+          "hex": "005eb8"
+        },
+        {
+          "name": "Black",
+          "hex": "282828"
+        },
+        {
+          "name": "Black Cherry",
+          "codes": [
+            "WMRL3005490G"
+          ],
+          "hex": "7a263a"
+        },
+        {
+          "name": "British Racing Green",
+          "codes": [
+            "GRL6005343G"
+          ],
+          "hex": "004225"
+        },
+        {
+          "name": "Castle Limestone Gray",
+          "codes": [
+            "CGRL7023416G"
+          ],
+          "hex": "8e9089"
+        },
+        {
+          "name": "Decepticon Purple",
+          "codes": [
+            "PRL40077449G"
+          ],
+          "hex": "6a6599"
+        },
+        {
+          "name": "Egg Yolk Yellow",
+          "codes": [
+            "SYRL1003137G"
+          ],
+          "hex": "f6a950"
+        },
+        {
+          "name": "Enzo Red",
+          "codes": [
+            "TRRL3020485G"
+          ],
+          "hex": "cc0605"
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "codes": [
+            "FBRL50087546G"
+          ],
+          "hex": "003b49"
+        },
+        {
+          "name": "Graphite Gray",
+          "codes": [
+            "BGRL7043425G"
+          ],
+          "hex": "494e53"
+        },
+        {
+          "name": "Hannibal Red",
+          "codes": [
+            "BHRL3009181G"
+          ],
+          "hex": "7b292c"
+        },
+        {
+          "name": "Harajuku Pink",
+          "codes": [
+            "TMRL4010675G"
+          ],
+          "hex": "cf3476"
+        },
+        {
+          "name": "Iron Red",
+          "codes": [
+            "IRRL30111815G"
+          ],
+          "hex": "8b2332"
+        },
+        {
+          "name": "McLaren Orange",
+          "codes": [
+            "ORL20112019G"
+          ],
+          "hex": "ff8000"
+        },
+        {
+          "name": "Mid Century Modern Teal",
+          "codes": [
+            "ATRL50217718G"
+          ],
+          "hex": "007377"
+        },
+        {
+          "name": "Military Green",
+          "codes": [
+            "OGRL60037764G"
+          ],
+          "hex": "4b5335"
+        },
+        {
+          "name": "Military Khaki",
+          "codes": [
+            "GBRL10197530G"
+          ],
+          "hex": "b59a6a"
+        },
+        {
+          "name": "Military MBT Brown",
+          "codes": [
+            "MGRL80007560G"
+          ],
+          "hex": "6b3e2e"
+        },
+        {
+          "name": "Primordial Earth",
+          "codes": [
+            "DERL7006G09G"
+          ],
+          "hex": "5c4033"
+        },
+        {
+          "name": "Prototype Gray",
+          "codes": [
+            "LGRL7035421G"
+          ],
+          "hex": "a7a8aa"
+        },
+        {
+          "name": "Simpson Yellow",
+          "codes": [
+            "YRL1018129G"
+          ],
+          "hex": "faca30"
+        },
+        {
+          "name": "Skin - Ivory",
+          "codes": [
+            "IRL10147501G"
+          ],
+          "hex": "e1cc4f"
+        },
+        {
+          "name": "Skin - Universal Beige",
+          "codes": [
+            "UBRL10017502G"
+          ],
+          "hex": "d5b59a"
+        },
+        {
+          "name": "Stealth Gray",
+          "codes": [
+            "IGRL7021419G"
+          ],
+          "hex": "5c5f63"
+        },
+        {
+          "name": "Terra Copper",
+          "codes": [
+            "CBRL8004484G"
+          ],
+          "hex": "b87333",
+          "finish": "glossy"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ]
+    },
+    {
+      "name": "Paramount 3D ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Autobot Blue",
+          "codes": [
+            "BRL50022118A"
+          ],
+          "hex": "20214d"
+        },
+        {
+          "name": "Battleship Gray",
+          "codes": [
+            "BGRL7031431A"
+          ],
+          "hex": "7f868c"
+        },
+        {
+          "name": "Black",
+          "hex": "0e0e10"
+        },
+        {
+          "name": "Black Cherry",
+          "codes": [
+            "WMRL3005490A"
+          ],
+          "hex": "6b1c23"
+        },
+        {
+          "name": "British Racing Green",
+          "codes": [
+            "GRL60053435A"
+          ],
+          "hex": "0f4336"
+        },
+        {
+          "name": "Castle Limestone Gray",
+          "codes": [
+            "CGRL7023416A"
+          ],
+          "hex": "8e9089"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea"
+        },
+        {
+          "name": "Decepticon Purple",
+          "codes": [
+            "PRL40077449A"
+          ],
+          "hex": "7d55c7"
+        },
+        {
+          "name": "Enzo Red",
+          "codes": [
+            "TRRL3020485A"
+          ],
+          "hex": "cc0605"
+        },
+        {
+          "name": "Fighter Jet Blue",
+          "codes": [
+            "FBRL50087546C"
+          ],
+          "hex": "003b49"
+        },
+        {
+          "name": "Game Cartridge Gray",
+          "codes": [
+            "LGRL7042423A"
+          ],
+          "hex": "a7a8aa"
+        },
+        {
+          "name": "Gold Krugerrand",
+          "hex": "c5a028",
+          "finish": "glossy"
+        },
+        {
+          "name": "Graphite Gray",
+          "codes": [
+            "BGRL7043425A"
+          ],
+          "hex": "494e53"
+        },
+        {
+          "name": "Harajuku Pink",
+          "codes": [
+            "TMRL4010675A"
+          ],
+          "hex": "cf3476"
+        },
+        {
+          "name": "Iron Red",
+          "codes": [
+            "IRRL30111815A"
+          ],
+          "hex": "8b2332"
+        },
+        {
+          "name": "McLaren Orange",
+          "codes": [
+            "ORL20112019A"
+          ],
+          "hex": "ff8000"
+        },
+        {
+          "name": "Mid Century Modern Teal",
+          "codes": [
+            "ATRL50217718A"
+          ],
+          "hex": "007377"
+        },
+        {
+          "name": "Military Green",
+          "codes": [
+            "OGRL60037764A"
+          ],
+          "hex": "4b5335"
+        },
+        {
+          "name": "Military Khaki",
+          "codes": [
+            "GBRL10197530A"
+          ],
+          "hex": "b59a6a"
+        },
+        {
+          "name": "Military MBT Brown",
+          "codes": [
+            "MGRL80007560A"
+          ],
+          "hex": "6b3e2e"
+        },
+        {
+          "name": "Primordial Earth",
+          "codes": [
+            "DERL7006G09A"
+          ],
+          "hex": "5c4033"
+        },
+        {
+          "name": "Prototype Gray",
+          "codes": [
+            "LGRL7035421A"
+          ],
+          "hex": "c5c7c4"
+        },
+        {
+          "name": "Silver Dollar",
+          "hex": "8d9093",
+          "finish": "glossy"
+        },
+        {
+          "name": "Simpson Yellow",
+          "codes": [
+            "YRL1018129A"
+          ],
+          "hex": "f6d600"
+        },
+        {
+          "name": "Skin - Dark Complexion",
+          "codes": [
+            "BBRL1011729A"
+          ],
+          "hex": "a67c52"
+        },
+        {
+          "name": "Skin - Fair Complexion",
+          "codes": [
+            "LIRL1015468A"
+          ],
+          "hex": "d4b59a"
+        },
+        {
+          "name": "Skin - Ivory",
+          "codes": [
+            "UBRL10147501A"
+          ],
+          "hex": "e1cc4f"
+        },
+        {
+          "name": "Skin - Universal Beige",
+          "codes": [
+            "UBRL10017502A"
+          ],
+          "hex": "d5b59a"
+        },
+        {
+          "name": "Steel Gray",
+          "codes": [
+            "SGRL7000430A"
+          ],
+          "hex": "a8a9ad"
+        },
+        {
+          "name": "Terra Cotta",
+          "codes": [
+            "BRRL30127591A"
+          ],
+          "hex": "9f4d36"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ]
+    },
+    {
+      "name": "Paramount 3D ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "BLACK"
+          ],
+          "hex": "101820"
+        },
+        {
+          "name": "Decepticon Purple",
+          "codes": [
+            "PRL40077449SA"
+          ],
+          "hex": "7d55c7"
+        },
+        {
+          "name": "Enzo Red",
+          "codes": [
+            "TRRL3020485SA"
+          ],
+          "hex": "da291c"
+        },
+        {
+          "name": "Graphite Gray",
+          "codes": [
+            "BGRL7043_425SA"
+          ],
+          "hex": "494e53"
+        },
+        {
+          "name": "Iron Red",
+          "codes": [
+            "IRRL30111815SA"
+          ],
+          "hex": "8b2332"
+        },
+        {
+          "name": "McLaren Orange",
+          "codes": [
+            "ORL20112019SA"
+          ],
+          "hex": "ff8000"
+        },
+        {
+          "name": "Military Green",
+          "codes": [
+            "OGRL60037764SA"
+          ],
+          "hex": "4b5335"
+        },
+        {
+          "name": "Military Khaki",
+          "codes": [
+            "GBRL10197530SA"
+          ],
+          "hex": "b59a6a"
+        },
+        {
+          "name": "Primordial Earth",
+          "codes": [
+            "DERL7006G09SA"
+          ],
+          "hex": "5c4033"
+        },
+        {
+          "name": "Stealth Gray",
+          "codes": [
+            "IGRL7021_419SA"
+          ],
+          "hex": "5c5f63"
+        },
+        {
+          "name": "Vapor Gray",
+          "codes": [
+            "LGRL7035421SA"
+          ],
+          "hex": "a7a8aa"
+        },
+        {
+          "name": "White",
+          "codes": [
+            "WHITE"
+          ],
+          "hex": "f4f4f4"
+        }
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ]
+    },
+    {
+      "name": "Paramount 3D PETG-CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "codes": [
+            "CF810031560202"
+          ],
+          "hex": "101820"
+        },
+        {
+          "name": "Steampunk",
+          "codes": [
+            "BCF810031560561"
+          ],
+          "hex": "808080"
+        }
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Paramount 3D ABS-CF {color_name}",
+      "material": "ABS-CF",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101820"
+        }
+      ],
+      "bed_temp_range": [
+        100,
+        110
+      ],
+      "fill": "carbon fiber"
+    }
+  ]
+}

--- a/filaments/phrozen.json
+++ b/filaments/phrozen.json
@@ -1,0 +1,245 @@
+{
+  "manufacturer": "Phrozen",
+  "filaments": [
+    {
+      "name": "Tough PLA {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "country_of_origin": "Taiwan",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "64020108006074"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "64020108037074"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "64020108046074"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "64020108004074"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "64020108016074"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "64020108014074"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "64020108047074"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "64020108027074"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Tough PLA Refill {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "country_of_origin": "Taiwan",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "46954030530747"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "46954030563515"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "46954030596283"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "46954030629051"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "46954030661819"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "46954030694587"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "46954030727355"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "46954030760123"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "High Speed PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Taiwan",
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0066cc",
+          "codes": [
+            "64020105106074"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "cc0000",
+          "codes": [
+            "64020105137074"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "64020105146074"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "64020105104074"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "228b22",
+          "codes": [
+            "64020105116074"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "64020105114074"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00",
+          "codes": [
+            "64020105147074"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00",
+          "codes": [
+            "64020105127074"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/pinball.json
+++ b/filaments/pinball.json
@@ -1,0 +1,292 @@
+{
+  "manufacturer": "Pinball",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "009dff"
+        },
+        {
+          "name": "Cherry Blossom Pink",
+          "hex": "f89af9"
+        },
+        {
+          "name": "Coffee",
+          "hex": "785700"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "2f9721"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "00ff4c"
+        },
+        {
+          "name": "Grey",
+          "hex": "7d7f7c"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff9d2e"
+        },
+        {
+          "name": "Purple",
+          "hex": "c900cc"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Red, Yellow, Blue, Green 4Pack",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Skin",
+          "hex": "e5b5a1"
+        },
+        {
+          "name": "Transparent",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black Gray",
+          "hex": "43454c"
+        },
+        {
+          "name": "Bright Gold",
+          "hex": "ffd031"
+        },
+        {
+          "name": "Bright Silver",
+          "hex": "a6b0ba"
+        },
+        {
+          "name": "Copper",
+          "hex": "794b35"
+        },
+        {
+          "name": "Copper Silk",
+          "hex": "8c4f31"
+        },
+        {
+          "name": "Rainbow Afterglow",
+          "hex": "ffd1fb"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "060503"
+        },
+        {
+          "name": "Blue",
+          "hex": "00a8f1"
+        },
+        {
+          "name": "Cherry Pink",
+          "hex": "eec3c5"
+        },
+        {
+          "name": "Green",
+          "hex": "009c61"
+        },
+        {
+          "name": "Grey",
+          "hex": "c5c9c1"
+        },
+        {
+          "name": "Red",
+          "hex": "ce261b"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue, Silver",
+          "hex": "cbf0ff"
+        },
+        {
+          "name": "Blue/Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red / Gold / Purple",
+          "hexes": [
+            "ff0000",
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red-Green-Blue",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/pinrui.json
+++ b/filaments/pinrui.json
@@ -1,0 +1,319 @@
+{
+  "manufacturer": "PINRUI",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Cyan",
+          "hex": "00ffff"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent Red",
+          "hex": "c5111a"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Chinese Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Gray",
+          "hex": "6e706b"
+        },
+        {
+          "name": "Sliver",
+          "hex": "989898"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Dark Red",
+          "hex": "6b0000"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "042339"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "6d712e"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "73c0f7"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLUE/GREEN",
+          "hexes": [
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Multi Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Multi colour",
+          "hex": "f10404"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Candy",
+          "hex": "8beac9"
+        },
+        {
+          "name": "Macaron",
+          "hex": "b5f0b9"
+        },
+        {
+          "name": "Red Gold Purple",
+          "hex": "c2435e"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Red Blue Gren",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "7de147"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/plastspaw.json
+++ b/filaments/plastspaw.json
@@ -1,0 +1,138 @@
+{
+  "manufacturer": "Plastspaw",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Szary Gołębi",
+          "hex": "dddddd"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "999999"
+        },
+        {
+          "name": "Orange",
+          "hex": "e05a00"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.26,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "00f900"
+        },
+        {
+          "name": "Industrial grey",
+          "hex": "a5b3b3"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "23a0da"
+        },
+        {
+          "name": "Light Brown / Jasny Brązowy",
+          "hex": "872807"
+        },
+        {
+          "name": "MIlitary Green (zielony wojskowy)",
+          "hex": "074331"
+        },
+        {
+          "name": "Orange / Pomarańczowy",
+          "hex": "fb7b4a"
+        },
+        {
+          "name": "Red",
+          "hex": "d31517"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood Beige / Drewno Beżowy",
+          "hex": "e9c8ad"
+        },
+        {
+          "name": "Żółty Satynowy",
+          "hex": "eacd1e"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/polaroid.json
+++ b/filaments/polaroid.json
@@ -1,0 +1,170 @@
+{
+  "manufacturer": "Polaroid",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "001eff"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "054d00"
+        },
+        {
+          "name": "Light Green",
+          "hex": "b0f7c2"
+        },
+        {
+          "name": "Magenta",
+          "hex": "d83163"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6c00"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff73ff"
+        },
+        {
+          "name": "Purple",
+          "hex": "6e27f1"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "7a7d7f"
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "04529f"
+        },
+        {
+          "name": "Yellow",
+          "hex": "eeff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0ac0f5"
+        },
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "80ff80"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff73ff"
+        },
+        {
+          "name": "Silver",
+          "hex": "84888a"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "808080"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/polyalchemy.json
+++ b/filaments/polyalchemy.json
@@ -1,0 +1,29 @@
+{
+  "manufacturer": "Polyalchemy",
+  "filaments": [
+    {
+      "name": "Elixir PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [200, 220],
+      "bed_temp_range": [0, 60],
+      "colors": [
+        {"name": "Abyss", "hex": "1D2731"},
+        {"name": "Emerald", "hex": "097969"},
+        {"name": "Copper", "hex": "B87333"},
+        {"name": "Gold", "hex": "FFD700"},
+        {"name": "Silver", "hex": "C0C0C0"},
+        {"name": "Ruby", "hex": "E0115F"},
+        {"name": "Cobalt", "hex": "0047AB"}
+      ]
+    }
+  ]
+}

--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -99,6 +99,244 @@
         ]
       },
       {
+        "name": "Fiberon\u2122 PA612-CF15 {color_name}",
+        "material": "PA",
+        "density": 1.03,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 2000.0,
+            "spool_weight": 370.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          250,
+          300
+        ],
+        "bed_temp_range": [
+          40,
+          50
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
+        "name": "Fiberon\u2122 PA612-ESD {color_name}",
+        "material": "PA",
+        "density": 1.1,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 3000.0,
+            "spool_weight": 425.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          280,
+          300
+        ],
+        "bed_temp_range": [
+          40,
+          50
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
+        "name": "Fiberon\u2122 PET-CF17 {color_name}",
+        "material": "PET-CF",
+        "density": 1.34,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 2000.0,
+            "spool_weight": 370.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          270,
+          300
+        ],
+        "bed_temp_range": [
+          70,
+          80
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
+        "name": "Fiberon\u2122 PETG-ESD {color_name}",
+        "material": "PETG",
+        "density": 1.24,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 2000.0,
+            "spool_weight": 370.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          250,
+          290
+        ],
+        "bed_temp_range": [
+          70,
+          80
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
+        "name": "Fiberon\u2122 PETG-rCF08 {color_name}",
+        "material": "PETG",
+        "density": 1.3,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 2000.0,
+            "spool_weight": 370.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          240,
+          270
+        ],
+        "bed_temp_range": [
+          60,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
+        "name": "Fiberon\u2122 PPS-CF10 {color_name}",
+        "material": "PPS-CF",
+        "density": 1.29,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 2000.0,
+            "spool_weight": 370.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          310,
+          350
+        ],
+        "bed_temp_range": [
+          80,
+          90
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
+        "name": "Fiberon\u2122 PPS-GF20 {color_name}",
+        "material": "PPS-GF20",
+        "density": 1.36,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          },
+          {
+            "weight": 3000.0,
+            "spool_weight": 425.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          310,
+          350
+        ],
+        "bed_temp_range": [
+          90,
+          90
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          }
+        ]
+      },
+      {
         "name": "PolyCast\u2122 {color_name}",
         "material": "PVB",
         "density": 1.1,
@@ -998,7 +1236,7 @@
         ]
       },
       {
-        "name": "Panchroma\u2122 Dual {color_name}",
+        "name": "Panchroma\u2122 Dual Matte PLA {color_name}",
         "material": "PLA",
         "density": 1.37,
         "weights": [
@@ -1023,13 +1261,102 @@
           {
             "name": "Chameleon (Teal-Yellow)",
             "hexes": [
-              "5AABB1",
-              "F0BE02"
+              "61BCC3",
+              "F3C432"
             ],
             "finish": "matte",
             "multi_color_direction": "coaxial"
-          }
-        ]
+          },
+          {
+            "name": "Camouflage (Dark Green-Brown)",
+            "hexes": [
+              "5F6244",
+              "795A4D"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Flamingo (Pink-Red)",
+            "hexes": [
+              "EAADBD",
+              "ED2F2E"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Foggy Orange (Grey-Orange)",
+            "hexes": [
+              "8A8C94",
+              "F88B17"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Foggy Purple (Grey-Purple)",
+            "hexes": [
+              "8A8C94",
+              "9572BF"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Glacier Blue (Ice-Blue)",
+            "hexes": [
+              "A4D0DF",
+              "0163A6"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Mixed Berries (Red-Dark Blue)",
+            "hexes": [
+              "BF312E",
+              "2E4462"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Shadow Black (White-Black)",
+            "hexes": [
+              "F4EFEB",
+              "2F2E30"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Shadow Orange (Orange-Black)",
+            "hexes": [
+              "F88B17",
+              "2F2E30"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Shadow Red (Black-Red)",
+            "hexes": [
+              "2F2E30",
+              "ED2F2E"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Sunrise (Red-Yellow)",
+            "hexes": [
+              "ED2F2E",
+              "F3C432"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "coaxial"
+          }]
       },
       {
         "name": "PolyLite\u2122 PLA Pro {color_name}",
@@ -1952,12 +2279,20 @@
             "hex": "764c99"
           },
           {
+            "name": "Emerald Green",
+            "hex": "22624f"
+          },
+          {
             "name": "Forest Green",
             "hex": "519f61"
           },
           {
             "name": "Fossil Grey",
             "hex": "6f727e"
+          },
+          {
+            "name": "Grass Green",
+            "hex": "32bc46"
           },
           {
             "name": "Lavender Purple",
@@ -1984,12 +2319,28 @@
             "hex": "656d60"
           },
           {
+            "name": "Muted Mauve",
+            "hex": "a36d82"
+          },
+          {
+            "name": "Muted Moss",
+            "hex": "92864f"
+          },
+          {
             "name": "Muted Purple",
             "hex": "7c5577"
           },
           {
             "name": "Muted Red",
             "hex": "db3e14"
+          },
+          {
+            "name": "Muted Teal",
+            "hex": "5d989e"
+          },
+          {
+            "name": "Muted Terracotta",
+            "hex": "c06443"
           },
           {
             "name": "Muted White",
@@ -2000,8 +2351,16 @@
             "hex": "f5cf6f"
           },
           {
+            "name": "Pastel Beige",
+            "hex": "e4d0b0"
+          },
+          {
             "name": "Pastel Candy",
             "hex": "dabcc8"
+          },
+          {
+            "name": "Pastel Coral",
+            "hex": "f09a7e"
           },
           {
             "name": "Pastel Ice",
@@ -2028,6 +2387,10 @@
             "hex": "e93a3f"
           },
           {
+            "name": "Raspberry Blue",
+            "hex": "5472d0"
+          },
+          {
             "name": "Sakura Pink",
             "hex": "e0a8bb"
           },
@@ -2040,6 +2403,10 @@
             "hex": "f0be02"
           },
           {
+            "name": "Seafoam Green",
+            "hex": "7dd4be"
+          },
+          {
             "name": "Sky Blue",
             "hex": "87ceeb"
           },
@@ -2048,8 +2415,62 @@
             "hex": "f78e0e"
           },
           {
+            "name": "Sunshine Yellow",
+            "hex": "F9DA07"
+          },
+          {
+            "name": "Wine Burgundy",
+            "hex": "753e4c"
+          },
+          {
             "name": "Wood Brown",
             "hex": "ad7441"
+          }
+        ]
+      },
+      {
+        "name": "Panchroma™ Translucent {color_name}",
+        "material": "PLA",
+        "translucent": true,
+        "density": 1.17,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 145.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Cyan",
+            "hex": "08abfb"
+          },
+          {
+            "name": "Magenta",
+            "hex": "d93b90"
+          },
+          {
+            "name": "Yellow",
+            "hex": "f9ed3d"
+          },
+          {
+            "name": "Grey",
+            "hex": "9991a4"
+          },
+          {
+            "name": "Natural",
+            "hex": "e8e6d0"
           }
         ]
       },
@@ -2096,6 +2517,1096 @@
           {
             "name": "Sandstone",
             "hex": "c6c781"
+          }
+        ]
+      },
+      {
+        "name": "Panchroma™ (Formerly PolyLite™) Starlight {color_name}",
+        "material": "PLA",
+        "pattern": "sparkle",
+        "density": 1.24,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Neptune",
+            "hex": "113148"
+          },
+          {
+            "name": "Mercury",
+            "hex": "33322D"
+          },
+          {
+            "name": "Jupiter",
+            "hex": "774718"
+          },
+          {
+            "name": "Comet",
+            "hex": "1F312A"
+          },
+          {
+            "name": "Meteor",
+            "hex": "2F3117"
+          },
+          {
+            "name": "Aurora",
+            "hex": "314530"
+          },
+          {
+            "name": "Nebula",
+            "hex": "462F32"
+          },
+          {
+            "name": "Twilight",
+            "hex": "1E3445"
+          },
+          {
+            "name": "Mars",
+            "hex": "962E31"
+          },
+          {
+            "name": "Midnight",
+            "hex": "475A64"
+          },
+          {
+            "name": "Pulsar",
+            "hex": "5C7BC1"
+          }
+        ]
+      },
+      {
+        "name": "Panchroma™ Celestial {color_name}",
+        "material": "PLA",
+        "pattern": "sparkle",
+        "density": 1.24,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Blue",
+            "hex": "6ADCF7"
+          },
+          {
+            "name": "Green",
+            "hex": "6FE2D2"
+          },
+          {
+            "name": "Purple",
+            "hex": "9678C8"
+          },
+          {
+            "name": "White",
+            "hex": "DCDAD0"
+          },
+          {
+            "name": "Light Yellow",
+            "hex": "D7CE89"
+          },
+          {
+            "name": "Light Pink",
+            "hex": "C3ADB8"
+          },
+          {
+            "name": "Yellow",
+            "hex": "F4C76A"
+          }
+        ]
+      },
+      {
+        "name": "Panchroma™ (Formerly PolyLite™) Silk {color_name}",
+        "material": "PLA",
+        "density": 1.24,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "363538"
+          },
+          {
+            "name": "Purple",
+            "hex": "786BB0"
+          },
+          {
+            "name": "Magenta",
+            "hex": "AA538E"
+          },
+          {
+            "name": "Rose",
+            "hex": "CF6076"
+          },
+          {
+            "name": "Red",
+            "hex": "C1443F"
+          },
+          {
+            "name": "Rose Gold",
+            "hex": "CBB0B1"
+          },
+          {
+            "name": "Quartz Pink",
+            "hex": "DBBBBB"
+          },
+          {
+            "name": "Bronze",
+            "hex": "AF6B4C"
+          },
+          {
+            "name": "Orange",
+            "hex": "EB6232"
+          },
+          {
+            "name": "White",
+            "hex": "DFE4E4"
+          },
+          {
+            "name": "Gold",
+            "hex": "C49449"
+          },
+          {
+            "name": "Yellow",
+            "hex": "EEC810"
+          },
+                    {
+            "name": "Lime",
+            "hex": "C4CF4C"
+          },
+          {
+            "name": "Green",
+            "hex": "55B687"
+          },
+          {
+            "name": "Teal",
+            "hex": "66C2B6"
+          },
+          {
+            "name": "Light Blue",
+            "hex": "4CC1CB"
+          },
+          {
+            "name": "Blue",
+            "hex": "4999C9"
+          },
+          {
+            "name": "Chrome",
+            "hex": "85898B"
+          },
+          {
+            "name": "Silver",
+            "hex": "BCC2C8"
+          },
+          {
+            "name": "Brass",
+            "hex": "968162"
+          },
+          {
+            "name": "Peridot Green",
+            "hex": "7F865B"
+          },
+          {
+            "name": "Periwinkle",
+            "hex": "768EC7"
+          },
+          {
+            "name": "Dark Blue",
+            "hex": "23599A"
+          },
+          {
+            "name": "Gunmetal Grey",
+            "hex": "676B6A"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Galaxy PLA {color_name}",
+        "density": 1.17,
+        "pattern": "sparkle",
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "161617",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Dark Blue",
+            "hex": "18192D",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Dark Green",
+            "hex": "13484D",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Dark Red",
+            "hex": "451E14",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Dark Grey",
+            "hex": "4E5658",
+            "pattern": "sparkle"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Neon PLA {color_name}",
+        "density": 1.17,
+        "colors": [
+          {
+            "name": "Magenta",
+            "hex": "F21185"
+          },
+          {
+            "name": "Green",
+            "hex": "00F263"
+          },
+          {
+            "name": "Yellow",
+            "hex": "E5DB2E"
+          },
+          {
+            "name": "Orange",
+            "hex": "FF7800"
+          },
+          {
+            "name": "Pink",
+            "hex": "FF3670"
+          },
+          {
+            "name": "Red",
+            "hex": "FE2D42"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Metallic PLA {color_name}",
+        "density": 1.17,
+        "pattern": "sparkle",
+        "colors": [
+          {
+            "name": "Gold",
+            "hex": "DA9F1D",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Silver",
+            "hex": "7A838E",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Bronze",
+            "hex": "926043",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Blue",
+            "hex": "2C3449",
+            "pattern": "sparkle"
+          },
+          {
+            "name": "Green",
+            "hex": "434D43",
+            "pattern": "sparkle"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Satin PLA {color_name}",
+        "density": 1.24,
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "302E30"
+          },
+          {
+            "name": "White",
+            "hex": "F5F0EC"
+          },
+          {
+            "name": "Grey",
+            "hex": "797E89"
+          },
+          {
+            "name": "Orange",
+            "hex": "FE9217"
+          },
+          {
+            "name": "Yellow",
+            "hex": "F4C131"
+          },
+          {
+            "name": "Green",
+            "hex": "5EAB71"
+          },
+          {
+            "name": "Polymaker Teal",
+            "hex": "61BBC1"
+          },
+          {
+            "name": "Blue",
+            "hex": "0162A6"
+          },
+          {
+            "name": "Purple",
+            "hex": "9272C1"
+          },
+          {
+            "name": "Red",
+            "hex": "DA1521"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Glow PLA {color_name}",
+        "density": 1.17,
+        "colors": [
+          {
+            "name": "Green",
+            "hex": "F2EADB",
+            "glow": true
+          },
+          {
+            "name": "Blue",
+            "hex": "F3EADB",
+            "glow": true
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ UV Shift PLA {color_name}",
+        "density": 1.17,
+        "colors": [
+          {
+            "name": "Natural/Orange",
+            "hex": "F1DBBF"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Dual Silk PLA {color_name}",
+        "density": 1.24,
+        "colors": [
+          {
+            "name": "Aubergine (Lime-Magenta)",
+            "hexes": [
+              "C4CF4C",
+              "AA538E"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Banquet (Gold-Magenta)",
+            "hexes": [
+              "C49449",
+              "AA538E"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Beluga (Silver-Blue)",
+            "hexes": [
+              "BCC2C8",
+              "4999C9"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Caribbean Sea (Blue-Green)",
+            "hexes": [
+              "4999C9",
+              "55B687"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Chameleon (Yellow-Blue)",
+            "hexes": [
+              "EEC810",
+              "4999C9"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Crown (Gold-Silver)",
+            "hexes": [
+              "C49449",
+              "BCC2C8"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Jadeite (Green-Chrome)",
+            "hexes": [
+              "55B687",
+              "85898B"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Sovereign (Gold-Purple)",
+            "hexes": [
+              "C49449",
+              "786BB0"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          },
+          {
+            "name": "Sunset (Gold-Red)",
+            "hexes": [
+              "C49449",
+              "CF6076"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Dual Special PLA {color_name}",
+        "density": 1.24,
+        "colors": [
+          {
+            "name": "Yin-Yang",
+            "hexes": [
+              "020203",
+              "CFCCD6"
+            ],
+            "multi_color_direction": "coaxial"
+          }
+        ]
+      },
+      {
+        "name": "Panchroma™ CoPE {color_name}",
+        "material": "COPE",
+        "density": 1.2,
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "080A0D"
+          },
+          {
+            "name": "White",
+            "hex": "EBF7FF"
+          },
+          {
+            "name": "Grey",
+            "hex": "8C9099"
+          },
+          {
+            "name": "Steel Grey",
+            "hex": "616469"
+          },
+          {
+            "name": "Dark Grey",
+            "hex": "485259"
+          },
+          {
+            "name": "Blue",
+            "hex": "003776"
+          },
+          {
+            "name": "Stone Blue",
+            "hex": "487BA2"
+          },
+          {
+            "name": "Aqua Blue",
+            "hex": "5EBDDB"
+          },
+          {
+            "name": "Red",
+            "hex": "E72F1D"
+          },
+          {
+            "name": "Wine Red",
+            "hex": "D60212"
+          },
+          {
+            "name": "Yellow",
+            "hex": "FFE800"
+          },
+          {
+            "name": "Lemon Yellow",
+            "hex": "EED230"
+          },
+          {
+            "name": "Orange",
+            "hex": "F67405"
+          },
+          {
+            "name": "Green",
+            "hex": "06924D"
+          },
+          {
+            "name": "Jungle Green",
+            "hex": "4E742D"
+          },
+          {
+            "name": "Lime Green",
+            "hex": "D5D701"
+          },
+          {
+            "name": "Olive Green",
+            "hex": "948902"
+          },
+          {
+            "name": "Olive Drab Green",
+            "hex": "575B54"
+          },
+          {
+            "name": "Purple",
+            "hex": "6C47B2"
+          },
+          {
+            "name": "Polymaker Teal",
+            "hex": "4CC0C7"
+          },
+          {
+            "name": "Brown",
+            "hex": "55331A"
+          },
+          {
+            "name": "Tan",
+            "hex": "A79E82"
+          },
+          {
+            "name": "Beige",
+            "hex": "C2AB72"
+          },
+          {
+            "name": "Cream",
+            "hex": "EED1A8"
+          },
+          {
+            "name": "Cold White",
+            "hex": "D9DFE5"
+          },
+          {
+            "name": "Magenta",
+            "hex": "F24574"
+          },
+          {
+            "name": "Pink",
+            "hex": "F1A1AF"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Gradient Matte PLA {color_name}",
+        "density": 1.37,
+        "finish": "matte",
+        "colors": [
+          {
+            "name": "Pastel Rainbow",
+            "hexes": [
+              "F7D475",
+              "F0D6D9",
+              "A4D0DF",
+              "D2DEBB",
+              "F6BF8B",
+              "ADB4E6"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Cappuccino",
+            "hexes": [
+              "BF9573",
+              "7C594A",
+              "F4EFEB"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Spring",
+            "hexes": [
+              "D2DEBB",
+              "60AD70",
+              "F7D475"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Summer",
+            "hexes": [
+              "F3C432",
+              "F88B17",
+              "ED2F2E"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Fall",
+            "hexes": [
+              "AB7449",
+              "F88B17",
+              "BF312E"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Winter",
+            "hexes": [
+              "A4D0DF",
+              "8A8C94",
+              "F4EFEB"
+            ],
+            "finish": "matte",
+            "multi_color_direction": "longitudinal"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Gradient Satin PLA {color_name}",
+        "density": 1.24,
+        "colors": [
+          {
+            "name": "Rainbow",
+            "hexes": [
+              "DA1521",
+              "FE9217",
+              "F4C131",
+              "5EAB71",
+              "0162A6",
+              "9272C1"
+            ],
+            "multi_color_direction": "longitudinal"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Gradient Silk PLA {color_name}",
+        "density": 1.24,
+        "colors": [
+          {
+            "name": "Rainbow",
+            "hexes": [
+              "C1443F",
+              "EB6232",
+              "EEC810",
+              "55B687",
+              "4999C9",
+              "786BB0"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Fire",
+            "hexes": [
+              "C1443F",
+              "EB6232",
+              "EEC810"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Water",
+            "hexes": [
+              "4CC1CB",
+              "4999C9",
+              "23599A"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Air",
+            "hexes": [
+              "DFE4E4",
+              "4CC1CB",
+              "768EC7"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Earth",
+            "hexes": [
+              "AF6B4C",
+              "55B687",
+              "7F865B"
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "longitudinal"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Gradient Translucent PLA {color_name}",
+        "density": 1.17,
+        "translucent": true,
+        "colors": [
+          {
+            "name": "Rainbow",
+            "hexes": [
+              "08ABFB",
+              "D93B90",
+              "F9ED3D"
+            ],
+            "translucent": true,
+            "multi_color_direction": "longitudinal"
+          }
+        ]
+      },
+      {
+        "material": "PLA",
+        "weights": [
+          {
+            "weight": 1000.0,
+            "spool_weight": 140.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          190,
+          230
+        ],
+        "bed_temp_range": [
+          25,
+          60
+        ],
+        "name": "Panchroma™ Gradient Galaxy PLA {color_name}",
+        "density": 1.17,
+        "pattern": "sparkle",
+        "colors": [
+          {
+            "name": "Black-Grey",
+            "hexes": [
+              "161617",
+              "4E5658"
+            ],
+            "pattern": "sparkle",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Blue-Green",
+            "hexes": [
+              "18192D",
+              "13484D"
+            ],
+            "pattern": "sparkle",
+            "multi_color_direction": "longitudinal"
+          },
+          {
+            "name": "Black-Blue",
+            "hexes": [
+              "161617",
+              "18192D"
+            ],
+            "pattern": "sparkle",
+            "multi_color_direction": "longitudinal"
           }
         ]
       }

--- a/filaments/polymate.json
+++ b/filaments/polymate.json
@@ -1,0 +1,161 @@
+{
+  "manufacturer": "PolyMate",
+  "filaments": [
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow Green",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Matte White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "201e8a"
+        },
+        {
+          "name": "Dark Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Atrovirens",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/polyterra.json
+++ b/filaments/polyterra.json
@@ -1,0 +1,276 @@
+{
+  "manufacturer": "PolyTerra",
+  "filaments": [
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Foggy Orange (Grey-Orange)",
+          "hex": "878787"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        27
+      ],
+      "colors": [
+        {
+          "name": "Arctic Teal",
+          "hex": "61bcc3"
+        },
+        {
+          "name": "Artic Teal",
+          "hex": "61bcc3"
+        },
+        {
+          "name": "Charcoal black",
+          "hex": "000000"
+        },
+        {
+          "name": "Charcoal Black (noir charbon)",
+          "hex": "1c1c1c"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "78ff7a"
+        },
+        {
+          "name": "Lavender Purple",
+          "hex": "9572bf"
+        },
+        {
+          "name": "Muted White",
+          "hex": "bbada4"
+        },
+        {
+          "name": "Pastel Ice",
+          "hex": "a4d0df"
+        },
+        {
+          "name": "Savannah Yellow",
+          "hex": "f3c432"
+        },
+        {
+          "name": "Sunrise Orange",
+          "hex": "f88b17"
+        },
+        {
+          "name": "white",
+          "hex": "f7f7f7"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "aab7c4"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Army Beige",
+          "hex": "dbbaa5"
+        },
+        {
+          "name": "Army Brown",
+          "hex": "795a4d"
+        },
+        {
+          "name": "Army Dark Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Charcoal Black",
+          "hex": "414144"
+        },
+        {
+          "name": "Cotton white",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Earth Brown",
+          "hex": "8a5c45"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "70ae69"
+        },
+        {
+          "name": "Lava Red",
+          "hex": "e42525"
+        },
+        {
+          "name": "Marble Slate Grey",
+          "hex": "85b2d8"
+        },
+        {
+          "name": "Marble White",
+          "hex": "f2f9ff"
+        },
+        {
+          "name": "Muted Blue",
+          "hex": "5f778e"
+        },
+        {
+          "name": "Muted Green",
+          "hex": "777e71"
+        },
+        {
+          "name": "Muted Purple",
+          "hex": "7c5c78"
+        },
+        {
+          "name": "Peanut",
+          "hex": "b88656"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "eaaabb"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "2191db"
+        },
+        {
+          "name": "Wood Brown",
+          "hex": "e0a272"
+        }
+      ]
+    },
+    {
+      "name": "Polyterra {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Fossil Gray",
+          "hex": "8a8c94"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Wood Brown",
+          "hex": "ad7441"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/precision3dfilament.json
+++ b/filaments/precision3dfilament.json
@@ -1,0 +1,69 @@
+{
+  "manufacturer": "Precision 3D Filament",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "e8f4f8",
+          "translucent": true,
+          "codes": [
+            "PLA-CLEAR-1KG"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Glow PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Glow Green",
+          "hex": "adff2f",
+          "glow": true,
+          "codes": [
+            "GLOW-PLA-1KG"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/priline3d.json
+++ b/filaments/priline3d.json
@@ -1,0 +1,334 @@
+{
+  "manufacturer": "PRILINE 3D",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Purple",
+          "hex": "4738b7"
+        },
+        {
+          "name": "Translucent Blue",
+          "hex": "122daf"
+        }
+      ]
+    },
+    {
+      "name": "98A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 100
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        250
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00ffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "abbed1"
+        },
+        {
+          "name": "Navy",
+          "hex": "000080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ea6e22"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PC-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        290
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "808080"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "38a6f5"
+        },
+        {
+          "name": "Orange",
+          "hex": "f59105"
+        },
+        {
+          "name": "Pink",
+          "hex": "e7a4f9"
+        },
+        {
+          "name": "Red",
+          "hex": "f0260f"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ecf934"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "000080"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Cool White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "adb4bb"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f8e277"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        215
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black Walnut",
+          "hex": "4d3c35"
+        },
+        {
+          "name": "Dark Wood",
+          "hex": "5a3a20"
+        },
+        {
+          "name": "Wood",
+          "hex": "a8917a"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/primacreator.json
+++ b/filaments/primacreator.json
@@ -1,0 +1,59 @@
+{
+  "manufacturer": "PrimaCreator",
+  "filaments": [
+    {
+      "name": "EasyPrint PLA {color_name}",
+      "material": "PLA",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 600,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [185, 220],
+      "bed_temp_range": [40, 60],
+      "colors": [
+        {"name": "Active Black", "hex": "101010"},
+        {"name": "Solid White", "hex": "F2F2F2"},
+        {"name": "Army Green", "hex": "4B5320"},
+        {"name": "Ruby Red", "hex": "E0115F"},
+        {"name": "Sapphire Blue", "hex": "0F52BA"},
+        {"name": "Canary Yellow", "hex": "FFEF00"}
+      ]
+    },
+    {
+      "name": "EasyPrint PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 600,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [210, 235],
+      "bed_temp_range": [40, 60],
+      "colors": [
+        {"name": "Solid Black", "hex": "101010"},
+        {"name": "Solid White", "hex": "F2F2F2"},
+        {"name": "Transparent Blue", "hex": "0000FF80"},
+        {"name": "Solid Red", "hex": "C01010"}
+      ]
+    }
+  ]
+}

--- a/filaments/primaselect.json
+++ b/filaments/primaselect.json
@@ -1,0 +1,1613 @@
+{
+  "manufacturer": "PrimaSelect",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 334,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Blood Red",
+          "hex": "A52019"
+        },
+        {
+          "name": "Brown",
+          "hex": "6F4F28"
+        },
+        {
+          "name": "Cerise",
+          "hex": "DE3163"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "45322E"
+        },
+        {
+          "name": "Dandelion Yellow",
+          "hex": "F6B600"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "27352A"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "52595D"
+        },
+        {
+          "name": "Dark Purple",
+          "hex": "6D3F5B"
+        },
+        {
+          "name": "Florecent Yellow",
+          "hex": "E6FF00"
+        },
+        {
+          "name": "Forrest Green",
+          "hex": "27352A"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Green",
+          "hex": "008351"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Grey Blue",
+          "hex": "6C7C98"
+        },
+        {
+          "name": "Lake Blue",
+          "hex": "004F7C"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "D7D7D7"
+        },
+        {
+          "name": "Magenta",
+          "hex": "A03472"
+        },
+        {
+          "name": "Orange",
+          "hex": "E15501"
+        },
+        {
+          "name": "Peacock Blue",
+          "hex": "005F6A"
+        },
+        {
+          "name": "Pink",
+          "hex": "FFC0CB"
+        },
+        {
+          "name": "Prima Blue",
+          "hex": "005387"
+        },
+        {
+          "name": "Purple",
+          "hex": "992572"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "Signal Orange",
+          "hex": "ED6B21"
+        },
+        {
+          "name": "Skin",
+          "hex": "CDBA88"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "2271B3"
+        },
+        {
+          "name": "Tangerine Orange",
+          "hex": "F54029"
+        },
+        {
+          "name": "Toxic Green",
+          "hex": "39FF14"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F6B600"
+        },
+        {
+          "name": "Yellow Green",
+          "hex": "57A639"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 334,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Blue Purple",
+          "hex": "6C6981"
+        },
+        {
+          "name": "Burgundy Red",
+          "hex": "800020"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "45322E"
+        },
+        {
+          "name": "Clear White",
+          "hex": "F8F8F8",
+          "translucent": true
+        },
+        {
+          "name": "Dark Green",
+          "hex": "27352A"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "52595D"
+        },
+        {
+          "name": "Gold",
+          "hex": "D4AF37"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Green",
+          "hex": "008351"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Grey Blue",
+          "hex": "6C7C98"
+        },
+        {
+          "name": "Lake Blue",
+          "hex": "004F7C"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "D7D7D7"
+        },
+        {
+          "name": "Orange",
+          "hex": "E15501"
+        },
+        {
+          "name": "Pink",
+          "hex": "FFC0CB"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F6B600"
+        }
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 334,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "52595D"
+        },
+        {
+          "name": "Dark Red",
+          "hex": "792423"
+        },
+        {
+          "name": "Glow In The Dark Blue",
+          "hex": "1B2A6B",
+          "glow": true
+        },
+        {
+          "name": "Glow in the Dark Green",
+          "hex": "39FF14",
+          "glow": true
+        },
+        {
+          "name": "Green",
+          "hex": "008351"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Lake Blue",
+          "hex": "004F7C"
+        },
+        {
+          "name": "Navy",
+          "hex": "000080"
+        },
+        {
+          "name": "Orange",
+          "hex": "E15501"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F6B600"
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.06,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 2500,
+          "spool_weight": 334,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Green",
+          "hex": "008351"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Orange",
+          "hex": "E15501"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        }
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ]
+    },
+    {
+      "name": "PLA Matt {color_name}",
+      "material": "PLA",
+      "density": 1.4,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Broken White",
+          "hex": "F4F4F0"
+        },
+        {
+          "name": "Carbon Grey",
+          "hex": "4E5754"
+        },
+        {
+          "name": "Cool Grey",
+          "hex": "8A959C"
+        },
+        {
+          "name": "Deep Ocean Blue",
+          "hex": "004F7C"
+        },
+        {
+          "name": "Mud Brown",
+          "hex": "6F4F28"
+        },
+        {
+          "name": "Mustard Yellow",
+          "hex": "D4A017"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "424632"
+        },
+        {
+          "name": "Pirate Black",
+          "hex": "1C1C1C"
+        },
+        {
+          "name": "Pumpkin Orange",
+          "hex": "E25303"
+        },
+        {
+          "name": "Rose Red",
+          "hex": "B42041"
+        },
+        {
+          "name": "Sahara Beige",
+          "hex": "C2B280"
+        },
+        {
+          "name": "Terracotta",
+          "hex": "B55239"
+        },
+        {
+          "name": "Warm Grey",
+          "hex": "A5A5A5"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA Satin {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Abyss Blue",
+          "hex": "004F7C"
+        },
+        {
+          "name": "Amber Orange",
+          "hex": "E25303"
+        },
+        {
+          "name": "Baby Blue",
+          "hex": "89CFF0"
+        },
+        {
+          "name": "Buttercup Yellow",
+          "hex": "FACA30"
+        },
+        {
+          "name": "Gecko Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Goldfish",
+          "hex": "FF8C00"
+        },
+        {
+          "name": "Jemstone Purple",
+          "hex": "6D3F5B"
+        },
+        {
+          "name": "Kashmir Gold",
+          "hex": "C5A253"
+        },
+        {
+          "name": "Kryptonite Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Magic Silver",
+          "hex": "C0C0C0"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "98FF98"
+        },
+        {
+          "name": "Ocean Turquoise",
+          "hex": "30D5C8"
+        },
+        {
+          "name": "Pearl White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Pretty In Pink",
+          "hex": "FFB6C1"
+        },
+        {
+          "name": "Rose Copper",
+          "hex": "B87333"
+        },
+        {
+          "name": "Rose Red",
+          "hex": "B42041"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "9B111E"
+        },
+        {
+          "name": "Skin",
+          "hex": "CDBA88"
+        },
+        {
+          "name": "Soft Black",
+          "hex": "2B2B2B"
+        },
+        {
+          "name": "Space Grey",
+          "hex": "52595D"
+        },
+        {
+          "name": "Tanzanite Purple",
+          "hex": "6C6981"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ]
+    },
+    {
+      "name": "PLA Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Burgundy Red",
+          "hex": "800020",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Deep Space Black",
+          "hex": "0A0A0A",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Diamond Grey",
+          "hex": "9DA3A6",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "287233",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Lemon Sprinkle Yellow",
+          "hex": "FFF44F",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Mermaid Turquoise",
+          "hex": "30D5C8",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Night Sky Blue",
+          "hex": "1B2A6B",
+          "pattern": "sparkle"
+        }
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PLA Pastel {color_name}",
+      "material": "PLA",
+      "density": 1.4,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Aqua Blue",
+          "hex": "00FFFF"
+        },
+        {
+          "name": "Clear Sky Blue",
+          "hex": "87CEEB"
+        },
+        {
+          "name": "Cream",
+          "hex": "FFFDD0"
+        },
+        {
+          "name": "Cyan",
+          "hex": "00FFFF"
+        },
+        {
+          "name": "Honeydew Yellow",
+          "hex": "FFFACD"
+        },
+        {
+          "name": "Hubba Bubba Pink",
+          "hex": "FF69B4"
+        },
+        {
+          "name": "Lavender",
+          "hex": "E6E6FA"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "98FF98"
+        },
+        {
+          "name": "Peach",
+          "hex": "FFCBA4"
+        },
+        {
+          "name": "Pistachio",
+          "hex": "93C572"
+        },
+        {
+          "name": "Powder Blue",
+          "hex": "B0E0E6"
+        },
+        {
+          "name": "Pretty In Pink",
+          "hex": "FFB6C1"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ]
+    },
+    {
+      "name": "PLA Metal-Shine {color_name}",
+      "material": "PLA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Champagne Gold",
+          "hex": "D4AF37"
+        },
+        {
+          "name": "Coffee Gold",
+          "hex": "8A7040"
+        },
+        {
+          "name": "Liquorice Black",
+          "hex": "1A1A1A"
+        },
+        {
+          "name": "Rose Gold",
+          "hex": "B76E79"
+        },
+        {
+          "name": "Seafoam Green",
+          "hex": "93E9BE"
+        },
+        {
+          "name": "Silver Surfer",
+          "hex": "C0C0C0"
+        },
+        {
+          "name": "Steel Blue",
+          "hex": "4682B4"
+        },
+        {
+          "name": "Storm Cloud Grey",
+          "hex": "4E5754"
+        },
+        {
+          "name": "Sunset Orange",
+          "hex": "E25303"
+        },
+        {
+          "name": "Velvet Green",
+          "hex": "2E8B57"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ]
+    },
+    {
+      "name": "PLA Glow in the Dark {color_name}",
+      "material": "PLA",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Dark Blue",
+          "hex": "1E3A5F",
+          "glow": true
+        },
+        {
+          "name": "Dark Green",
+          "hex": "27352A",
+          "glow": true
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ]
+    },
+    {
+      "name": "PLA Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Blue/Green",
+          "hexes": [
+            "004F7C",
+            "008351"
+          ]
+        },
+        {
+          "name": "Blue/White",
+          "hexes": [
+            "004F7C",
+            "F6F6F6"
+          ]
+        },
+        {
+          "name": "Gold/Deep Green/Deep Blue/Blue Purple/Copper/Red",
+          "hexes": [
+            "D4AF37",
+            "27352A",
+            "1E3A5F",
+            "6C6981",
+            "B87333",
+            "CC0605"
+          ]
+        },
+        {
+          "name": "Red/White",
+          "hexes": [
+            "CC0605",
+            "F6F6F6"
+          ]
+        },
+        {
+          "name": "Yellow/Green/Sky Blue/Purple/Rose Red/Kashmir Gold",
+          "hexes": [
+            "F6B600",
+            "57A639",
+            "2271B3",
+            "992572",
+            "B42041",
+            "C5A253"
+          ]
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "multi_color_direction": "longitudinal"
+    },
+    {
+      "name": "PLA Marble {color_name}",
+      "material": "PLA",
+      "density": 1.18,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "A Touch Of Jade Green",
+          "hex": "008351",
+          "pattern": "marble"
+        },
+        {
+          "name": "Chocolate Sprinkle Brown",
+          "hex": "45322E",
+          "pattern": "marble"
+        },
+        {
+          "name": "Classic Granite",
+          "hex": "9DA3A6",
+          "pattern": "marble"
+        },
+        {
+          "name": "Concrete Grey",
+          "hex": "9DA3A6",
+          "pattern": "marble"
+        },
+        {
+          "name": "Galaxy Black",
+          "hex": "0A0A0A",
+          "pattern": "marble"
+        },
+        {
+          "name": "Gem Red",
+          "hex": "CC0605",
+          "pattern": "marble"
+        },
+        {
+          "name": "Lunar Surface",
+          "hex": "D7D7D7",
+          "pattern": "marble"
+        },
+        {
+          "name": "Stardust Black",
+          "hex": "0A0A0A",
+          "pattern": "marble"
+        }
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA Carbon {color_name}",
+      "material": "PLA-CF",
+      "density": 1.28,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "45322E"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "27352A"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PVA {color_name}",
+      "material": "PVA",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "E8DCC8"
+        }
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ]
+    },
+    {
+      "name": "ABS Metal-Shine {color_name}",
+      "material": "ABS",
+      "density": 1.06,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Champagne Gold",
+          "hex": "D4AF37"
+        },
+        {
+          "name": "Coffee Gold",
+          "hex": "8A7040"
+        },
+        {
+          "name": "Liquorice Black",
+          "hex": "1A1A1A"
+        },
+        {
+          "name": "Silver Surfer",
+          "hex": "C0C0C0"
+        },
+        {
+          "name": "Steel Blue",
+          "hex": "4682B4"
+        },
+        {
+          "name": "Velvet Green",
+          "hex": "2E8B57"
+        }
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ]
+    },
+    {
+      "name": "PLA Flame Retardant {color_name}",
+      "material": "PLA",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ]
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Clear Black",
+          "hex": "1A1A1A80",
+          "translucent": true
+        },
+        {
+          "name": "Clear White",
+          "hex": "F8F8F8",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        }
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ]
+    },
+    {
+      "name": "PC-CF {color_name}",
+      "material": "PC-CF",
+      "density": 1.32,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        }
+      ],
+      "extruder_temp_range": [
+        270,
+        300
+      ],
+      "bed_temp_range": [
+        70,
+        100
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "BVOH {color_name}",
+      "material": "BVOH",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "E8DCC8"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ]
+    },
+    {
+      "name": "OBC {color_name}",
+      "material": "OBC",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Natural",
+          "hex": "E8DCC8"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ]
+    },
+    {
+      "name": "TPU 64D {color_name}",
+      "material": "TPU-64D",
+      "density": 1.203,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        }
+      ],
+      "extruder_temp_range": [
+        215,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        80
+      ]
+    },
+    {
+      "name": "TPU 77D {color_name}",
+      "material": "TPU-77D",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        }
+      ],
+      "extruder_temp_range": [
+        215,
+        240
+      ],
+      "bed_temp_range": [
+        55,
+        80
+      ]
+    },
+    {
+      "name": "TPU 80A {color_name}",
+      "material": "TPU-80A",
+      "density": 1.157,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ]
+    },
+    {
+      "name": "TPU 85A {color_name}",
+      "material": "TPU-85A",
+      "density": 1.11,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Natural",
+          "hex": "E8DCC8"
+        },
+        {
+          "name": "Perfect Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Transparent White",
+          "hex": "FFFFFF80",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        80
+      ]
+    },
+    {
+      "name": "TPU 90A {color_name}",
+      "material": "TPU-90A",
+      "density": 1.13,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        80
+      ]
+    },
+    {
+      "name": "TPU 95A {color_name}",
+      "material": "TPU-95A",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Green",
+          "hex": "008351"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Orange",
+          "hex": "E15501"
+        },
+        {
+          "name": "Perfect Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "Transparent White",
+          "hex": "FFFFFF80",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F6B600"
+        }
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        50,
+        80
+      ]
+    },
+    {
+      "name": "PLA Tough {color_name}",
+      "material": "PLA",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 3000,
+          "spool_weight": 334,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E3A5F"
+        },
+        {
+          "name": "Green",
+          "hex": "008351"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Orange",
+          "hex": "E15501"
+        },
+        {
+          "name": "Red",
+          "hex": "CC0605"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F6B600"
+        }
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ]
+    },
+    {
+      "name": "PLA-CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        }
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PC Heat-Resistance {color_name}",
+      "material": "PC",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 205,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0A0A0A"
+        }
+      ],
+      "extruder_temp_range": [
+        310,
+        350
+      ],
+      "bed_temp_range": [
+        140,
+        180
+      ]
+    }
+  ]
+}

--- a/filaments/primavalue.json
+++ b/filaments/primavalue.json
@@ -1,0 +1,178 @@
+{
+  "manufacturer": "PrimaValue",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Dark Grey",
+          "hex": "3b3d3f"
+        },
+        {
+          "name": "red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "cccccc",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "03386d"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "444444"
+        },
+        {
+          "name": "Light Green",
+          "hex": "5de65b"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Silver",
+          "hex": "919191"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black Matt",
+          "hex": "212121"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "c4c3c5"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "c4c7c1"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/princore.json
+++ b/filaments/princore.json
@@ -1,0 +1,223 @@
+{
+  "manufacturer": "Princore",
+  "filaments": [
+    {
+      "name": "Cf {color_name}",
+      "material": "PA12-CF",
+      "density": 1.02,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PP-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PA6-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        265,
+        285
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PA12-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        245,
+        265
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Grau",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Leuchtpink",
+          "hex": "fe2d90"
+        },
+        {
+          "name": "Petrol",
+          "hex": "004d65"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PLA-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Türkis",
+          "hex": "009ca6"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Leuchtgelb",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Petrol",
+          "hex": "006272"
+        },
+        {
+          "name": "Reinorange",
+          "hex": "fe5000"
+        },
+        {
+          "name": "Schwarz",
+          "hex": "000000"
+        },
+        {
+          "name": "Türkis",
+          "hex": "009ca6"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/printalot.json
+++ b/filaments/printalot.json
@@ -1,0 +1,285 @@
+{
+  "manufacturer": "Printalot",
+  "filaments": [
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Turquesa / Blanco",
+          "hex": "00fbff"
+        }
+      ]
+    },
+    {
+      "name": "Eco {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Coffee",
+          "hex": "6f4e37"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Oro Metalizado",
+          "hex": "877720"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Verde",
+          "hex": "04ff00"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Celeste",
+          "hex": "57cdff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Amarillo Fluorescente",
+          "hex": "e1ff00"
+        },
+        {
+          "name": "Azul Pal/Pal Blue",
+          "hex": "2391e7"
+        },
+        {
+          "name": "Azul/Blue",
+          "hexes": [
+            "1325b4",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blanco/White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Cobre Metalizado",
+          "hex": "903914"
+        },
+        {
+          "name": "Kriptonita Metalizado",
+          "hex": "006607"
+        },
+        {
+          "name": "Naranja Fluorescente",
+          "hex": "ff6200"
+        },
+        {
+          "name": "Negro/Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Piedra / Stone",
+          "hex": "d1cbc2"
+        },
+        {
+          "name": "Piel",
+          "hex": "ffecd9"
+        },
+        {
+          "name": "Pink",
+          "hex": "d991bb"
+        },
+        {
+          "name": "Rojo",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Uva Metalizado",
+          "hex": "993366"
+        },
+        {
+          "name": "Verde/Green",
+          "hexes": [
+            "0d4f27",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Violeta",
+          "hex": "4c009e"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Blanco",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f8f7ed"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/printbed.json
+++ b/filaments/printbed.json
@@ -1,0 +1,484 @@
+{
+  "manufacturer": "Printbed",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 840
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "636452"
+        },
+        {
+          "name": "Baja Blue",
+          "hex": "017068"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Charcoal",
+          "hex": "353537"
+        },
+        {
+          "name": "Cloud",
+          "hex": "c5c9d4"
+        },
+        {
+          "name": "Flamingo",
+          "hex": "db486e"
+        },
+        {
+          "name": "Meadow",
+          "hex": "2c784a"
+        },
+        {
+          "name": "Natural",
+          "hex": "e9e4d0"
+        },
+        {
+          "name": "Pistachio",
+          "hex": "b1d597"
+        },
+        {
+          "name": "Redwood",
+          "hex": "9b6251"
+        },
+        {
+          "name": "Robin Egg",
+          "hex": "79c5a8"
+        },
+        {
+          "name": "Tangerine",
+          "hex": "e17625"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Blend {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Purple Crystal",
+          "hex": "501f3f"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Chameleon",
+          "hex": "d3d302"
+        }
+      ]
+    },
+    {
+      "name": "Crystal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green Crystal",
+          "hex": "249d1d"
+        },
+        {
+          "name": "Sea Crystal",
+          "hex": "00a7a2"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glowstick Green",
+          "hex": "e3e1d5"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black FORGE",
+          "hex": "000000"
+        },
+        {
+          "name": "Natural FORGE",
+          "hex": "f3eed9"
+        },
+        {
+          "name": "White FORGE",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Clear",
+          "hex": "ccd4d6"
+        },
+        {
+          "name": "Flamingo",
+          "hex": "db486e"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glacier",
+          "hex": "41b6b5"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Baja Blue V2",
+          "hex": "017068"
+        },
+        {
+          "name": "Banana Taffy",
+          "hex": "ffea00"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Black Cherry",
+          "hex": "722822"
+        },
+        {
+          "name": "Blue",
+          "hex": "015ad1"
+        },
+        {
+          "name": "Blue Steel",
+          "hex": "4e6168"
+        },
+        {
+          "name": "Blueberry Pearl",
+          "hex": "283964"
+        },
+        {
+          "name": "Bubble Gum",
+          "hex": "f69fb2"
+        },
+        {
+          "name": "Chocolate V2",
+          "hex": "4e3629"
+        },
+        {
+          "name": "Cookies N' Cream",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Cosmic Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cosmic Purple",
+          "hex": "930ea4"
+        },
+        {
+          "name": "Dragon Egg",
+          "hex": "313c31"
+        },
+        {
+          "name": "Electric Orange",
+          "hex": "fb790e"
+        },
+        {
+          "name": "Evergreen",
+          "hex": "096d1d"
+        },
+        {
+          "name": "French Vanilla",
+          "hex": "f1e7cc"
+        },
+        {
+          "name": "Frost",
+          "hex": "a9c9d6"
+        },
+        {
+          "name": "Green",
+          "hex": "019c3e"
+        },
+        {
+          "name": "Grey",
+          "hex": "757a74"
+        },
+        {
+          "name": "Hot Pink",
+          "hex": "ff4e9b"
+        },
+        {
+          "name": "Jungle Green",
+          "hex": "546223"
+        },
+        {
+          "name": "Latte",
+          "hex": "ddcba4"
+        },
+        {
+          "name": "Lavender V2",
+          "hex": "d4c1d5"
+        },
+        {
+          "name": "Leftovers",
+          "hex": "dadfe2"
+        },
+        {
+          "name": "Licorice",
+          "hex": "991f1c"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "26344f"
+        },
+        {
+          "name": "Mint",
+          "hex": "7dd3c9"
+        },
+        {
+          "name": "Mystery",
+          "hex": "fbff00"
+        },
+        {
+          "name": "Nacho Cheese",
+          "hex": "fcc543"
+        },
+        {
+          "name": "Natural",
+          "hex": "e6e0c6"
+        },
+        {
+          "name": "Orange",
+          "hex": "fd5307"
+        },
+        {
+          "name": "Peanut Butter V2",
+          "hex": "db9a55"
+        },
+        {
+          "name": "Pink Glaze",
+          "hex": "fd49ee"
+        },
+        {
+          "name": "Pirate's Gold",
+          "hex": "a16c25"
+        },
+        {
+          "name": "Pumpkin Pie",
+          "hex": "d2742d"
+        },
+        {
+          "name": "Purple",
+          "hex": "9c1e58"
+        },
+        {
+          "name": "Red",
+          "hex": "f62a29"
+        },
+        {
+          "name": "Royal Purple",
+          "hex": "513655"
+        },
+        {
+          "name": "Sour Apple V2",
+          "hex": "99ca20"
+        },
+        {
+          "name": "Tennis Ball",
+          "hex": "8dd945"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f7c901"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/printedsolid.json
+++ b/filaments/printedsolid.json
@@ -1,0 +1,231 @@
+{
+  "manufacturer": "Printed Solid",
+  "filaments": [
+    {
+      "name": "Jessie {color_name} PLA",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 297,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 205,
+      "bed_temp": 60,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "2A242D"
+        },
+        {
+          "name": "White",
+          "hex": "EFEFE8"
+        },
+        {
+          "name": "Gun Metal Grey",
+          "hex": "89908E"
+        },
+        {
+          "name": "Soul Black Glitter",
+          "hex": "292823"
+        },
+        {
+          "name": "Yellow Bird",
+          "hex": "FDC22E"
+        },
+        {
+          "name": "PS Red",
+          "hex": "C2403B"
+        },
+        {
+          "name": "Quarter White",
+          "hex": "E5E7E1"
+        },
+        {
+          "name": "3DPN Vanilla Bean Ice Cream",
+          "hex": "9FA8A9"
+        },
+        {
+          "name": "Tree Green",
+          "hex": "3A853B"
+        },
+        {
+          "name": "Bold Blue",
+          "hex": "0851A6"
+        },
+        {
+          "name": "Beige 500",
+          "hex": "DBD0BC"
+        },
+        {
+          "name": "Blue Ice",
+          "hex": "034C73"
+        },
+        {
+          "name": "Pure Cyan",
+          "hex": "0686B2"
+        },
+        {
+          "name": "Mystery Orange",
+          "hex": "F56232"
+        },
+        {
+          "name": "Purple Eater",
+          "hex": "8E4FAF"
+        },
+        {
+          "name": "Design White",
+          "hex": "D0CDC7"
+        },
+        {
+          "name": "Blood Red Light Glitter",
+          "hex": "A23C33"
+        },
+        {
+          "name": "Red Ice",
+          "hex": "862E26"
+        },
+        {
+          "name": "Tree Brown",
+          "hex": "584136"
+        },
+        {
+          "name": "Golden Winner Glitter",
+          "hex": "906E30"
+        },
+        {
+          "name": "Blue Moon",
+          "hex": "221E89"
+        },
+        {
+          "name": "Tan 64",
+          "hex": "9B8978"
+        },
+        {
+          "name": "Safety Orange",
+          "hex": "F66A1F"
+        },
+        {
+          "name": "Pure Magenta",
+          "hex": "EEB4D7"
+        },
+        {
+          "name": "Green Ice",
+          "hex": "365926"
+        },
+        {
+          "name": "Blue Whale Grey",
+          "hex": "36608D"
+        },
+        {
+          "name": "Limer Green",
+          "hex": "52AB2B"
+        },
+        {
+          "name": "Army Green",
+          "hex": "524D28"
+        },
+        {
+          "name": "Purple Ice",
+          "hex": "8C41AE"
+        },
+        {
+          "name": "Orange Glitter",
+          "hex": "DB5532"
+        },
+        {
+          "name": "Neon Pink",
+          "hex": "FD636A"
+        },
+        {
+          "name": "Deep Purple",
+          "hex": "5D4F5D"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "B0DA00"
+        },
+        {
+          "name": "Green Slime Glitter",
+          "hex": "8D9222"
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "D3E500"
+        }
+      ]
+    },
+    {
+      "name": "Jessie {color_name} PETG",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 297,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 240,
+      "bed_temp": 80,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "221E21"
+        },
+        {
+          "name": "Soul Black Glitter",
+          "hex": "292823"
+        },
+        {
+          "name": "Gun Metal Grey",
+          "hex": "99999A"
+        },
+        {
+          "name": "White",
+          "hex": "ECEBE8"
+        },
+        {
+          "name": "Mystery Orange",
+          "hex": "F56232"
+        },
+        {
+          "name": "PS Red",
+          "hex": "BE2F2A"
+        },
+        {
+          "name": "Bold Blue",
+          "hex": "054A98"
+        },
+        {
+          "name": "Clear",
+          "hex": "BBC7CC"
+        },
+        {
+          "name": "Tree Green",
+          "hex": "217E3E"
+        },
+        {
+          "name": "Pure Cyan",
+          "hex": "078BBA"
+        },
+        {
+          "name": "Yellow Bird",
+          "hex": "EFBC2F"
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "E3DF00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/printme.json
+++ b/filaments/printme.json
@@ -1,0 +1,352 @@
+{
+  "manufacturer": "Print-Me",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black Volcano",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "fffaf4"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Natural Ivory",
+          "hex": "e6e0d9"
+        }
+      ]
+    },
+    {
+      "name": "Eco {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Polar White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Ecofil {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dark blue",
+          "hex": "165daa"
+        },
+        {
+          "name": "Pastel blue",
+          "hex": "c3d8ea"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gleaming yellow",
+          "hex": "c8d1cb"
+        }
+      ]
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Antique gold",
+          "hex": "ac9b78"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marble carrara",
+          "hex": "e9e5d0",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "21a1de"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Antique Gold",
+          "hex": "ac9b78"
+        },
+        {
+          "name": "Green bottle",
+          "hex": "0c3b2c"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bone",
+          "hex": "cdcac2"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        310
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black (20ShD)",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bamboo",
+          "hex": "897367"
+        },
+        {
+          "name": "Cork",
+          "hex": "45362b"
+        },
+        {
+          "name": "Wood",
+          "hex": "bfa47d"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/printomax.json
+++ b/filaments/printomax.json
@@ -1,0 +1,296 @@
+{
+  "manufacturer": "Printomax",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        175,
+        220
+      ],
+      "bed_temp_range": [
+        85,
+        85
+      ],
+      "colors": [
+        {
+          "name": "BLACK",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLACK PAILLETTÉ",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "MARBLE RED",
+          "hex": "8c3636",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLACK",
+          "hex": "000000"
+        },
+        {
+          "name": "RED",
+          "hex": "c40000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLACK",
+          "hex": "000000"
+        },
+        {
+          "name": "FRUITY FRAMBOISE - FUSHIA",
+          "hex": "c412ac"
+        },
+        {
+          "name": "GOLD",
+          "hex": "d4af37"
+        },
+        {
+          "name": "Green",
+          "hex": "22a03b"
+        },
+        {
+          "name": "RED",
+          "hex": "ff4013"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BEIGE",
+          "hex": "d3bc8d"
+        },
+        {
+          "name": "BLACK",
+          "hex": "000000"
+        },
+        {
+          "name": "Blood Red",
+          "hex": "b91716"
+        },
+        {
+          "name": "BLUE NAVY",
+          "hex": "403a60"
+        },
+        {
+          "name": "BROWN",
+          "hex": "674736"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "0f4336"
+        },
+        {
+          "name": "Duck Blue",
+          "hex": "05868e"
+        },
+        {
+          "name": "Golden Brick",
+          "hex": "fec700"
+        },
+        {
+          "name": "GREEN",
+          "hex": "317f43"
+        },
+        {
+          "name": "LIGHT PEACH",
+          "hex": "ffdab6"
+        },
+        {
+          "name": "LIGHT PINK",
+          "hex": "ea899a"
+        },
+        {
+          "name": "Light purple",
+          "hex": "d357fe"
+        },
+        {
+          "name": "Pink",
+          "hex": "d38286"
+        },
+        {
+          "name": "PURE WHITE",
+          "hex": "ecece7"
+        },
+        {
+          "name": "PURPLE",
+          "hex": "553a76"
+        },
+        {
+          "name": "RED COPPER",
+          "hex": "cb6d51"
+        },
+        {
+          "name": "Red Wine Bordeaux",
+          "hex": "722b3d"
+        },
+        {
+          "name": "Rich Gold",
+          "hex": "a7a67b"
+        },
+        {
+          "name": "SKY BLUE",
+          "hex": "92c1e9"
+        },
+        {
+          "name": "yellow",
+          "hex": "f1dd39"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "BLACK/PURPLE",
+          "hexes": [
+            "000000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/printonion.json
+++ b/filaments/printonion.json
@@ -1,0 +1,667 @@
+{
+  "manufacturer": "PrintOnion",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ed0707"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "212721"
+        },
+        {
+          "name": "White",
+          "hex": "f6f8f6"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ABS-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Carbon Fiber Black",
+          "hex": "141414"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Crystal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Starry Transparent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        255
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "232323",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "9cffb0"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "ce8946"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        255
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        255
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "141414"
+        },
+        {
+          "name": "Green",
+          "hex": "25d047"
+        },
+        {
+          "name": "Grey",
+          "hex": "595962"
+        },
+        {
+          "name": "Khaki",
+          "hex": "606060"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "adadad"
+        },
+        {
+          "name": "Military Green",
+          "hex": "263e0f"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "96ffef"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffb514"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff9ee0"
+        },
+        {
+          "name": "Purple",
+          "hex": "c524ff"
+        },
+        {
+          "name": "Silver",
+          "hex": "919191"
+        },
+        {
+          "name": "Taro Purple",
+          "hex": "e891e6"
+        },
+        {
+          "name": "Transparent",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        210
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "787882"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Balck",
+          "hex": "141414"
+        },
+        {
+          "name": "Beige",
+          "hex": "afa081"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0f57ff"
+        },
+        {
+          "name": "Coffee",
+          "hex": "652e1a"
+        },
+        {
+          "name": "Cyan",
+          "hex": "1e88eb"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "093577"
+        },
+        {
+          "name": "Green",
+          "hex": "238b2a"
+        },
+        {
+          "name": "Grey",
+          "hex": "787882"
+        },
+        {
+          "name": "Marble",
+          "hex": "e7e9ea"
+        },
+        {
+          "name": "Military Green",
+          "hex": "355031"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "5eb5ad"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffb514"
+        },
+        {
+          "name": "Pink",
+          "hex": "f69bff"
+        },
+        {
+          "name": "Purple",
+          "hex": "864ffe"
+        },
+        {
+          "name": "Red",
+          "hex": "f71818"
+        },
+        {
+          "name": "Rose",
+          "hex": "ec3697"
+        },
+        {
+          "name": "Viridis Green",
+          "hex": "88f231"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Wood",
+          "hex": "947b5e"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fff838"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Cream Yellow",
+          "hex": "f5e1a4"
+        },
+        {
+          "name": "Imitated Wood",
+          "hex": "9e8470"
+        },
+        {
+          "name": "Khaki Gray",
+          "hex": "787664"
+        },
+        {
+          "name": "Khaki Green",
+          "hex": "53664a"
+        },
+        {
+          "name": "Military Green",
+          "hex": "477632"
+        },
+        {
+          "name": "Pink",
+          "hex": "ff9ee0"
+        },
+        {
+          "name": "Transparent",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "238b2a"
+        },
+        {
+          "name": "Grey",
+          "hex": "adb3b8"
+        },
+        {
+          "name": "Purple",
+          "hex": "8910c1"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ebebeb"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "fafafa"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/printwithsmile.json
+++ b/filaments/printwithsmile.json
@@ -1,0 +1,1644 @@
+{
+  "manufacturer": "Print With Smile",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        225,
+        275
+      ],
+      "bed_temp_range": [
+        80,
+        120
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "Cherry RED",
+          "codes": [
+            "116"
+          ],
+          "eans": [
+            "8594196451163"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "Cobalt BLUE/modrá",
+          "codes": [
+            "115"
+          ],
+          "eans": [
+            "8594196451156"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "GREEN",
+          "codes": [
+            "121"
+          ],
+          "eans": [
+            "8594196451217"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "Lemon DROP",
+          "codes": [
+            "118"
+          ],
+          "eans": [
+            "8594196451187"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Light GREEN",
+          "codes": [
+            "120"
+          ],
+          "eans": [
+            "8594196451200"
+          ],
+          "hex": "90ee90"
+        },
+        {
+          "name": "NATURAL Ivory",
+          "codes": [
+            "111"
+          ],
+          "eans": [
+            "8594196451118"
+          ],
+          "hex": "fffff0"
+        },
+        {
+          "name": "Satine Black",
+          "codes": [
+            "114"
+          ],
+          "eans": [
+            "8594196451149"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "Satine White",
+          "codes": [
+            "112"
+          ],
+          "eans": [
+            "8594196451125"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "SILVER Shine",
+          "codes": [
+            "119"
+          ],
+          "eans": [
+            "8594196451194"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Sky BLUE",
+          "codes": [
+            "126"
+          ],
+          "eans": [
+            "8594196451262"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "YELLOW",
+          "codes": [
+            "117"
+          ],
+          "eans": [
+            "8594196451170"
+          ],
+          "hex": "ffff00"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 850
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "BLACK volkano",
+          "codes": [
+            "409"
+          ],
+          "eans": [
+            "8594196454096"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "CHERRY RED",
+          "codes": [
+            "411"
+          ],
+          "eans": [
+            "8594196454119"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "DARK BLUE",
+          "codes": [
+            "410"
+          ],
+          "eans": [
+            "8594196454102"
+          ],
+          "hex": "00008b"
+        },
+        {
+          "name": "Dark GREY",
+          "codes": [
+            "404"
+          ],
+          "eans": [
+            "8594196454041"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "NATURAL",
+          "codes": [
+            "406"
+          ],
+          "eans": [
+            "8594196454065"
+          ],
+          "hex": "f5e6c8"
+        },
+        {
+          "name": "ORANGE",
+          "codes": [
+            "403"
+          ],
+          "eans": [
+            "8594196454034"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "SIVER SHINE",
+          "codes": [
+            "408"
+          ],
+          "eans": [
+            "8594196454089"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "WHITE",
+          "codes": [
+            "407"
+          ],
+          "eans": [
+            "8594196454072"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "XXL BLACK Volkano",
+          "codes": [
+            "421"
+          ],
+          "eans": [
+            "8594196454218"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "YELLOW",
+          "codes": [
+            "405"
+          ],
+          "eans": [
+            "8594196454058"
+          ],
+          "hex": "ffff00"
+        },
+        {
+          "name": "Yellow GREEN",
+          "codes": [
+            "402"
+          ],
+          "eans": [
+            "8594196454027"
+          ],
+          "hex": "228b22"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "BIOFIL {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        170,
+        200
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "Matt WHITE",
+          "codes": [
+            "518"
+          ],
+          "eans": [
+            "8594196455185"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "WOOD",
+          "codes": [
+            "519"
+          ],
+          "eans": [
+            "8594196455192"
+          ],
+          "hex": "c4a574"
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "COMPOSITE {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 850
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "ASA KEVLAR BLACK",
+          "codes": [
+            "430",
+            "441"
+          ],
+          "eans": [
+            "8594196454300",
+            "8594196454416"
+          ],
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "COMPOSITE {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "PA12 CF15",
+          "codes": [
+            "903"
+          ],
+          "eans": [
+            "8594196459039"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "PLA UVHT C15",
+          "codes": [
+            "910"
+          ],
+          "eans": [
+            "8594196459107"
+          ],
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "HIS PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "natural",
+          "codes": [
+            "515"
+          ],
+          "eans": [
+            "8594196455154"
+          ],
+          "hex": "f5e6c8"
+        }
+      ]
+    },
+    {
+      "name": "MULTICOLOR {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "DUAL SILK PLA BLACK/RED",
+          "codes": [
+            "916"
+          ],
+          "eans": [
+            "8594196459169"
+          ],
+          "hexes": [
+            "000000",
+            "cc0000"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "DUAL SILK PLA BLUE/GREEN",
+          "codes": [
+            "918"
+          ],
+          "eans": [
+            "8594196459183"
+          ],
+          "hexes": [
+            "0066cc",
+            "228b22"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "DUAL SILK PLA BLUE/ORANGE",
+          "codes": [
+            "915"
+          ],
+          "eans": [
+            "8594196459152"
+          ],
+          "hexes": [
+            "0066cc",
+            "ff8c00"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "DUAL SILK PLA BLUE/YELLOW",
+          "codes": [
+            "917"
+          ],
+          "eans": [
+            "8594196459176"
+          ],
+          "hexes": [
+            "0066cc",
+            "ffff00"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "DUAL SILK PLA PURPLE/BLUE",
+          "codes": [
+            "913"
+          ],
+          "eans": [
+            "8594196459138"
+          ],
+          "hexes": [
+            "800080",
+            "0066cc"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "DUAL SILK PLA ROSE/JADE",
+          "codes": [
+            "919"
+          ],
+          "eans": [
+            "8594196459190"
+          ],
+          "hexes": [
+            "ff66cc",
+            "00a86b"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "DUAL SILK PLA WINTER",
+          "codes": [
+            "914"
+          ],
+          "eans": [
+            "8594196459145"
+          ],
+          "hex": "87ceeb"
+        },
+        {
+          "name": "RAINBOW MATTE",
+          "codes": [
+            "925"
+          ],
+          "eans": [
+            "8594196459251"
+          ],
+          "hexes": [
+            "ff0000",
+            "ff8c00",
+            "ffff00",
+            "228b22",
+            "0066cc",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "SILK PLA PASTEL RAINBOW",
+          "codes": [
+            "926"
+          ],
+          "eans": [
+            "8594196459268"
+          ],
+          "hexes": [
+            "ff0000",
+            "ff8c00",
+            "ffff00",
+            "228b22",
+            "0066cc",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "SILK PLA RAINBOW",
+          "codes": [
+            "927"
+          ],
+          "eans": [
+            "8594196459275"
+          ],
+          "hexes": [
+            "ff0000",
+            "ff8c00",
+            "ffff00",
+            "228b22",
+            "0066cc",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "TRIPLE SILK PLA BLUE/PURPLE/YELLOW",
+          "codes": [
+            "920"
+          ],
+          "eans": [
+            "8594196459206"
+          ],
+          "hexes": [
+            "0066cc",
+            "800080",
+            "ffff00"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "TRIPLE SILK PLA GOLD/GREEN/BLACK",
+          "codes": [
+            "922"
+          ],
+          "eans": [
+            "8594196459220"
+          ],
+          "hexes": [
+            "daa520",
+            "228b22",
+            "000000"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "TRIPLE SILK PLA GOLD/GREEN/FUCHSIA",
+          "codes": [
+            "924"
+          ],
+          "eans": [
+            "8594196459244"
+          ],
+          "hexes": [
+            "daa520",
+            "228b22",
+            "ff00ff"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "TRIPLE SILK PLA RED/GOLD/PURPLE",
+          "codes": [
+            "921"
+          ],
+          "eans": [
+            "8594196459213"
+          ],
+          "hexes": [
+            "cc0000",
+            "daa520",
+            "800080"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "TRIPLE SILK PLA ROSE RED/GREEN/BLUE",
+          "codes": [
+            "923"
+          ],
+          "eans": [
+            "8594196459237"
+          ],
+          "hexes": [
+            "cc0000",
+            "228b22",
+            "0066cc"
+          ],
+          "multi_color_direction": "coaxial"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "BICOLOR METALLIC PET G GREEN BROWN",
+          "codes": [
+            "205"
+          ],
+          "eans": [
+            "8594196452054"
+          ],
+          "hex": "8b4513"
+        },
+        {
+          "name": "BICOLOR METALLIC PET G VIOLET SILVER",
+          "codes": [
+            "206"
+          ],
+          "eans": [
+            "8594196452061"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "BICOLOR METALLIC PET G VIOLET SPARKLE",
+          "codes": [
+            "204"
+          ],
+          "eans": [
+            "8594196452047"
+          ],
+          "hex": "8a2be2"
+        },
+        {
+          "name": "PET G COLOR CHANGE",
+          "codes": [
+            "935"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "REC PET G COLOR CHANGE",
+          "codes": [
+            "299"
+          ],
+          "eans": [
+            "8594196452993"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "XXL Satine BLACK",
+          "codes": [
+            "227"
+          ],
+          "eans": [
+            "8594196452276"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "XXL Satine WHITE",
+          "codes": [
+            "224"
+          ],
+          "eans": [
+            "8594196452245"
+          ],
+          "hex": "ffffff"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        },
+        {
+          "weight": 750
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "5XL BLACK",
+          "codes": [
+            "065"
+          ],
+          "eans": [
+            "8594196450654"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "5XL WHITE",
+          "codes": [
+            "064"
+          ],
+          "eans": [
+            "8594196450647"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "BICOLOR METALLIC PLA GREEN BROWN",
+          "codes": [
+            "094"
+          ],
+          "eans": [
+            "8594196450944"
+          ],
+          "hex": "8b4513"
+        },
+        {
+          "name": "BICOLOR METALLIC PLA VIOLET SILVER",
+          "codes": [
+            "093"
+          ],
+          "eans": [
+            "8594196450937"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "BICOLOR METALLIC PLA VIOLET SPARKLE",
+          "codes": [
+            "092"
+          ],
+          "eans": [
+            "8594196450920"
+          ],
+          "hex": "8a2be2"
+        },
+        {
+          "name": "Black",
+          "codes": [
+            "041",
+            "005"
+          ],
+          "eans": [
+            "8594196450418",
+            "8594196450050"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "BLACK STAR",
+          "codes": [
+            "063",
+            "061"
+          ],
+          "eans": [
+            "8594196450630",
+            "8594196450616"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "Chocolade Shine",
+          "codes": [
+            "042",
+            "014"
+          ],
+          "eans": [
+            "8594196450425",
+            "8594196450142"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Cloudy Grey",
+          "codes": [
+            "021",
+            "016"
+          ],
+          "eans": [
+            "8594196450210",
+            "8594196450166"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Cobalt BLUE",
+          "codes": [
+            "040",
+            "006"
+          ],
+          "eans": [
+            "8594196450401",
+            "8594196450067"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "Copper BROWN",
+          "codes": [
+            "050",
+            "049"
+          ],
+          "eans": [
+            "8594196450500",
+            "8594196450494"
+          ],
+          "hex": "8b4513"
+        },
+        {
+          "name": "Coral PINK",
+          "codes": [
+            "031",
+            "010"
+          ],
+          "eans": [
+            "8594196450319",
+            "8594196450104"
+          ],
+          "hex": "ff69b4"
+        },
+        {
+          "name": "Creamy",
+          "codes": [
+            "019",
+            "091"
+          ],
+          "eans": [
+            "8594196450197",
+            "8594196450913"
+          ],
+          "hex": "fffdd0"
+        },
+        {
+          "name": "Dark GREEN",
+          "codes": [
+            "023"
+          ],
+          "eans": [
+            "8594196450234"
+          ],
+          "hex": "006400"
+        },
+        {
+          "name": "Eco TYRKYS",
+          "codes": [
+            "528"
+          ],
+          "eans": [
+            "8594196455284"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Fresh MINT",
+          "codes": [
+            "044",
+            "015"
+          ],
+          "eans": [
+            "8594196450449",
+            "8594196450159"
+          ],
+          "hex": "98ff98"
+        },
+        {
+          "name": "GREEN",
+          "codes": [
+            "037"
+          ],
+          "eans": [
+            "8594196450371"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "GREEN Apple",
+          "codes": [
+            "018"
+          ],
+          "eans": [
+            "8594196450180"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "Grey",
+          "codes": [
+            "026"
+          ],
+          "eans": [
+            "8594196450265"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Just BLUE",
+          "codes": [
+            "537"
+          ],
+          "eans": [
+            "8594196455376"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "Just BROWN",
+          "codes": [
+            "588"
+          ],
+          "eans": [
+            "8594196455888"
+          ],
+          "hex": "8b4513"
+        },
+        {
+          "name": "Just GREY",
+          "codes": [
+            "542"
+          ],
+          "eans": [
+            "8594196455420"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Just RED",
+          "codes": [
+            "534"
+          ],
+          "eans": [
+            "8594196455345"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "Just YELLOW",
+          "codes": [
+            "532"
+          ],
+          "eans": [
+            "8594196455321"
+          ],
+          "hex": "ffff00"
+        },
+        {
+          "name": "Lemon Drop",
+          "codes": [
+            "029",
+            "008"
+          ],
+          "eans": [
+            "8594196450296",
+            "8594196450081"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "Light GREEN",
+          "codes": [
+            "035",
+            "017"
+          ],
+          "eans": [
+            "8594196450357",
+            "8594196450173"
+          ],
+          "hex": "90ee90"
+        },
+        {
+          "name": "Low GREY",
+          "codes": [
+            "587"
+          ],
+          "eans": [
+            "8594196455871"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "MARBLE Bright",
+          "codes": [
+            "054",
+            "053"
+          ],
+          "eans": [
+            "8594196450548",
+            "8594196450531"
+          ],
+          "hex": "f0f0f0"
+        },
+        {
+          "name": "May GREEN",
+          "codes": [
+            "535"
+          ],
+          "eans": [
+            "8594196455352"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "Maya BLUE",
+          "codes": [
+            "536"
+          ],
+          "eans": [
+            "8594196455369"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "Metallic BLUE",
+          "codes": [
+            "089",
+            "087"
+          ],
+          "eans": [
+            "8594196450890",
+            "8594196450876"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "Metallic GREEN",
+          "codes": [
+            "052",
+            "051"
+          ],
+          "eans": [
+            "8594196450524",
+            "8594196450517"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "Natural",
+          "codes": [
+            "001"
+          ],
+          "eans": [
+            "8594196450012"
+          ],
+          "hex": "f5e6c8"
+        },
+        {
+          "name": "Orange",
+          "codes": [
+            "033",
+            "012"
+          ],
+          "eans": [
+            "8594196450333",
+            "8594196450128"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Pastel BLUE",
+          "codes": [
+            "028",
+            "007"
+          ],
+          "eans": [
+            "8594196450289",
+            "8594196450074"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "Pumkin ORANGE",
+          "codes": [
+            "533"
+          ],
+          "eans": [
+            "8594196455338"
+          ],
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Purple",
+          "codes": [
+            "043",
+            "004"
+          ],
+          "eans": [
+            "8594196450432",
+            "8594196450043"
+          ],
+          "hex": "800080"
+        },
+        {
+          "name": "Rubin RED",
+          "codes": [
+            "032",
+            "011"
+          ],
+          "eans": [
+            "8594196450326",
+            "8594196450111"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "SATIN PLA Peach RED",
+          "codes": [
+            "066",
+            "056"
+          ],
+          "eans": [
+            "8594196450661",
+            "8594196450562"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "SATIN PLA Princess PINK",
+          "codes": [
+            "057"
+          ],
+          "eans": [
+            "8594196450579"
+          ],
+          "hex": "ff69b4"
+        },
+        {
+          "name": "SATIN PLA Sky BLUE",
+          "codes": [
+            "068",
+            "058"
+          ],
+          "eans": [
+            "8594196450685",
+            "8594196450586"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "SATIN PLA Spring GREEN",
+          "codes": [
+            "069",
+            "059"
+          ],
+          "eans": [
+            "8594196450692",
+            "8594196450593"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "SATIN PLA Violet",
+          "codes": [
+            "070",
+            "060"
+          ],
+          "eans": [
+            "8594196450708",
+            "8594196450609"
+          ],
+          "hex": "8a2be2"
+        },
+        {
+          "name": "SATIN PLA Yellow",
+          "codes": [
+            "071",
+            "055"
+          ],
+          "eans": [
+            "8594196450715",
+            "8594196450555"
+          ],
+          "hex": "ffff00"
+        },
+        {
+          "name": "SILK PLA COPPER",
+          "codes": [
+            "592"
+          ],
+          "eans": [
+            "8594196455925"
+          ],
+          "hex": "b87333"
+        },
+        {
+          "name": "SILK PLA OLD GOLD",
+          "codes": [
+            "582"
+          ],
+          "eans": [
+            "8594196455826"
+          ],
+          "hex": "daa520"
+        },
+        {
+          "name": "Silver",
+          "codes": [
+            "038",
+            "024"
+          ],
+          "eans": [
+            "8594196450388",
+            "8594196450241"
+          ],
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Sunset GOLD",
+          "codes": [
+            "048"
+          ],
+          "eans": [
+            "8594196450487"
+          ],
+          "hex": "daa520"
+        },
+        {
+          "name": "THERM PLA BLUE",
+          "codes": [
+            "545"
+          ],
+          "eans": [
+            "8594196455451"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "THERM PLA RED",
+          "codes": [
+            "546"
+          ],
+          "eans": [
+            "8594196455468"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "Turquoise BLUE",
+          "codes": [
+            "090",
+            "088"
+          ],
+          "eans": [
+            "8594196450906",
+            "8594196450883"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "White",
+          "codes": [
+            "025",
+            "002"
+          ],
+          "eans": [
+            "8594196450258",
+            "8594196450029"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "XXL BLACK",
+          "codes": [
+            "046"
+          ],
+          "eans": [
+            "8594196450463"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "XXL Just BLACK",
+          "codes": [
+            "540"
+          ],
+          "eans": [
+            "8594196455406"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "XXL Just WHITE",
+          "codes": [
+            "539"
+          ],
+          "eans": [
+            "8594196455390"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "XXL WHITE",
+          "codes": [
+            "045"
+          ],
+          "eans": [
+            "8594196450456"
+          ],
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "codes": [
+            "030",
+            "009"
+          ],
+          "eans": [
+            "8594196450302",
+            "8594196450098"
+          ],
+          "hex": "ffff00"
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA Natural Fibers {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 450
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "PLA EBEN Wood 450 g",
+          "codes": [
+            "507"
+          ],
+          "eans": [
+            "8594196455079"
+          ],
+          "hex": "c4a574"
+        },
+        {
+          "name": "PLA MAHAGON Wood 450 g",
+          "codes": [
+            "508"
+          ],
+          "eans": [
+            "8594196455086"
+          ],
+          "hex": "c4a574"
+        },
+        {
+          "name": "PLA White Wood 450 g",
+          "codes": [
+            "506"
+          ],
+          "eans": [
+            "8594196455062"
+          ],
+          "hex": "c4a574"
+        },
+        {
+          "name": "PLA Wood 450 g",
+          "codes": [
+            "503"
+          ],
+          "eans": [
+            "8594196455031"
+          ],
+          "hex": "c4a574"
+        }
+      ],
+      "fill": "wood"
+    },
+    {
+      "name": "REFILL PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 850,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        65
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "BLACK Volkano",
+          "codes": [
+            "432"
+          ],
+          "eans": [
+            "8594196454324"
+          ],
+          "hex": "000000"
+        },
+        {
+          "name": "Dark GREY",
+          "codes": [
+            "433"
+          ],
+          "eans": [
+            "8594196454331"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "WHITE",
+          "codes": [
+            "431"
+          ],
+          "eans": [
+            "8594196454317"
+          ],
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Czech Republic",
+      "colors": [
+        {
+          "name": "PRINT WS FLEX BLUE 96A",
+          "codes": [
+            "339"
+          ],
+          "eans": [
+            "8594196453396"
+          ],
+          "hex": "0066cc"
+        },
+        {
+          "name": "PRINT WS FLEX DARK GREY 96A",
+          "codes": [
+            "337"
+          ],
+          "eans": [
+            "8594196453372"
+          ],
+          "hex": "808080"
+        },
+        {
+          "name": "PRINT WS FLEX GREEN 96A",
+          "codes": [
+            "341"
+          ],
+          "eans": [
+            "8594196453419"
+          ],
+          "hex": "228b22"
+        },
+        {
+          "name": "PRINT WS FLEX RED 96A",
+          "codes": [
+            "340"
+          ],
+          "eans": [
+            "8594196453402"
+          ],
+          "hex": "cc0000"
+        },
+        {
+          "name": "PRINT WS FLEX WHITE 96A",
+          "codes": [
+            "336"
+          ],
+          "eans": [
+            "8594196453365"
+          ],
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/professionallab.json
+++ b/filaments/professionallab.json
@@ -1,0 +1,118 @@
+{
+  "manufacturer": "Professional LAB",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Water Blue",
+          "hex": "a0e6ff"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        }
+      ],
+      "country_of_origin": "Poland"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "Poland"
+    }
+  ]
+}

--- a/filaments/prografen.json
+++ b/filaments/prografen.json
@@ -1,0 +1,145 @@
+{
+  "manufacturer": "Prografen",
+  "filaments": [
+    {
+      "name": "PLA Graphene Light {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        265
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "finish": "glossy",
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "PG_5007"
+          ],
+          "eans": [
+            "5904433780155"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Graphene Strong {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        265
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "finish": "glossy",
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "PG_5003"
+          ],
+          "eans": [
+            "5904433780117"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Graphene Light {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        265
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "finish": "glossy",
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "PG_5008"
+          ],
+          "eans": [
+            "5904433780179"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG Graphene Strong {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        265
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "finish": "glossy",
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "PG_5004"
+          ],
+          "eans": [
+            "5904433781350"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/proteorprint.json
+++ b/filaments/proteorprint.json
@@ -1,0 +1,163 @@
+{
+  "manufacturer": "Proteor Print",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 4500
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Transparent",
+          "hex": "e8f4f8",
+          "translucent": true,
+          "codes": [
+            "PETG.F.2.85.4.5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CPX-KyronMAX {color_name}",
+      "material": "PP",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 3200
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "finish": "matte",
+      "fill": "carbon fiber",
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "CPX.KM.F.2.85.3.2k"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Icarus CPX-PP {color_name}",
+      "material": "PP",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 3500
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5e6c8",
+          "codes": [
+            "CPX.PP.F.2.85.3.5kg"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Alto CPX-PP {color_name}",
+      "material": "PP",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 3500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5e6c8",
+          "codes": [
+            "PL003#3.5"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "EVA+ {color_name}",
+      "material": "EVA",
+      "density": 0.95,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5e6c8",
+          "codes": [
+            "EVA+"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/prusa.json
+++ b/filaments/prusa.json
@@ -1,0 +1,357 @@
+{
+  "manufacturer": "Prusa",
+  "filaments": [
+    {
+      "name": "ABS+PLUS {color_name}",
+      "material": "ABS+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "e6e8fa"
+        },
+        {
+          "name": "Yellowgreen",
+          "hex": "9acd32"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "999aa0"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "737373",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "292b2b"
+        },
+        {
+          "name": "Ocean Blue",
+          "hex": "003b45"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Signal Weiß",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Slate Silver (Metallic Silver)",
+          "hex": "55575a"
+        },
+        {
+          "name": "Turquoise Blue",
+          "hex": "00ffef"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        10,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Azure blue",
+          "hex": "3d8ad1"
+        },
+        {
+          "name": "Galaxy Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Galaxy green",
+          "hex": "153720"
+        },
+        {
+          "name": "Galaxy purple",
+          "hex": "4b0977"
+        },
+        {
+          "name": "Glow green",
+          "hex": "a5f76e"
+        },
+        {
+          "name": "Jet black",
+          "hex": "000000"
+        },
+        {
+          "name": "Lila",
+          "hex": "de9ee0"
+        },
+        {
+          "name": "Lime green",
+          "hex": "77dd69"
+        },
+        {
+          "name": "Lipstick red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Pineapple Yellow",
+          "hex": "e2e600"
+        },
+        {
+          "name": "Prusa Orange",
+          "hex": "ff4d08"
+        },
+        {
+          "name": "Roval blue",
+          "hex": "002aff"
+        },
+        {
+          "name": "Silver",
+          "hex": "999aa0"
+        },
+        {
+          "name": "Simply green",
+          "hex": "49f35d"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Sweet mint",
+          "hex": "a1e3e1"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Lithophane",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PVB {color_name}",
+      "material": "PVB",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        225
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d6d6d6"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Violet",
+          "hex": "ee82ee"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/prusament.json
+++ b/filaments/prusament.json
@@ -9,7 +9,7 @@
                 {
                     "weight": 1000.0,
                     "spool_weight": 193.0,
-                    "spool_type": "plastic"
+                    "spool_type": "cardboard"
                 },
                 {
                     "weight": 2000.0,
@@ -101,6 +101,10 @@
                     "hex": "2B3B61"
                 },
                 {
+                    "name": "Carmine Red",
+                    "hex": "B54230"
+                },
+                {
                     "name": "Clear",
                     "hex": "dcdcdc"
                 }
@@ -145,7 +149,7 @@
                 {
                     "weight": 1000.0,
                     "spool_weight": 186.0,
-                    "spool_type": "plastic"
+                    "spool_type": "cardboard"
                 }
             ],
             "diameters": [
@@ -215,7 +219,7 @@
                 {
                     "weight": 1000.0,
                     "spool_weight": 193.0,
-                    "spool_type": "plastic"
+                    "spool_type": "cardboard"
                 }
             ],
             "diameters": [
@@ -267,7 +271,7 @@
                 {
                     "weight": 800.0,
                     "spool_weight": 193.0,
-                    "spool_type": "plastic"
+                    "spool_type": "cardboard"
                 }
             ],
             "diameters": [
@@ -393,7 +397,7 @@
                 {
                     "weight": 1000.0,
                     "spool_weight": 193.0,
-                    "spool_type": "plastic"
+                    "spool_type": "cardboard"
                 },
                 {
                     "weight": 2000.0,
@@ -490,6 +494,14 @@
                 {
                     "name": "Natural",
                     "hex": "DFDFD3"
+                },
+                {
+                    "name": "Ms. Pink",
+                    "hex": "E34A94"
+                },
+                {
+                    "name": "Galaxy Red",
+                    "hex": "D94A5A"
                 }
             ]
         }

--- a/filaments/purefil.json
+++ b/filaments/purefil.json
@@ -1,0 +1,174 @@
+{
+  "manufacturer": "PureFil",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.17,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "0e0e10"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blau transparent",
+          "hex": "2d8ae6"
+        },
+        {
+          "name": "Jet black",
+          "hex": "000000"
+        },
+        {
+          "name": "pure white",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Anthracite Grey",
+          "hex": "111212"
+        },
+        {
+          "name": "BEIGE",
+          "hex": "c2b078"
+        },
+        {
+          "name": "Blau",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Farbwechsel",
+          "hex": "7f7f7f"
+        },
+        {
+          "name": "Gold",
+          "hex": "808080"
+        },
+        {
+          "name": "gris anthracite",
+          "hex": "293133"
+        },
+        {
+          "name": "Gris beton concrete",
+          "hex": "686c5e"
+        },
+        {
+          "name": "Gris clair / Lichtgrau",
+          "hex": "d7d7d7"
+        },
+        {
+          "name": "Gris Fer Eisengrau",
+          "hex": "434b4d"
+        },
+        {
+          "name": "Gris perle Perlhegrau",
+          "hex": "9c9c9c"
+        },
+        {
+          "name": "leuchtorange",
+          "hex": "ff4d06"
+        },
+        {
+          "name": "Reinweiss",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "007caf"
+        },
+        {
+          "name": "Transparent",
+          "hex": "d1d1d1"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Wood",
+          "hex": "e4bd90"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/pushplastic.json
+++ b/filaments/pushplastic.json
@@ -1,0 +1,135 @@
+{
+  "manufacturer": "Push Plastic",
+  "filaments": [
+    {
+      "name": "Push Plastic PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 3000,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 10000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [210, 230],
+      "bed_temp_range": [30, 70],
+      "country_of_origin": "USA",
+      "tds_url": "https://cdn.shopify.com/s/files/1/0260/7421/files/Push_Plastic_PLA_Technical_Data_sheet.pdf",
+      "colors": [
+        {"name": "Black", "hex": "1a1a1a", "codes": ["PLA175-1KG-BLK"]},
+        {"name": "White", "hex": "f5f5f5", "codes": ["PLA175-1KG-WHT"]},
+        {"name": "Red", "hex": "c41e2a", "codes": ["PLA175-1KG-RED"]},
+        {"name": "Green", "hex": "2e7d32", "codes": ["PLA175-1KG-GRN"]},
+        {"name": "Yellow", "hex": "fdd835", "codes": ["PLA175-1KG-YLW"]},
+        {"name": "Orange", "hex": "f57c00", "codes": ["PLA175-1KG-ORG"]},
+        {"name": "Purple", "hex": "6a1b9a", "codes": ["PLA175-1KG-PRP"]},
+        {"name": "Pink", "hex": "e873a5", "codes": ["PLA175-1KG-PNK"]},
+        {"name": "Natural", "hex": "e8e0d0", "codes": ["PLA175-1KG-NAT"]},
+        {"name": "Beige", "hex": "d4c4a8", "codes": ["PLA175-1KG-BGE"]},
+        {"name": "Light Grey", "hex": "a0a0a0", "codes": ["PLA175-1KG-LGY"]},
+        {"name": "Dark Grey", "hex": "4a4a4a", "codes": ["PLA175-1KG-DGY"]},
+        {"name": "Navy Blue", "hex": "1a2a5e", "codes": ["PLA175-1KG-NVY"]},
+        {"name": "Ultra Blue", "hex": "005fe8", "codes": ["PLA175-1KG-UBL"]},
+        {"name": "Ocean Blue", "hex": "1b6b8a", "codes": ["PLA175-1KG-OBL"]}
+      ]
+    },
+    {
+      "name": "Push Plastic PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 3000,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 10000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [235, 250],
+      "bed_temp_range": [80, 100],
+      "country_of_origin": "USA",
+      "tds_url": "https://cdn.shopify.com/s/files/1/0260/7421/files/Push_Plastic_PETG_Technical_Data_sheet_6b420a6b-aea1-47d5-b931-464a8804abb4.pdf",
+      "colors": [
+        {"name": "Black", "hex": "1a1a1a"},
+        {"name": "White", "hex": "f5f5f5"},
+        {"name": "Red", "hex": "c41e2a"},
+        {"name": "Green", "hex": "2e7d32"},
+        {"name": "Orange", "hex": "f57c00"},
+        {"name": "Purple", "hex": "6a1b9a"},
+        {"name": "Light Grey", "hex": "a0a0a0"},
+        {"name": "Dark Grey", "hex": "4a4a4a"},
+        {"name": "Navy Blue", "hex": "1a2a5e"},
+        {"name": "Ultra Blue", "hex": "005fe8"},
+        {"name": "Electric Blue", "hex": "00a8e8"},
+        {"name": "Light Teal", "hex": "3d9e8a"},
+        {"name": "Rust", "hex": "b5523a"},
+        {"name": "Silver Metallic", "hex": "b0b0b0"},
+        {"name": "Translucent Blue", "hex": "4da6d9", "translucent": true},
+        {"name": "Translucent Green", "hex": "5cb85c", "translucent": true},
+        {"name": "Translucent Amber", "hex": "e6a23c", "translucent": true}
+      ]
+    },
+    {
+      "name": "Push Plastic ABS {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 3000,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 10000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 250],
+      "bed_temp_range": [100, 120],
+      "country_of_origin": "USA",
+      "tds_url": "https://cdn.shopify.com/s/files/1/0260/7421/files/Push_Plastic_ABS_Technical_Data_sheet_8f0e2174-914e-4312-8018-fb4d1a5d2e9b.pdf",
+      "colors": [
+        {"name": "Black", "hex": "1a1a1a"},
+        {"name": "White", "hex": "f5f5f5"},
+        {"name": "Green", "hex": "2e7d32"},
+        {"name": "Yellow", "hex": "fdd835"},
+        {"name": "Orange", "hex": "f57c00"},
+        {"name": "Pink", "hex": "e873a5"},
+        {"name": "Purple", "hex": "6a1b9a"},
+        {"name": "Natural", "hex": "e8e0d0"},
+        {"name": "Beige", "hex": "d4c4a8"},
+        {"name": "Brown", "hex": "6b3e2e"},
+        {"name": "Light Grey", "hex": "a0a0a0"},
+        {"name": "Dark Grey", "hex": "4a4a4a"},
+        {"name": "Magenta", "hex": "c2185b"},
+        {"name": "Ultra Blue", "hex": "005fe8"},
+        {"name": "Ocean Blue", "hex": "1b6b8a"},
+        {"name": "Desert Tan", "hex": "c4a882"},
+        {"name": "Flat Dark Earth", "hex": "8b7355"},
+        {"name": "Silver Metallic", "hex": "b0b0b0"},
+        {"name": "Gold Metallic", "hex": "c9a227"},
+        {"name": "Bronze Metallic", "hex": "8c6239"}
+      ]
+    }
+  ]
+}

--- a/filaments/r3d.json
+++ b/filaments/r3d.json
@@ -1,87 +1,676 @@
 {
     "manufacturer": "R3D",
-    "filaments": 
+    "filaments":
     [
         {
-            "name": "{color_name}", "material": "PETG", "density": 1.27, 
-            "weights": 
+            "name": "ABS {color_name}", "material": "ABS", "density": 1.04,
+            "weights":
             [
                 {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
-                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"},
-                {"weight": 3000.0, "spool_weight": 320.0, "spool_type": "plastic"}
-            ], 
-            "diameters": [1.75], 
-            "extruder_temp": 245, 
-            "bed_temp": 75, 
-            "colors": 
-            [
-                {"name": "Black", "hex": "000000"},
-                {"name": "White", "hex": "FFFFFF"},
-                {"name": "Grey", "hex": "808080"},
-                {"name": "Transparent", "hex": "000000", "translucent": true},
-                {"name": "Tangerine", "hex": "F28500"},
-                {"name": "Purple", "hex": "800080"},
-                {"name": "Grape Purple", "hex": "6A0DAD"},
-                {"name": "Dark Blue", "hex": "00008B"},
-                {"name": "Royal Blue", "hex": "4169E1"},
-                {"name": "Sapphire", "hex": "0F52BA"},
-                {"name": "Light Blue", "hex": "ADD8E6"},
-                {"name": "Pine Green", "hex": "01796F"},
-                {"name": "Turquoise", "hex": "40E0D0"},
-                {"name": "Bambu Green", "hex": "7CFC00"},
-                {"name": "F Green", "hex": "008000"},
-                {"name": "Yellow", "hex": "FFFF00"},
-                {"name": "Lemon", "hex": "FFF44F"},
-                {"name": "Red", "hex": "FF0000"},
-                {"name": "Pink", "hex": "FFC0CB"},
-                {"name": "Skin", "hex": "FAD6A5"},
-                {"name": "Coffee Brown", "hex": "6F4E37"},
-                {"name": "Silver", "hex": "C0C0C0"},
-                {"name": "Gliding", "hex": "D4AF37"}
-            ]
-        },
-        {
-            "name": "Translucent {color_name}", "material": "PETG", "density": 1.27, 
-            "weights": 
-            [
-                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
-                {"weight": 1000.0, "spool_weight": 100.0, "spool_type": "cardboard"}
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
             ],
-            "diameters": [1.75], "extruder_temp": 260, "bed_temp": 80, 
-            "colors": 
+            "diameters": [1.75],
+            "extruder_temp": 250,
+            "bed_temp": 100,
+            "colors":
             [
-                {"name": "Black", "hex": "000000", "translucent": true},
-                {"name": "Blue", "hex": "0000FF", "translucent": true},
-                {"name": "Purple", "hex": "800080", "translucent": true},
-                {"name": "Red", "hex": "FF0000", "translucent": true},
-                {"name": "Orange", "hex": "FFA500", "translucent": true},
-                {"name": "Yellow", "hex": "FFFF00", "translucent": true},
-                {"name": "Pink", "hex": "FFC0CB", "translucent": true},
-                {"name": "Light Blue", "hex": "ADD8E6", "translucent": true}
+                {"name": "Grey", "hex": "BFBFC0"}
             ]
         },
         {
-            "name": "PLA BASIC {color_name}", "material": "PLA", "density": 1.27, 
-            "weights": 
+            "name": "High Speed ABS {color_name}", "material": "ABS", "density": 1.04,
+            "weights":
             [
                 {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
-                {"weight": 1000.0, "spool_weight": 100.0, "spool_type": "cardboard"}
-            ], 
-            "diameters": [1.75], 
-            "extruder_temp": 210, 
-            "bed_temp": 50, 
-            "colors": 
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 250,
+            "bed_temp": 100,
+            "colors":
             [
-                {"name": "White", "hex": "FFFFFF"},
+                {"name": "Black", "hex": "000000"}
+            ]
+        },
+        {
+            "name": "ABS-CF {color_name}", "material": "ABS-CF", "density": 1.04,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 250,
+            "bed_temp": 100,
+            "colors":
+            [
+                {"name": "Black", "hex": "000000"}
+            ]
+        },
+        {
+            "name": "ASA {color_name}", "material": "ASA", "density": 1.05,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 250,
+            "bed_temp": 90,
+            "colors":
+            [
+                {"name": "Ash Gray", "hex": "303030"}
+            ]
+        },
+        {
+            "name": "Nylon {color_name}", "material": "PA", "density": 1.52,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 260,
+            "bed_temp": 80,
+            "colors":
+            [
+                {"name": "Black", "hex": "000000"}
+            ]
+        },
+        {
+            "name": "PEBA {color_name}", "material": "PEBA", "density": 1.04,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors":
+            [
+                {"name": "Lemon green", "hex": "96D35F"},
+                {"name": "Matcha brown", "hex": "7A4A00"}
+            ]
+        },
+        {
+            "name": "Fluorescent PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors":
+            [
+                {"name": "Fluorescent Green", "hex": "00B473"}
+            ]
+        },
+        {
+            "name": "High Speed PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors":
+            [
                 {"name": "Black", "hex": "000000"},
-                {"name": "Red", "hex": "FF0000"},
-                {"name": "Orange", "hex": "FFA500"},
-                {"name": "Yellow", "hex": "FFFF00"},
-                {"name": "S. Green", "hex": "00FF00"},
-                {"name": "Cobalt Blue", "hex": "0047AB"},
+                {"name": "RED", "hex": "FF0000"},
+                {"name": "White", "hex": "FFFFFF"}
+            ]
+        },
+        {
+            "name": "Marble PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "pattern": "marble",
+            "colors":
+            [
+                {"name": "Granite", "hex": "F2F2F2"},
+                {"name": "Light Blue", "hex": "A8FFFF"},
+                {"name": "Light Green", "hex": "A8FFC8"},
+                {"name": "Light Purple", "hex": "E0BFFF"},
+                {"name": "Milk Coffee", "hex": "F9F2FF"}
+            ]
+        },
+        {
+            "name": "Matte PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "finish": "matte",
+            "colors":
+            [
+                {"name": "Apricot Pollen", "hex": "F8D7E4"},
+                {"name": "Black", "hex": "000000"},
+                {"name": "Bronze Gold", "hex": "9B693C"},
+                {"name": "Brown", "hex": "7A493E"},
+                {"name": "Chinese Red", "hex": "E53C34"},
+                {"name": "Dark Navy Blue", "hex": "00204D"},
+                {"name": "Fresh Green", "hex": "91B87E"},
+                {"name": "Glacier Blue", "hex": "AFE3EB"},
+                {"name": "Gun Gray", "hex": "383F41"},
+                {"name": "Haze Blue", "hex": "7F939F"},
+                {"name": "Khaki", "hex": "AC946A"},
+                {"name": "Light Gray", "hex": "969392"},
+                {"name": "Light Purple", "hex": "D3B7D7"},
+                {"name": "Light Sky Blue", "hex": "D1DDEE"},
+                {"name": "Military Green", "hex": "44543A"},
+                {"name": "Milky Apricot Yellow", "hex": "DCBB93"},
+                {"name": "Oatmeal White", "hex": "B2A19C"},
+                {"name": "Olive Green", "hex": "355627"},
+                {"name": "Red Wine", "hex": "5B2E2F"},
+                {"name": "Sky Blue", "hex": "5DAAD8"},
+                {"name": "Snow Waxy Skin", "hex": "D8BDAA"},
+                {"name": "Soft Skin", "hex": "E5D2BF"},
+                {"name": "Warm Gray", "hex": "B7ADA5"},
+                {"name": "White", "hex": "FFFFFF"},
+                {"name": "White Green", "hex": "CDECE8"},
+                {"name": "Yellow", "hex": "F8EF45"},
+                {"name": "Yellow Orange", "hex": "DF7E4B"},
+                {"name": "Zinc Yellow", "hex": "E1C739"}
+            ]
+        },
+        {
+            "name": "PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "colors":
+            [
+                {"name": "Bambu Green", "hex": "7BB661"},
+                {"name": "Black", "hex": "000000"},
+                {"name": "China Red", "hex": "BE3130"},
+                {"name": "Chinese Red", "hex": "BE3130"},
+                {"name": "Coffee Brown", "hex": "4E2C2B"},
+                {"name": "Dark Green", "hex": "38571A"},
+                {"name": "DarkBlue", "hex": "00008B"},
+                {"name": "Emerald", "hex": "156B53"},
+                {"name": "Fish Belly White", "hex": "FBFDFB"},
+                {"name": "Gilded Gold", "hex": "A78F61"},
+                {"name": "Gray", "hex": "E7EAF2"},
+                {"name": "Grey", "hex": "808080"},
+                {"name": "Iris", "hex": "4D00FF"},
+                {"name": "Just Purple", "hex": "966CD3"},
+                {"name": "Latte", "hex": "CDA14B"},
+                {"name": "Light Blue", "hex": "ADD8E6"},
+                {"name": "Light Purple", "hex": "D8BFD8"},
+                {"name": "Mibao White", "hex": "EFEBDB"},
+                {"name": "Mint Green", "hex": "6ED5C4"},
+                {"name": "Ocher", "hex": "9E6443"},
+                {"name": "Orange", "hex": "FF7427"},
+                {"name": "Pastel Violet", "hex": "EE82EE"},
+                {"name": "Peach", "hex": "FEA9DB"},
+                {"name": "Pink", "hex": "CA71BB"},
                 {"name": "Purple", "hex": "800080"},
-                {"name": "Rose Pink", "hex": "FFC0CB"},
-                {"name": "Brown", "hex": "A52A2A"}
+                {"name": "Red", "hex": "FF2600"},
+                {"name": "Royal Blue", "hex": "222C90"},
+                {"name": "Silver", "hex": "666666"},
+                {"name": "Skin", "hex": "FFDBAC"},
+                {"name": "Snow White Skin", "hex": "FFF1E6"},
+                {"name": "Tangerine", "hex": "F28500"},
+                {"name": "White", "hex": "FFFFFF"},
+                {"name": "Wood", "hex": "DABEAB"},
+                {"name": "Yellow", "hex": "FFFF00"}
+            ]
+        },
+        {
+            "name": "Sparkle PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "pattern": "sparkle",
+            "colors":
+            [
+                {"name": "Sparkle Pink", "hex": "E6649B", "pattern": "sparkle"}
+            ]
+        },
+        {
+            "name": "Translucent PETG {color_name}", "material": "PETG", "density": 1.27,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 240,
+            "bed_temp": 80,
+            "translucent": true,
+            "colors":
+            [
+                {"name": "Blue Cost-Effective", "hex": "5EB4F6", "translucent": true},
+                {"name": "Clear", "hex": "FFFFFF", "translucent": true},
+                {"name": "Clear (Cost-Effective)", "hex": "000000", "translucent": true},
+                {"name": "Clear Grey", "hex": "919191", "translucent": true}
+            ]
+        },
+        {
+            "name": "Color Change PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Purple to Red", "hex": "942192"}
+            ]
+        },
+        {
+            "name": "Fluorescent PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Green", "hex": "0DC923"},
+                {"name": "Yellow", "hex": "FFBA4F"}
+            ]
+        },
+        {
+            "name": "Glow PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "glow": true,
+            "colors":
+            [
+                {"name": "Neon Green", "hex": "39FF14", "glow": true},
+                {"name": "Turquoise", "hexes": ["A2FBF1", "E5FCFF"], "multi_color_direction": "coaxial", "glow": true}
+            ]
+        },
+        {
+            "name": "High Speed Marble PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 215,
+            "bed_temp": 60,
+            "pattern": "marble",
+            "colors":
+            [
+                {"name": "Marble White", "hex": "BFBFC0", "pattern": "marble"}
+            ]
+        },
+        {
+            "name": "High Speed Matte PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 215,
+            "bed_temp": 60,
+            "finish": "matte",
+            "colors":
+            [
+                {"name": "Dark blue", "hex": "2826A1"},
+                {"name": "MAtte Navy Blue", "hex": "384571"}
+            ]
+        },
+        {
+            "name": "Magic PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Black-Red", "hexes": ["000000", "FF0000"], "multi_color_direction": "coaxial"},
+                {"name": "Silver Lavender", "hexes": ["9EB5F6", "3556BE"], "multi_color_direction": "coaxial"}
+            ]
+        },
+        {
+            "name": "Marble PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "pattern": "marble",
+            "colors":
+            [
+                {"name": "Blue-grey", "hex": "3FABA9"}
+            ]
+        },
+        {
+            "name": "Matte PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "finish": "matte",
+            "colors":
+            [
+                {"name": "Army Green", "hex": "4C5637"},
+                {"name": "Ash Grey", "hex": "3D3D3D"},
+                {"name": "Avocado Green", "hex": "01E91C"},
+                {"name": "Black", "hex": "000000"},
+                {"name": "Black (Refill)", "hex": "000000"},
+                {"name": "Cream Yellow", "hex": "FCF7B9"},
+                {"name": "Dark Grey", "hex": "4F4F4F"},
+                {"name": "Glacier Blue", "hex": "94E3FE"},
+                {"name": "Grey", "hex": "BEC2C6"},
+                {"name": "Ice Blue", "hex": "39E7EA"},
+                {"name": "Lemon Yellow", "hex": "FFFC79"},
+                {"name": "Light Pink", "hex": "FEA9DB"},
+                {"name": "Lotus Pink", "hex": "FA92E0"},
+                {"name": "Matte White", "hex": "FFFFFF"},
+                {"name": "Oats", "hex": "CDAB8F"},
+                {"name": "Olive Green (A1EA21H)", "hex": "646A5C"},
+                {"name": "Orange", "hex": "FF6A00"},
+                {"name": "Pine Green", "hex": "009966"},
+                {"name": "Red", "hex": "FF0000"},
+                {"name": "Sage Blue", "hex": "DBE8DE"},
+                {"name": "Scallion Green", "hex": "16C158"},
+                {"name": "Sea Green", "hex": "4D536D"},
+                {"name": "Terra Cotta", "hex": "B87561"},
+                {"name": "White", "hex": "FFFFFF"},
+                {"name": "White (Refill)", "hex": "FFFFFF"}
+            ]
+        },
+        {
+            "name": "PLA Basic {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Black", "hex": "000000"},
+                {"name": "Brown", "hex": "865E3C"},
+                {"name": "Dark Skin", "hex": "E0A184"},
+                {"name": "Dark Yellow", "hex": "F6D32D"},
+                {"name": "Grey", "hex": "919191"},
+                {"name": "Lime Green", "hex": "DCFF5E"},
+                {"name": "Marble", "hex": "E7E9EA", "pattern": "marble"},
+                {"name": "Mint Green", "hex": "73F2D2"},
+                {"name": "Nightglow Blue", "hex": "FFFFFF", "glow": true},
+                {"name": "Oats", "hex": "CDAB8F"},
+                {"name": "Orange", "hex": "FF2600"},
+                {"name": "Persimmon Yellow", "hex": "F5C211"},
+                {"name": "Purple", "hex": "A020F0"},
+                {"name": "Red", "hex": "F31212"},
+                {"name": "Transparent", "hex": "FFFFFF", "translucent": true},
+                {"name": "White", "hex": "FFFFFF"}
+            ]
+        },
+        {
+            "name": "Rainbow PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Rainbow one", "hexes": ["FF0000", "FFFF00", "0000FF"], "multi_color_direction": "longitudinal"}
+            ]
+        },
+        {
+            "name": "Silk Dual-Color PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Autumn", "hexes": ["D35400", "F39C12"], "multi_color_direction": "coaxial"},
+                {"name": "Black-Blue", "hexes": ["000000", "0B6ED0"], "multi_color_direction": "coaxial"},
+                {"name": "Black-red", "hexes": ["000000", "C90303"], "multi_color_direction": "coaxial"},
+                {"name": "Blue Orange", "hexes": ["1293E2", "D7711D"], "multi_color_direction": "coaxial"},
+                {"name": "Blue-green", "hexes": ["0061FF", "77BB41"], "multi_color_direction": "coaxial"},
+                {"name": "Green-Orange", "hexes": ["00FF00", "FFA500"], "multi_color_direction": "coaxial"},
+                {"name": "Orange-Bronze", "hexes": ["FF9500", "A49F1E"], "multi_color_direction": "coaxial"},
+                {"name": "Rose Red-Gold", "hexes": ["FF0095", "F0F425"], "multi_color_direction": "coaxial"},
+                {"name": "Silk Black-Green", "hex": "2B5029"},
+                {"name": "Silk Black-Purple", "hex": "3E3E4B"}
+            ]
+        },
+        {
+            "name": "Silk PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Cherry Blossoms", "hex": "FFB7C5"},
+                {"name": "Copper", "hex": "F07D43"},
+                {"name": "Gold", "hex": "DA9100"},
+                {"name": "Green", "hex": "00B200"},
+                {"name": "Lemon Yellow", "hex": "FFF44F"},
+                {"name": "Orange", "hex": "FB7228"},
+                {"name": "Pink", "hex": "F8A49B"},
+                {"name": "Rainbow Two", "hex": "6903A0"},
+                {"name": "Silk Blue", "hex": "00C7FC"},
+                {"name": "Silk Bronze", "hex": "7BC71F"},
+                {"name": "Silk Red", "hex": "F20006"},
+                {"name": "Silk Silver", "hex": "D6D6D6"},
+                {"name": "White", "hex": "FFFFFF"}
+            ]
+        },
+        {
+            "name": "Silk Tri-Color PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Blue-Purple-Black", "hexes": ["000000", "0074C7", "591EC8"], "multi_color_direction": "coaxial"},
+                {"name": "Green Purple Copper", "hexes": ["82D3BB", "BE9FE5", "F0927A"], "multi_color_direction": "coaxial"},
+                {"name": "Red-gold-black", "hexes": ["B51A00", "D29D00", "000000"], "multi_color_direction": "coaxial"},
+                {"name": "Rose Red-Purple-Silver", "hexes": ["591EC8", "818C9F", "C239F3"], "multi_color_direction": "coaxial"}
+            ]
+        },
+        {
+            "name": "Sparkle PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "pattern": "sparkle",
+            "colors":
+            [
+                {"name": "Twinkling Red", "hex": "FF0000", "pattern": "sparkle"}
+            ]
+        },
+        {
+            "name": "Translucent PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "translucent": true,
+            "colors":
+            [
+                {"name": "Blue", "hex": "251DCD", "translucent": true},
+                {"name": "Red", "hex": "FF0000", "translucent": true}
+            ]
+        },
+        {
+            "name": "UV Color Change PLA {color_name}", "material": "PLA", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Blue to Pink", "hex": "FF80C0"}
+            ]
+        },
+        {
+            "name": "PLA Pro High Speed Matte {color_name}", "material": "PLA+", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "finish": "matte",
+            "colors":
+            [
+                {"name": "Avacado Green", "hex": "6EE79D"},
+                {"name": "Beige", "hex": "FCE5C1"},
+                {"name": "Terracotta", "hex": "BD6735"}
+            ]
+        },
+        {
+            "name": "PLA Pro High Speed {color_name}", "material": "PLA+", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "colors":
+            [
+                {"name": "Black", "hex": "000000"},
+                {"name": "Coffee", "hex": "280300"},
+                {"name": "Emerald", "hex": "006624"},
+                {"name": "Navy", "hex": "384571"},
+                {"name": "Red", "hex": "E02531"},
+                {"name": "Skin", "hex": "FFDBAC"},
+                {"name": "White", "hex": "FFFFFF"}
+            ]
+        },
+        {
+            "name": "PLA Pro Matte {color_name}", "material": "PLA+", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "finish": "matte",
+            "colors":
+            [
+                {"name": "Ash Grey", "hex": "474747"}
+            ]
+        },
+        {
+            "name": "PLA Pro {color_name}", "material": "PLA+", "density": 1.24,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 220,
+            "bed_temp": 60,
+            "colors":
+            [
+                {"name": "Latte", "hex": "BDAB98"},
+                {"name": "Red", "hex": "EB4D3D"}
+            ]
+        },
+        {
+            "name": "TPU {color_name}", "material": "TPU", "density": 1.21,
+            "weights":
+            [
+                {"weight": 1000.0, "spool_weight": 127.0, "spool_type": "plastic"},
+                {"weight": 1000.0, "spool_weight": 140.0, "spool_type": "cardboard"}
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors":
+            [
+                {"name": "Black", "hex": "000000"},
+                {"name": "White", "hex": "FFFFFF"}
             ]
         }
     ]

--- a/filaments/raise3d.json
+++ b/filaments/raise3d.json
@@ -1,0 +1,852 @@
+{
+  "manufacturer": "Raise3D",
+  "filaments": [
+    {
+      "name": "Premium PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Art White",
+          "hex": "f8f6f0"
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2024/12/Raise3D-Premium_PLA_TDS_V6.0_EN.pdf"
+    },
+    {
+      "name": "Premium ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2025/08/Raise3D_Premium_ABS_TDS_V7.2.pdf"
+    },
+    {
+      "name": "Premium ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2024/07/Raise3D-Premium-ASA_TDS_v6.0.pdf"
+    },
+    {
+      "name": "Premium PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Premium PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2024/07/Raise3d_Premium_PC_Black_White__TDS_V6.pdf"
+    },
+    {
+      "name": "Premium TPU-95A {color_name}",
+      "material": "TPU-95A",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2024/10/Raise3D-Premium-TPU95A_TDS_V2.2.pdf"
+    },
+    {
+      "name": "Premium PVA+ {color_name}",
+      "material": "PVA+",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2021/06/Raise3D-Premium-PVA_TDS_V2.1-2021_06.pdf"
+    },
+    {
+      "name": "Hyper Speed PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffd700"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2024/12/Raise3D_Hyper-Speed-PLA-Filament_TDS-V4.0_EN.pdf"
+    },
+    {
+      "name": "Hyper Speed ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2023/10/Raise3D_Hyper-Speed-ABS-V2-Filament_TDS_V1.0.pdf"
+    },
+    {
+      "name": "Hyper Speed PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Brick Red",
+          "hex": "8b3a3a"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "808080"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2025/07/Raise3D-Hyper-Speed-PLA-Pro-_TDS_V1.0_1.pdf"
+    },
+    {
+      "name": "Hyper Core ABS CF15 {color_name}",
+      "material": "ABS-CF15",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2024/01/Raise3D-Hyper-Core-ABS-CF15_TDS_V1.0.pdf"
+    },
+    {
+      "name": "Hyper Core PPA CF25 {color_name}",
+      "material": "PPA-CF25",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        320
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2024/09/Raise3D-Hyper-Core-PPA-CF25_TDS_V2.0.pdf"
+    },
+    {
+      "name": "Hyper Core PPA GF25 {color_name}",
+      "material": "PPA-GF25",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        320
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://s1.raise3d.com/2024/05/Raise3D-Hyper-Core-PPA-GF25_TDS_V1.1.pdf"
+    },
+    {
+      "name": "Hyper Speed PET CF {color_name}",
+      "material": "PET-CF",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2025/05/Raise3D-Hyper-Speed-PET-CF_TDS_V1.0.pdf"
+    },
+    {
+      "name": "Hyper Speed PETG CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2025/05/Raise3D-Hyper-Speed-PETG-CF_TDS_V1.0.pdf"
+    },
+    {
+      "name": "Industrial PA12 CF Support {color_name}",
+      "material": "PA12-CF",
+      "density": 1.1,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "808080"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2021/11/Raise3D-Industrial-PA12-CF-Support_TDS_V1.pdf"
+    },
+    {
+      "name": "Industrial PA12 CF+ {color_name}",
+      "material": "PA12-CF",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2024/09/Raise3D-Industrial-PA12-CF_TDS_V3.0.pdf"
+    },
+    {
+      "name": "Industrial PPA CF {color_name}",
+      "material": "PPA-CF",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        320
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2022/04/Raise3D-Industrial-PPA-CF_TDS-V21.pdf"
+    },
+    {
+      "name": "Industrial PPA GF {color_name}",
+      "material": "PPA-GF",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        320
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff6600"
+        }
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://s1.raise3d.com/2023/02/Raise3D-Industrial-PPA-GF-TDS_v2.1.pdf"
+    },
+    {
+      "name": "Industrial PPA Support {color_name}",
+      "material": "PPA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        280,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Purple",
+          "hex": "808080"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2021/12/Raise3D-Industrial-PPA-Support_TDS.pdf"
+    },
+    {
+      "name": "Industrial PET CF {color_name}",
+      "material": "PET-CF",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2024/09/Raise3D-Industrial-PET-CF_TDS_V4.0.pdf"
+    },
+    {
+      "name": "Industrial PET GF {color_name}",
+      "material": "PET-GF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "PET GF Black",
+          "hex": "808080"
+        },
+        {
+          "name": "PET GF Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "PET GF Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "PET GF Red",
+          "hex": "808080"
+        }
+      ],
+      "fill": "glass fiber",
+      "tds_url": "https://s1.raise3d.com/2023/03/Raise3D-Industrial-PET-GF_TDS_V1.pdf"
+    },
+    {
+      "name": "Industrial PET Support {color_name}",
+      "material": "PET",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2023/03/Raise3D-Industrial-PET-Support_TDS_V1.pdf"
+    },
+    {
+      "name": "Industrial PETG ESD {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "tds_url": "https://s1.raise3d.com/2024/12/Raise3D_Industrial-PETG-ESD_TDS_V3.pdf"
+    },
+    {
+      "name": "Industrial PPS CF {color_name}",
+      "material": "PPS-CF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        310,
+        330
+      ],
+      "bed_temp_range": [
+        100,
+        120
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber",
+      "tds_url": "https://s1.raise3d.com/2025/08/Raise3D-Industrial-PPS-CF_TDS_V1.1.pdf"
+    }
+  ]
+}

--- a/filaments/rambery.json
+++ b/filaments/rambery.json
@@ -1,0 +1,355 @@
+{
+  "manufacturer": "Rambery",
+  "filaments": [
+    {
+      "name": "Blend {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Tricolor - Gold/Blue/Red Copper",
+          "hexes": [
+            "808080",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Luminous Blue",
+          "hex": "caf0fe"
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "f2f7b7"
+        }
+      ]
+    },
+    {
+      "name": "Luminous Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue/Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Yellow/Green",
+          "hexes": [
+            "ffff00",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Naval Gray",
+          "hex": "3a4464"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow Lollipop",
+          "hex": "c4b8f2"
+        },
+        {
+          "name": "Red Coral (2202)",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow Candy",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "fae851"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue / Green",
+          "hexes": [
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold / Green",
+          "hexes": [
+            "ffd700",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold / Red",
+          "hexes": [
+            "ffd700",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / Blue",
+          "hexes": [
+            "ff0000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Shiny Candy",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Natural Wood",
+          "hex": "e6bf9a"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/ratrigpunkfil.json
+++ b/filaments/ratrigpunkfil.json
@@ -1,0 +1,206 @@
+{
+  "manufacturer": "RatRig Punkfil",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        245,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        105
+      ],
+      "colors": [
+        {
+          "name": "Balls Blue",
+          "hex": "228489"
+        },
+        {
+          "name": "Brute Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Gooey Green",
+          "hex": "dfffbf"
+        },
+        {
+          "name": "Rancid Red",
+          "hex": "972527"
+        },
+        {
+          "name": "Screaming Steel",
+          "hex": "69696b"
+        },
+        {
+          "name": "Punkfil Brute Black",
+          "hex": "131718"
+        },
+        {
+          "name": "Punkfil Gooey Green",
+          "hex": "bcec00"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        260
+      ],
+      "bed_temp_range": [
+        105,
+        105
+      ],
+      "colors": [
+        {
+          "name": "Punkfil Brute Black",
+          "hex": "131718"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Brute Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ASA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Compulsive Carbon",
+          "hex": "7c858e"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Balls Blue",
+          "hex": "228489"
+        },
+        {
+          "name": "Brute Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Gooey Green",
+          "hex": "dfffbf"
+        },
+        {
+          "name": "Screaming Steel",
+          "hex": "69696b"
+        }
+      ]
+    },
+    {
+      "name": "PETG+CF10 {color_name}",
+      "material": "PETG+CF10",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Punkfil Brute Black",
+          "hex": "131718"
+        }
+      ],
+      "fill": "carbon fiber"
+    }
+  ]
+}

--- a/filaments/real.json
+++ b/filaments/real.json
@@ -1,0 +1,377 @@
+{
+  "manufacturer": "Real",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Purple",
+          "hex": "78218a"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        245
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "black low warp",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "ff00ff"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow in the dark",
+          "hex": "c2ebb4"
+        }
+      ]
+    },
+    {
+      "name": "High Gloss {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        33,
+        33
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG+PLUS {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "brass",
+          "hex": "2a834c"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        225
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Antique silver",
+          "hex": "808080"
+        },
+        {
+          "name": "Dark Red",
+          "hex": "7d1a1c"
+        },
+        {
+          "name": "Neutral",
+          "hex": "f7f7f8"
+        },
+        {
+          "name": "Shadow Grey",
+          "hex": "6a6a6a"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Brown",
+          "hex": "6c4731"
+        },
+        {
+          "name": "Dark blue",
+          "hex": "0019d6"
+        },
+        {
+          "name": "Dark grey",
+          "hex": "404040"
+        },
+        {
+          "name": "Gold Old",
+          "hex": "837d56"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "69c2f8"
+        },
+        {
+          "name": "neutral",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Nuclear Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "808080"
+        },
+        {
+          "name": "Satin Splash",
+          "hex": "0080ff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Onyx black",
+          "hex": "808080",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Purple Topaz",
+          "hex": "fc1dc5",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Clear",
+          "hex": "f0f2f5"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/recreus.json
+++ b/filaments/recreus.json
@@ -1,0 +1,169 @@
+{
+  "manufacturer": "Recreus",
+  "filaments": [
+    {
+      "name": "FilaFlex 82A {color_name}",
+      "material": "TPU",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        215,
+        250
+      ],
+      "bed_temp_range": [
+        0,
+        40
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "d4243a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1f3d73"
+        },
+        {
+          "name": "Green",
+          "hex": "4caf50"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffeb3b"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff9800"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "translucent": true
+        },
+        {
+          "name": "Skin",
+          "hex": "d2a27a"
+        },
+        {
+          "name": "Grey",
+          "hex": "9e9e9e"
+        }
+      ]
+    },
+    {
+      "name": "FilaFlex 70A {color_name}",
+      "material": "TPU",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        235
+      ],
+      "bed_temp_range": [
+        0,
+        40
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "translucent": true
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        }
+      ]
+    },
+    {
+      "name": "FilaFlex 95A {color_name}",
+      "material": "TPU",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 500,
+          "spool_type": "cardboard"
+        },
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        215,
+        250
+      ],
+      "bed_temp_range": [
+        0,
+        40
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "d4243a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1f3d73"
+        },
+        {
+          "name": "Green",
+          "hex": "4caf50"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffeb3b"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0",
+          "translucent": true
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/recyclingfabrik.json
+++ b/filaments/recyclingfabrik.json
@@ -1,0 +1,49 @@
+{
+  "manufacturer": "Recycling Fabrik",
+  "filaments": [
+    {
+      "name": "Recycling Fabrik rPLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 180,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [195, 220],
+      "bed_temp_range": [50, 60],
+      "colors": [
+        {"name": "Schwarz (Black)", "hex": "101010"},
+        {"name": "Weiß (White)", "hex": "F2F2F2"},
+        {"name": "Graublau (Gray-Blue)", "hex": "4A6572"},
+        {"name": "Flaschengrün (Bottle Green)", "hex": "1B4D3E"},
+        {"name": "Ziegelrot (Brick Red)", "hex": "B22222"}
+      ]
+    },
+    {
+      "name": "Recycling Fabrik rPETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 180,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [220, 235],
+      "bed_temp_range": [70, 80],
+      "colors": [
+        {"name": "Schwarz (Black)", "hex": "101010"},
+        {"name": "Weiß (White)", "hex": "F2F2F2"},
+        {"name": "Grau (Gray)", "hex": "808080"},
+        {"name": "Rot (Red)", "hex": "C01010"},
+        {"name": "Blau (Blue)", "hex": "1010C0"}
+      ]
+    }
+  ]
+}

--- a/filaments/redlinefilament.json
+++ b/filaments/redlinefilament.json
@@ -1,0 +1,120 @@
+{
+    "manufacturer": "REDLINE FILAMENT",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 155,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                195,
+                215
+            ],
+            "bed_temp_range": [
+                0,
+                60
+            ],
+            "colors": [
+                {"name": "Beige", "hex": "c2b078"},
+                {"name": "Maisgelb", "hex": "e3a500"},
+                {"name": "Elfenbein", "hex": "e6d2b5"},
+                {"name": "Schwefelgelb", "hex": "f5d033"},
+                {"name": "Gelb", "hex": "fad201"},
+                {"name": "Goldbraun", "hex": "a38c15"},
+                {"name": "Bronzegold", "hex": "9f8932"},
+                {"name": "Gelborange", "hex": "f0a500"},
+                {"name": "Hellorange", "hex": "ed760e"},
+                {"name": "Orange", "hex": "f3752b"},
+                {"name": "Weinrot (Braunrot)", "hex": "412227"},
+                {"name": "Rot", "hex": "cc2529"},
+                {"name": "Orientrot", "hex": "763420"},
+                {"name": "Lila", "hex": "8d7598"},
+                {"name": "Magenta", "hex": "c63678"},
+                {"name": "Lavendel", "hex": "a5154a"},
+                {"name": "Dunkelblau", "hex": "20214f"},
+                {"name": "Kobaltblau", "hex": "1d1f5b"},
+                {"name": "Himmelblau", "hex": "2271b3"},
+                {"name": "Islandblau", "hex": "6daedd", "translucent": true},
+                {"name": "Taubenblau", "hex": "6d8099"},
+                {"name": "Wasserblau", "hex": "358698"},
+                {"name": "Blattgrün", "hex": "4d7c43"},
+                {"name": "Dunkelgrün", "hex": "1e6b4a"},
+                {"name": "Apfelgrün", "hex": "36b336"},
+                {"name": "Olivgrün", "hex": "3f4030"},
+                {"name": "Leichtes Grün", "hex": "a8d8cb"},
+                {"name": "Grau", "hex": "7e8b92"},
+                {"name": "Khaki", "hex": "6a5f31"},
+                {"name": "Eisengrau", "hex": "4e5965"},
+                {"name": "Hellgrau", "hex": "d7d7d7"},
+                {"name": "Kupferbraun", "hex": "8e402a"},
+                {"name": "Braun", "hex": "59351f"},
+                {"name": "Beigebraun", "hex": "7b5141"},
+                {"name": "Crem Weiß (Perlweiß)", "hex": "fdf4e3"},
+                {"name": "Weiß", "hex": "f4f4f4"},
+                {"name": "Silber", "hex": "a5a5a5"},
+                {"name": "Schwarz", "hex": "1e1e1e"},
+                {"name": "Neon Grün", "hex": "00b140", "translucent": true},
+                {"name": "Neon Pink", "hex": "fe17a2"},
+                {"name": "Neon Orange", "hex": "fe5000", "translucent": true},
+                {"name": "Leichtes Blau", "hex": "74b2dd"},
+                {"name": "Neon Gelb", "hex": "d4ed47", "translucent": true},
+                {"name": "Gelbgold", "hex": "c9a96e"},
+                {"name": "Neon Transparent", "hex": "b8d4e8", "translucent": true},
+                {"name": "Leichtes Pink", "hex": "f9c4ba"},
+                {"name": "Blau", "hex": "1b4f8a"},
+                {"name": "Natur Transparent", "hex": "e8e4d8", "translucent": true},
+                {"name": "Glow in the Dark (Grün)", "hex": "c8e04a", "glow": true},
+                {"name": "Glow in the Dark (Blau)", "hex": "5bb8f5", "glow": true}
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ASA-X",
+            "density": 1.11,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 155,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 255,
+            "extruder_temp_range": [
+                235,
+                255
+            ],
+            "bed_temp_range": [
+                80,
+                90
+            ],
+            "colors": [
+                {"name": "Schwarz", "hex": "1e1e1e"},
+                {"name": "Weiß", "hex": "f4f4f4"},
+                {"name": "Rot", "hex": "cc2529"},
+                {"name": "Dunkelblau", "hex": "20214f"},
+                {"name": "Eisengrau", "hex": "4e5965"},
+                {"name": "Hellgrau", "hex": "d7d7d7"},
+                {"name": "Verkehrsblau", "hex": "2271b3"},
+                {"name": "Apfelgrün", "hex": "57a639"},
+                {"name": "Blattgrün", "hex": "4d7c43"},
+                {"name": "Dunkelsilber", "hex": "9a9697"},
+                {"name": "Orange", "hex": "f3752b"},
+                {"name": "Gelb", "hex": "fad201"},
+                {"name": "Glitzer Eisengau", "hex": "535a5e", "pattern": "sparkle"},
+                {"name": "Glitzer Oxidrot", "hex": "911e1e", "pattern": "sparkle"}
+            ]
+        }
+    ]
+}

--- a/filaments/redlinefilament.json
+++ b/filaments/redlinefilament.json
@@ -78,7 +78,7 @@
         },
         {
             "name": "{color_name}",
-            "material": "ASA-X",
+            "material": "ASA",
             "density": 1.11,
             "weights": [
                 {

--- a/filaments/renkforce.json
+++ b/filaments/renkforce.json
@@ -1,0 +1,573 @@
+{
+  "manufacturer": "Renkforce",
+  "filaments": [
+    {
+      "name": "ABS Heat Resistant {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        245,
+        265
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-6838912"
+          ],
+          "eans": [
+            "4064161481227"
+          ]
+        },
+        {
+          "name": "Ecru",
+          "hex": "F5F5DC",
+          "codes": [
+            "RF-6838914"
+          ],
+          "eans": [
+            "4064161481234"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "RF-6838916"
+          ],
+          "eans": [
+            "4064161481241"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        245,
+        265
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-4738584"
+          ],
+          "eans": [
+            "4064161175119"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-6838910"
+          ],
+          "eans": [
+            "4064161481210"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ]
+    },
+    {
+      "name": "PETG Classic {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        240
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-4738592"
+          ],
+          "eans": [
+            "4064161177212"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-6838904"
+          ],
+          "eans": [
+            "4064161481180"
+          ]
+        },
+        {
+          "name": "Ecru",
+          "hex": "F5F5DC",
+          "codes": [
+            "RF-6838906"
+          ],
+          "eans": [
+            "4064161481197"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "RF-6838908"
+          ],
+          "eans": [
+            "4064161481203"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ]
+    },
+    {
+      "name": "PLA CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-6838918"
+          ],
+          "eans": [
+            "4064161481258"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PLA HF {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-5771490"
+          ],
+          "eans": [
+            "4064161258416"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "PLA Highspeed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hex": "FF00FF",
+          "codes": [
+            "RF-6838890"
+          ],
+          "eans": [
+            "4064161481128"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "PLA Lite {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-5771478"
+          ],
+          "eans": [
+            "4064161258355"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-6838892"
+          ],
+          "eans": [
+            "4064161481135"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "RF-6855450"
+          ],
+          "eans": [
+            "4064161482064"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "RF-6838902"
+          ],
+          "eans": [
+            "4064161481173"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-4511188"
+          ],
+          "eans": [
+            "4064161043999"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "RF-4511194"
+          ],
+          "eans": [
+            "4064161044026"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "RF-4511198"
+          ],
+          "eans": [
+            "4064161044040"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "RF-4511192"
+          ],
+          "eans": [
+            "4064161044019"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "FFA500",
+          "codes": [
+            "RF-4511208"
+          ],
+          "eans": [
+            "4064161044095"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "RF-4511210"
+          ],
+          "eans": [
+            "4064161044101"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "RF-4511196"
+          ],
+          "eans": [
+            "4064161044033"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0",
+          "codes": [
+            "RF-4511204"
+          ],
+          "eans": [
+            "4064161044071"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "FFFFFF",
+          "codes": [
+            "RF-4511200"
+          ],
+          "eans": [
+            "4064161044057"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "RF-4511190"
+          ],
+          "eans": [
+            "4064161044002"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "RF-4511202"
+          ],
+          "eans": [
+            "4064161044064"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA 2.85mm {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "RF-4511228"
+          ],
+          "eans": [
+            "4064161044194"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "RF-4511230"
+          ],
+          "eans": [
+            "4064161044200"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/reprapper.json
+++ b/filaments/reprapper.json
@@ -1,0 +1,43 @@
+{
+    "manufacturer": "Reprapper",
+    "filaments": [
+        {
+            "name": "Reprapper PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 180
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/sa3dfusion.json
+++ b/filaments/sa3dfusion.json
@@ -1,0 +1,88 @@
+{
+  "manufacturer": "SA 3D Fusion",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Birch Grey",
+          "hex": "b2a79b"
+        },
+        {
+          "name": "Green",
+          "hex": "125e55"
+        },
+        {
+          "name": "Ivory",
+          "hex": "fff6dc"
+        },
+        {
+          "name": "Khaki",
+          "hex": "242320"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "1bd500"
+        },
+        {
+          "name": "Mustard",
+          "hex": "d88e2e"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "7c7e6c"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7b00"
+        },
+        {
+          "name": "Pebble Grey",
+          "hex": "3e3e42"
+        },
+        {
+          "name": "Red",
+          "hex": "c11b23"
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "2a307a"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "1e81f8"
+        },
+        {
+          "name": "Terracotta Brown",
+          "hex": "964822"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "d7ec00"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/safilament.json
+++ b/filaments/safilament.json
@@ -1,0 +1,445 @@
+{
+  "manufacturer": "SA Filament",
+  "filaments": [
+    {
+      "name": "98A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "ABS Premium {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "c9c9c9"
+        },
+        {
+          "name": "Silver",
+          "hex": "8fa9bb"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "d6ffd1"
+        }
+      ]
+    },
+    {
+      "name": "High Speed Cf {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Green",
+          "hex": "6ef777"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "ef6f10"
+        },
+        {
+          "name": "Red",
+          "hex": "a20707"
+        }
+      ]
+    },
+    {
+      "name": "Neon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Lunar Yellow",
+          "hex": "edf047"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blaze Orange",
+          "hex": "ff6400"
+        },
+        {
+          "name": "Grey",
+          "hex": "575757"
+        },
+        {
+          "name": "Luminous Green",
+          "hex": "139516"
+        },
+        {
+          "name": "Purple",
+          "hex": "7600a8"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        245
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Air Force Blue",
+          "hex": "5380ac"
+        },
+        {
+          "name": "Baby Pink",
+          "hex": "f0bce9"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "303ef8"
+        },
+        {
+          "name": "Green",
+          "hex": "169224"
+        },
+        {
+          "name": "Grey",
+          "hex": "919191"
+        },
+        {
+          "name": "Olive Drab",
+          "hex": "324e35"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8800"
+        },
+        {
+          "name": "Pale Green",
+          "hex": "b6edd6"
+        },
+        {
+          "name": "Powder Blue",
+          "hex": "b0e0e6"
+        },
+        {
+          "name": "Purple",
+          "hex": "8966aa"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Chrome Silver",
+          "hex": "b5bdc4"
+        },
+        {
+          "name": "Merlot",
+          "hex": "d51e50"
+        },
+        {
+          "name": "Pearl",
+          "hex": "e3e8ee"
+        },
+        {
+          "name": "Silky Peach",
+          "hex": "eebb8b"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "3799fb"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        245
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue Blood",
+          "hex": "0000d7"
+        },
+        {
+          "name": "Golden Leaf",
+          "hex": "16c559"
+        },
+        {
+          "name": "Sapphire Forest",
+          "hex": "69a3f8"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Crimson Eclipse",
+          "hex": "814f83"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/sainsmart.json
+++ b/filaments/sainsmart.json
@@ -1,0 +1,39 @@
+{
+    "manufacturer": "SainSmart",
+    "filaments": [
+        {
+            "name": "SainSmart TPU {color_name}",
+            "material": "TPU",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 50,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/sakata3d.json
+++ b/filaments/sakata3d.json
@@ -1,0 +1,1172 @@
+{
+  "manufacturer": "Sakata 3D",
+  "filaments": [
+    {
+      "name": "ABS-E {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "extruder_temp_range": [
+        235,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        100
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 850
+        },
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Caramel",
+          "hex": "755847"
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "6A93B0"
+        },
+        {
+          "name": "Natural",
+          "hex": "F1F0EA",
+          "translucent": true
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28"
+        },
+        {
+          "name": "Purple",
+          "hex": "6D6680"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Silver",
+          "hex": "8C9196"
+        },
+        {
+          "name": "Tile",
+          "hex": "D05D28"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 850
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Natural",
+          "hex": "F1F0EA",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "FleX-920 {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "extruder_temp_range": [
+        220,
+        245
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "diameters": [
+        1.75
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Camel",
+          "hex": "CDBA88"
+        },
+        {
+          "name": "Chocolate",
+          "hex": "755847"
+        },
+        {
+          "name": "Fluor Lime",
+          "hex": "FFFF00",
+          "glow": false
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "6A5D7B"
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28"
+        },
+        {
+          "name": "Orange Fresh",
+          "hex": "FF2300"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Skin Tone 1",
+          "hex": "ECC3B2"
+        },
+        {
+          "name": "Surf Green",
+          "hex": "478A84"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Natural white",
+          "hex": "F1F0EA"
+        }
+      ]
+    },
+    {
+      "name": "PET-G {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Ambar",
+          "hex": "FF2300",
+          "translucent": true
+        },
+        {
+          "name": "Anthracite Grey",
+          "hex": "8C9196"
+        },
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Emerald",
+          "hex": "478A84",
+          "translucent": true
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "6A5D7B"
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "8D9499"
+        },
+        {
+          "name": "Natural",
+          "hex": "F1F0EA",
+          "translucent": true
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Ruby",
+          "hex": "CB2821",
+          "translucent": true
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        },
+        {
+          "name": "Zaphire",
+          "hex": "154889",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "PET-G CF15 {color_name}",
+      "material": "PETG-CF15",
+      "density": 1.3,
+      "fill": "carbon fiber",
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "diameters": [
+        1.75
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        }
+      ]
+    },
+    {
+      "name": "PET-G V0 {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "diameters": [
+        1.75
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Natural",
+          "hex": "F1F0EA",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "PLA 700 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        185,
+        195
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Grey",
+          "hex": "57A639"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        }
+      ]
+    },
+    {
+      "name": "PLA 850 Glass {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        70
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "translucent": true,
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1E2460",
+          "translucent": true
+        },
+        {
+          "name": "Green",
+          "hex": "57A639",
+          "translucent": true
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28",
+          "translucent": true
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821",
+          "translucent": true
+        },
+        {
+          "name": "Violet",
+          "hex": "6D6680",
+          "translucent": true
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "PLA 850 Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        70
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "pattern": "sparkle",
+      "colors": [
+        {
+          "name": "Coal",
+          "hex": "211F20",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "154889",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Plus Blue",
+          "hex": "154889",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Plus Coal",
+          "hex": "211F20",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Plus Red",
+          "hex": "CC0605",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Plus Silver",
+          "hex": "7F8274",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Purple",
+          "hex": "6A5D7B",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Silver",
+          "hex": "7F8274",
+          "glow": false,
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Star Gold",
+          "hex": "6A664F",
+          "glow": false,
+          "pattern": "sparkle"
+        }
+      ]
+    },
+    {
+      "name": "PLA 850 Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        70
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "finish": "glossy",
+      "colors": [
+        {
+          "name": "Arctic",
+          "hex": "6A93B0",
+          "finish": "glossy"
+        },
+        {
+          "name": "Aubergine",
+          "hex": "6A5D7B",
+          "finish": "glossy"
+        },
+        {
+          "name": "Clover",
+          "hex": "57A639",
+          "finish": "glossy"
+        },
+        {
+          "name": "Fir Green",
+          "hex": "57A639",
+          "finish": "glossy"
+        },
+        {
+          "name": "Gold",
+          "hex": "6A664F",
+          "finish": "glossy"
+        },
+        {
+          "name": "Midnight",
+          "hex": "154889",
+          "finish": "glossy"
+        },
+        {
+          "name": "Ocean",
+          "hex": "154889",
+          "finish": "glossy"
+        },
+        {
+          "name": "Snow",
+          "hex": "F6F6F6",
+          "finish": "glossy"
+        },
+        {
+          "name": "Sunset",
+          "hex": "D05D28",
+          "finish": "glossy"
+        },
+        {
+          "name": "Wine",
+          "hex": "CB8D73",
+          "finish": "glossy"
+        }
+      ]
+    },
+    {
+      "name": "PLA 850 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        70
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2500
+        },
+        {
+          "weight": 5000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Andalucia Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Anthracite Gray",
+          "hex": "8C9196"
+        },
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Carmine Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Chocolate",
+          "hex": "755847"
+        },
+        {
+          "name": "Clay",
+          "hex": "755847"
+        },
+        {
+          "name": "Fluor Light Green",
+          "hex": "57A639",
+          "glow": false
+        },
+        {
+          "name": "Fluor Lime",
+          "hex": "FFFF00",
+          "glow": false
+        },
+        {
+          "name": "Fluor Orange",
+          "hex": "FF2300",
+          "glow": false
+        },
+        {
+          "name": "Fluor Orange Fresh",
+          "hex": "FF2300",
+          "glow": false
+        },
+        {
+          "name": "Fluor Yellow",
+          "hex": "FFFF00",
+          "glow": false
+        },
+        {
+          "name": "Fucsia",
+          "hex": "6A5D7B"
+        },
+        {
+          "name": "Gold",
+          "hex": "6A664F"
+        },
+        {
+          "name": "Granite",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Ivory",
+          "hex": "E9E0D2"
+        },
+        {
+          "name": "Militar Tone 1 Gc",
+          "hex": "4B5320"
+        },
+        {
+          "name": "Militar Tone 2",
+          "hex": "C2B280"
+        },
+        {
+          "name": "Natural",
+          "hex": "F1F0EA",
+          "translucent": true
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28"
+        },
+        {
+          "name": "Pastel Baby Pink",
+          "hex": "CB8D73"
+        },
+        {
+          "name": "Pastel Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Pastel Lilac",
+          "hex": "6D6680"
+        },
+        {
+          "name": "Pastel Mango Yellow",
+          "hex": "FAD201"
+        },
+        {
+          "name": "Pink",
+          "hex": "CB8D73"
+        },
+        {
+          "name": "Purple",
+          "hex": "6A5D7B"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Silver",
+          "hex": "7F8274"
+        },
+        {
+          "name": "Skin Tone 1",
+          "hex": "ECC3B2"
+        },
+        {
+          "name": "Skin Tone 2",
+          "hex": "CDBA88"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "6A93B0"
+        },
+        {
+          "name": "Solidary",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Surf Green",
+          "hex": "478A84"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    },
+    {
+      "name": "PLA GO&PRINT {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        185,
+        205
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Chocolate",
+          "hex": "755847"
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "6A5D7B"
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28"
+        },
+        {
+          "name": "Pastel Pink",
+          "hex": "CB8D73"
+        },
+        {
+          "name": "Pastel Torquoise",
+          "hex": "478A84"
+        },
+        {
+          "name": "Pastel Yellow",
+          "hex": "FAD201"
+        },
+        {
+          "name": "Pink",
+          "hex": "CB8D73"
+        },
+        {
+          "name": "Purple",
+          "hex": "6D6680"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Silver",
+          "hex": "8C9196"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    },
+    {
+      "name": "PLA HR-870 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Natural",
+          "hex": "F1F0EA",
+          "translucent": true
+        },
+        {
+          "name": "Orange",
+          "hex": "D05D28"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "Silver",
+          "hex": "8C9196"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    },
+    {
+      "name": "PLA HS High Speed PRO {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "diameters": [
+        1.75
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Fluor Light Blue",
+          "hex": "6A93B0",
+          "glow": false
+        },
+        {
+          "name": "Fluor Light Green",
+          "hex": "57A639",
+          "glow": false
+        },
+        {
+          "name": "Fluor Purple",
+          "hex": "6D6680",
+          "glow": false
+        },
+        {
+          "name": "Green",
+          "hex": "57A639"
+        },
+        {
+          "name": "Grey",
+          "hex": "9DA3A6"
+        },
+        {
+          "name": "Ivory",
+          "hex": "E9E0D2"
+        },
+        {
+          "name": "Militar 2",
+          "hex": "C2B280"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    },
+    {
+      "name": "PLA WOOD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "fill": "wood",
+      "extruder_temp_range": [
+        200,
+        255
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "diameters": [
+        1.75
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "colors": [
+        {
+          "name": "Arce",
+          "hex": "755847",
+          "pattern": "marble"
+        },
+        {
+          "name": "Oak",
+          "hex": "755847",
+          "pattern": "marble"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "57A639",
+          "pattern": "marble"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6",
+          "pattern": "marble"
+        }
+      ]
+    },
+    {
+      "name": "PLA-M {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "finish": "matte",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "211F20"
+        },
+        {
+          "name": "Blue",
+          "hex": "1E2460"
+        },
+        {
+          "name": "Grey",
+          "hex": "57A639"
+        },
+        {
+          "name": "Red",
+          "hex": "CB2821"
+        },
+        {
+          "name": "White",
+          "hex": "F6F6F6"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FAD201"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/sirayatech.json
+++ b/filaments/sirayatech.json
@@ -1,0 +1,569 @@
+{
+  "manufacturer": "Siraya Tech",
+  "filaments": [
+    {
+      "name": "64D {color_name}",
+      "material": "TPU",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "85A {color_name}",
+      "material": "PEBA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "85A {color_name}",
+      "material": "TPU",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Green",
+          "hex": "b6f671"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "95A {color_name}",
+      "material": "PEBA",
+      "density": 1.0,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Air {color_name}",
+      "material": "PEBA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Air {color_name}",
+      "material": "TPU",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        270
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "b2ed6f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PPA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PET-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        300
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PAHT-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        290,
+        310
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black - rCF08",
+          "hex": "000000"
+        },
+        {
+          "name": "HF - Black",
+          "hex": "000000"
+        },
+        {
+          "name": "HF Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Pro HF Black",
+          "hex": "000000"
+        },
+        {
+          "name": "rCF08 Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ABS-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Core Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "ASA-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PPA-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        320
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "PET-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        300,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Flat Dark Earth",
+          "hex": "745f39"
+        },
+        {
+          "name": "OD Green",
+          "hex": "36320c"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "TPU-GF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Gf {color_name}",
+      "material": "ABS-GF",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        280
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "e7eae7"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "fill": "glass fiber"
+    },
+    {
+      "name": "Ht {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "HF Black",
+          "hex": "000000"
+        },
+        {
+          "name": "HF White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/slic3d.json
+++ b/filaments/slic3d.json
@@ -1,0 +1,152 @@
+{
+  "manufacturer": "Slic3D",
+  "filaments": [
+    {
+      "name": "Lite {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "Spain"
+    },
+    {
+      "name": "Lite {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "Spain"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 1130
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "022cac"
+        },
+        {
+          "name": "Gray",
+          "hex": "adaeb1"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "country_of_origin": "Spain"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "666666"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffb0d8"
+        },
+        {
+          "name": "Red",
+          "hex": "c80000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "country_of_origin": "Spain"
+    }
+  ]
+}

--- a/filaments/sliceworx.json
+++ b/filaments/sliceworx.json
@@ -1,0 +1,388 @@
+{
+  "manufacturer": "SliceWorx",
+  "filaments": [
+    {
+      "name": "Gradient Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "New Mexcio",
+          "hex": "b05800"
+        }
+      ]
+    },
+    {
+      "name": "Gradient {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Fall foliage",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "HS Prototype Series PLA GREY",
+          "hex": "a5a9ac"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        215
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "RUBICON Blue-Pink-Gold",
+          "hex": "242212"
+        }
+      ]
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "flaming forest",
+          "hex": "008000"
+        }
+      ]
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Freedom",
+          "hex": "ef0000"
+        },
+        {
+          "name": "Rose Red-Yellow-Blue",
+          "hex": "5cc3e6"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Aquazee",
+          "hex": "8000ff"
+        }
+      ]
+    },
+    {
+      "name": "PETG Pro {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Dark Grey",
+          "hex": "202020"
+        },
+        {
+          "name": "Robitobi Green",
+          "hex": "cbc805"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Old Glory Blue",
+          "hex": "002040"
+        },
+        {
+          "name": "Old Glory Red",
+          "hex": "e73651"
+        },
+        {
+          "name": "Pearly White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Robitobi Green",
+          "hex": "c0e869"
+        },
+        {
+          "name": "WHITE",
+          "hex": "f7f7f7"
+        }
+      ]
+    },
+    {
+      "name": "PLA Pro {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Robitobi Green",
+          "hex": "cbc805"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Chocolate Brown",
+          "hex": "822813"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "ocean cyan",
+          "hex": "00b0b0"
+        },
+        {
+          "name": "Vault Yellow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Satin",
+          "hex": "000000"
+        },
+        {
+          "name": "lithopane white",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/smartfil.json
+++ b/filaments/smartfil.json
@@ -1,0 +1,492 @@
+{
+  "manufacturer": "Smartfil",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Sapphire",
+          "hex": "068fd0"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "RUBY M",
+          "hex": "e01b24"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "TRUE BLACK",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Red Glitter",
+          "hex": "b20015",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Silver",
+          "hex": "658ab3",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Violet",
+          "hex": "773bad",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "d1ecff"
+        },
+        {
+          "name": "Green",
+          "hex": "aeefca"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Chlorophyll",
+          "hex": "44d839"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "PALE SKIN",
+          "hex": "ebebd5"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "SILVER",
+          "hex": "abb8c4"
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "694d12"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Glace",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "black",
+          "hex": "000000"
+        },
+        {
+          "name": "Gold",
+          "hex": "694d12"
+        },
+        {
+          "name": "Green",
+          "hex": "00be23"
+        },
+        {
+          "name": "Orinoco",
+          "hex": "f7da31"
+        },
+        {
+          "name": "Pastel",
+          "hex": "ceafd9"
+        },
+        {
+          "name": "Signal blue",
+          "hex": "005083"
+        },
+        {
+          "name": "True Black",
+          "hex": "000000"
+        },
+        {
+          "name": "white",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "Recycled {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cold White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Coral",
+          "hex": "ff757e"
+        },
+        {
+          "name": "Gold",
+          "hex": "694d12"
+        },
+        {
+          "name": "Green",
+          "hex": "02e905"
+        },
+        {
+          "name": "Grenade",
+          "hex": "700000"
+        },
+        {
+          "name": "Ivory White",
+          "hex": "d8e1ed"
+        },
+        {
+          "name": "Light Green",
+          "hex": "058b8c"
+        },
+        {
+          "name": "Purple",
+          "hex": "47243c"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2600"
+        },
+        {
+          "name": "Violet",
+          "hex": "6b4bb4"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f1dd38"
+        }
+      ]
+    },
+    {
+      "name": "Recycled {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Signal Orange",
+          "hex": "cc5d29"
+        }
+      ]
+    },
+    {
+      "name": "Support {color_name}",
+      "material": "PVA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "fbedff"
+        }
+      ]
+    },
+    {
+      "name": "Support {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Weiß Reinigungsfilament",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        245
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "005e83"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Wenge",
+          "hex": "000000"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/smartmaterials.json
+++ b/filaments/smartmaterials.json
@@ -1,0 +1,767 @@
+{
+  "manufacturer": "SmartMaterials",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "FLEX 93A True Back",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "98A {color_name}",
+      "material": "TPU",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        235
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "True Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Crystal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "304ca8"
+        },
+        {
+          "name": "Red",
+          "hex": "b31c23"
+        },
+        {
+          "name": "Yellow",
+          "hex": "b8ac22"
+        }
+      ]
+    },
+    {
+      "name": "Easy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        205
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Ivory White",
+          "hex": "f0f9fe"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "48444e",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Blue",
+          "hex": "315d88",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Dark Green Glitter",
+          "hex": "384f35",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Green",
+          "hex": "42a581",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Red",
+          "hex": "852735",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Silver",
+          "hex": "717577",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Violet",
+          "hex": "7b5aab",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "68cede"
+        },
+        {
+          "name": "Green",
+          "hex": "85d49c"
+        }
+      ]
+    },
+    {
+      "name": "Neon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Neo Pink",
+          "hex": "fd5c62"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "fce115"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "2f3f5b"
+        },
+        {
+          "name": "Burdeos",
+          "hex": "592b2e"
+        },
+        {
+          "name": "Cooper",
+          "hex": "893727"
+        },
+        {
+          "name": "Red",
+          "hex": "712834"
+        },
+        {
+          "name": "Silver",
+          "hex": "a6a6a4"
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "b0771c"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Iris Alexandrite",
+          "hex": "476441"
+        },
+        {
+          "name": "Iris Granate",
+          "hex": "63494c"
+        },
+        {
+          "name": "Iris Pearl",
+          "hex": "c2bba1"
+        },
+        {
+          "name": "Iris Tanzanite",
+          "hex": "374f5e"
+        },
+        {
+          "name": "Iris Topaz",
+          "hex": "3a6055"
+        },
+        {
+          "name": "Medium Skin",
+          "hex": "f4c0b1"
+        },
+        {
+          "name": "Pale Skin",
+          "hex": "ebd1b8"
+        },
+        {
+          "name": "Smartfil Oyster",
+          "hex": "b9966f"
+        },
+        {
+          "name": "Tan Skin",
+          "hex": "a36844"
+        },
+        {
+          "name": "Antracita (Dark Grey)",
+          "hex": "585d61"
+        },
+        {
+          "name": "Aubergine (Purple)",
+          "hex": "231738"
+        },
+        {
+          "name": "Chlorophyll (Green)",
+          "hex": "54c040"
+        },
+        {
+          "name": "Cobalt (Dark Blue)",
+          "hex": "2b408d"
+        },
+        {
+          "name": "Coral (Coral)",
+          "hex": "f36062"
+        },
+        {
+          "name": "Emerald (Light Green)",
+          "hex": "50c3a1"
+        },
+        {
+          "name": "Gold (Gold)",
+          "hex": "665e3d"
+        },
+        {
+          "name": "Green Army (Green Army)",
+          "hex": "285742"
+        },
+        {
+          "name": "Grenade (Grenade)",
+          "hex": "6f121e"
+        },
+        {
+          "name": "Hillier Lake (Pink)",
+          "hex": "c14aac"
+        },
+        {
+          "name": "Ivory White (White)",
+          "hex": "f1f2e9"
+        },
+        {
+          "name": "Jade (Dark Green)",
+          "hex": "143e34"
+        },
+        {
+          "name": "Light Gray (Light Gray)",
+          "hex": "c0c0c5"
+        },
+        {
+          "name": "Mahogany (Brown)",
+          "hex": "582622"
+        },
+        {
+          "name": "May (May)",
+          "hex": "458b37"
+        },
+        {
+          "name": "Natural",
+          "hex": "d7ceb8"
+        },
+        {
+          "name": "Neo Yellow",
+          "hex": "e0e722"
+        },
+        {
+          "name": "Orinoco (Yellow)",
+          "hex": "f3f034"
+        },
+        {
+          "name": "Ruby (Red)",
+          "hex": "e82730"
+        },
+        {
+          "name": "Sapphire (Blue)",
+          "hex": "3f9cd1"
+        },
+        {
+          "name": "Signal Blue (Signal Blue)",
+          "hex": "28618b"
+        },
+        {
+          "name": "Silver (Silver)",
+          "hex": "6a6e6f"
+        },
+        {
+          "name": "Snow (Cold White)",
+          "hex": "e8f4f0"
+        },
+        {
+          "name": "Sunset (Orange)",
+          "hex": "f3592e"
+        },
+        {
+          "name": "Traffic (Traffic)",
+          "hex": "e2a81e"
+        },
+        {
+          "name": "True Black",
+          "hex": "000000"
+        },
+        {
+          "name": "True Black (Black)",
+          "hex": "1d1e1f"
+        },
+        {
+          "name": "White Snow",
+          "hex": "fffafa"
+        },
+        {
+          "name": "Wisteria (Violet)",
+          "hex": "7257b1"
+        }
+      ]
+    },
+    {
+      "name": "Pastello {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Aqua",
+          "hex": "dff0f2"
+        },
+        {
+          "name": "Lavender",
+          "hex": "e5bee3"
+        },
+        {
+          "name": "Mint",
+          "hex": "e2edd0"
+        },
+        {
+          "name": "Quartz",
+          "hex": "f7e9f4"
+        },
+        {
+          "name": "Vanilla",
+          "hex": "f1e8b7"
+        }
+      ]
+    },
+    {
+      "name": "Recycled {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "2b2b2c"
+        },
+        {
+          "name": "Blue",
+          "hex": "007caf"
+        },
+        {
+          "name": "Brown",
+          "hex": "a45729"
+        },
+        {
+          "name": "Cold White",
+          "hex": "eff5f4"
+        },
+        {
+          "name": "Coral",
+          "hex": "ca555d"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "222d5a"
+        },
+        {
+          "name": "Dark Green",
+          "hex": "005f4e"
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "575d5e"
+        },
+        {
+          "name": "Gold",
+          "hex": "806440"
+        },
+        {
+          "name": "Green",
+          "hex": "38d53a"
+        },
+        {
+          "name": "Green Army",
+          "hex": "315442"
+        },
+        {
+          "name": "Grenade",
+          "hex": "861a22"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "6093ac"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "c5c7c4"
+        },
+        {
+          "name": "Light Green",
+          "hex": "048b8c"
+        },
+        {
+          "name": "Lilac",
+          "hex": "76689a"
+        },
+        {
+          "name": "May",
+          "hex": "587f40"
+        },
+        {
+          "name": "Orange",
+          "hex": "ee672f"
+        },
+        {
+          "name": "Pink",
+          "hex": "bb4077"
+        },
+        {
+          "name": "Purple",
+          "hex": "47243c"
+        },
+        {
+          "name": "Red",
+          "hex": "eb302d"
+        },
+        {
+          "name": "Signal Blue",
+          "hex": "005387"
+        },
+        {
+          "name": "Silver",
+          "hex": "a5a3ac"
+        },
+        {
+          "name": "Traffic",
+          "hex": "f7b500"
+        },
+        {
+          "name": "Violet",
+          "hex": "76689a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Woman's day",
+          "hex": "c09fce"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fae83c"
+        }
+      ]
+    },
+    {
+      "name": "Refill {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Dark Green",
+          "hex": "015d52"
+        }
+      ]
+    },
+    {
+      "name": "Support {color_name}",
+      "material": "PP",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 700
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        0,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Acacia",
+          "hex": "d5bd89"
+        },
+        {
+          "name": "Maple",
+          "hex": "7f8346"
+        },
+        {
+          "name": "Sapelly",
+          "hex": "874d3d"
+        },
+        {
+          "name": "Teka",
+          "hex": "ac7040"
+        },
+        {
+          "name": "Wenge",
+          "hex": "363a36"
+        },
+        {
+          "name": "Willow",
+          "hex": "66815d"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/smartmaterials3d.json
+++ b/filaments/smartmaterials3d.json
@@ -1,0 +1,85 @@
+{
+  "manufacturer": "Smart Materials 3D",
+  "filaments": [
+    {
+      "name": "Smartfil PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 180,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 180,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [200, 220],
+      "bed_temp_range": [0, 60],
+      "colors": [
+        {"name": "Ivory White", "hex": "F2EFE9"},
+        {"name": "True Black", "hex": "0E0E0E"},
+        {"name": "Ruby Red", "hex": "BE1E2D"},
+        {"name": "Cobalt Blue", "hex": "1C3F94"},
+        {"name": "Grass Green", "hex": "2E9F47"},
+        {"name": "Mustard Yellow", "hex": "E1B022"}
+      ]
+    },
+    {
+      "name": "Smartfil PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 180,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 180,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [70, 90],
+      "colors": [
+        {"name": "Black", "hex": "131313"},
+        {"name": "White", "hex": "FAFAFA"},
+        {"name": "Red", "hex": "C01515"},
+        {"name": "Blue", "hex": "154FC0"},
+        {"name": "Clear", "hex": "FFFFFF80"}
+      ]
+    },
+    {
+      "name": "Smartfil ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_weight": 180,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 1000,
+          "spool_weight": 180,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [80, 100],
+      "colors": [
+        {"name": "Black", "hex": "181818"},
+        {"name": "White", "hex": "FBFBFB"},
+        {"name": "Grey", "hex": "858585"}
+      ]
+    }
+  ]
+}

--- a/filaments/smartprint.json
+++ b/filaments/smartprint.json
@@ -1,0 +1,219 @@
+{
+  "manufacturer": "SmartPrint",
+  "filaments": [
+    {
+      "name": "PLA Plus {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Natural",
+          "hex": "fdf5e6",
+          "translucent": true
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        }
+      ],
+      "country_of_origin": "Poland"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Natural",
+          "hex": "fdf5e6",
+          "translucent": true
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ],
+      "country_of_origin": "Poland"
+    },
+    {
+      "name": "ABS Plus {color_name}",
+      "material": "ABS",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Brown",
+          "hex": "8b4513"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        }
+      ],
+      "country_of_origin": "Poland"
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ],
+      "country_of_origin": "Poland"
+    }
+  ]
+}

--- a/filaments/snapmaker.json
+++ b/filaments/snapmaker.json
@@ -1,0 +1,416 @@
+{
+  "manufacturer": "Snapmaker",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "fbe800"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "080a0d"
+        },
+        {
+          "name": "Blue",
+          "hex": "003776"
+        },
+        {
+          "name": "Brown",
+          "hex": "6f4c2f"
+        },
+        {
+          "name": "Green",
+          "hex": "2d9e59"
+        },
+        {
+          "name": "Grey",
+          "hex": "8c9099"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "aabb54"
+        },
+        {
+          "name": "Orange",
+          "hex": "f97429"
+        },
+        {
+          "name": "Pearl White",
+          "hex": "e2dedb"
+        },
+        {
+          "name": "Purple",
+          "hex": "6c5bb1"
+        },
+        {
+          "name": "Red",
+          "hex": "e72f1d"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f4c032"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "4169e1"
+        },
+        {
+          "name": "Red",
+          "hex": "a80008"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Ash Gray",
+          "hex": "7d7d7d"
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Celestial Blue",
+          "hex": "8bd5ee"
+        },
+        {
+          "name": "Engine Red",
+          "hex": "de0d0d"
+        },
+        {
+          "name": "Ivory White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Lava Orange",
+          "hex": "f78e0e"
+        },
+        {
+          "name": "Moss Mist",
+          "hex": "c9e6b6"
+        },
+        {
+          "name": "Pine Green",
+          "hex": "519f61"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "f4a4c0"
+        },
+        {
+          "name": "Sunburst Yellow",
+          "hex": "f0be02"
+        },
+        {
+          "name": "Watermelon Red",
+          "hex": "e36868"
+        },
+        {
+          "name": "Wood",
+          "hex": "9c927c"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        210
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blau",
+          "hex": "0056d6"
+        },
+        {
+          "name": "Braun",
+          "hex": "551029"
+        },
+        {
+          "name": "Gelb",
+          "hex": "f5ec00"
+        },
+        {
+          "name": "Glow in the dark Grün",
+          "hex": "39ff14"
+        },
+        {
+          "name": "Grau",
+          "hex": "999999"
+        },
+        {
+          "name": "Grün",
+          "hex": "669d34"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffab01"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Rot",
+          "hex": "ff4015"
+        },
+        {
+          "name": "Schwarz",
+          "hex": "000000"
+        },
+        {
+          "name": "Violett",
+          "hex": "982abc"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Panchroma Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Sunrise Orange",
+          "hex": "f88b17"
+        }
+      ]
+    },
+    {
+      "name": "Support {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Breakaway Support White",
+          "hex": "e3e4df"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Wood",
+          "hex": "d2b48c"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/sovb3d.json
+++ b/filaments/sovb3d.json
@@ -1,0 +1,1275 @@
+{
+  "manufacturer": "SOVB 3D",
+  "filaments": [
+    {
+      "name": "ABS Alumine {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Noir Alumine",
+          "hex": "000000",
+          "codes": [
+            "RO1.75AB1KGB01"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        100
+      ]
+    },
+    {
+      "name": "ABS Phosphorescent {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Phosphorescent",
+          "hex": "CCFF00",
+          "codes": [
+            "RO1.75AB1KGB22"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        100
+      ]
+    },
+    {
+      "name": "ABS Standard {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Aluminium",
+          "hex": "A9A9A9",
+          "codes": [
+            "RO1.75AB1KGB21"
+          ]
+        },
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75AB1KGB11"
+          ]
+        },
+        {
+          "name": "Blanc Crème",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75AB1KGB20"
+          ]
+        },
+        {
+          "name": "Blanc Gris",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75AB1KGB15"
+          ]
+        },
+        {
+          "name": "Bleu Ciel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75AB1KGB17"
+          ]
+        },
+        {
+          "name": "Bleu Clair",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75AB1KGB04"
+          ]
+        },
+        {
+          "name": "Bleu Nuit",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75AB1KGB08"
+          ]
+        },
+        {
+          "name": "Bleu Turquoise",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75AB1KGB19"
+          ]
+        },
+        {
+          "name": "Gris",
+          "hex": "808080",
+          "codes": [
+            "RO1.75AB1KGB13"
+          ]
+        },
+        {
+          "name": "Jaune",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75AB1KGB06"
+          ]
+        },
+        {
+          "name": "Jaune Fluo",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75AB1KGB03"
+          ]
+        },
+        {
+          "name": "Naturel",
+          "hex": "F5DEB3",
+          "codes": [
+            "RO1.75AB1KGB00"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO1.75AB1KGB10"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75AB1KGB07"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75AB1KGB02"
+          ]
+        },
+        {
+          "name": "Rose",
+          "hex": "FFC0CB",
+          "codes": [
+            "RO1.75AB1KGB14"
+          ]
+        },
+        {
+          "name": "Rouge",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75AB1KGB12"
+          ]
+        },
+        {
+          "name": "Vert Clair",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75AB1KGB05"
+          ]
+        },
+        {
+          "name": "Vert Foncé",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75AB1KGB09"
+          ]
+        },
+        {
+          "name": "Vert Mai",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75AB1KGB16"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "800080",
+          "codes": [
+            "RO1.75AB1KGB18"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        100
+      ]
+    },
+    {
+      "name": "ABS-PC {color_name}",
+      "material": "ABS",
+      "density": 1.03,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75ABPC1KGB11"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO1.75ABPC1KGB10"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        90,
+        100
+      ]
+    },
+    {
+      "name": "PLA Alumine {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Beige Nacré Alumine",
+          "hex": "F5F5DC",
+          "codes": [
+            "RO1.75PL1KGB40"
+          ]
+        },
+        {
+          "name": "Bleu Nacré Alumine",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB41"
+          ]
+        },
+        {
+          "name": "Bleu nuit alumine",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB30"
+          ]
+        },
+        {
+          "name": "Noir alumine",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL1KGB32"
+          ]
+        },
+        {
+          "name": "Rouge alumine",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL1KGB29"
+          ]
+        },
+        {
+          "name": "Vert Nacré Alumine",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB39"
+          ]
+        },
+        {
+          "name": "Vert mai alumine",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB34"
+          ]
+        },
+        {
+          "name": "Vert militaire",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB42"
+          ]
+        },
+        {
+          "name": "Violet alumine",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL1KGB35"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Alumine {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Bleu nuit alumine",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL2KGB30"
+          ]
+        },
+        {
+          "name": "Noir alumine",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL2KGB32"
+          ]
+        },
+        {
+          "name": "Rouge alumine",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL2KGB29"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Alumine {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Bleu nuit alumine",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB30"
+          ]
+        },
+        {
+          "name": "Noir alumine",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL0.5KGB32"
+          ]
+        },
+        {
+          "name": "Rouge alumine",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL0.5KGB29"
+          ]
+        },
+        {
+          "name": "Vert mai alumine",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB34"
+          ]
+        },
+        {
+          "name": "Violet alumine",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL0.5KGB35"
+          ]
+        },
+        {
+          "name": "beige nacré alumine",
+          "hex": "F5F5DC",
+          "codes": [
+            "RO1.75PL0.5KGB40"
+          ]
+        },
+        {
+          "name": "bleu nacré alumine",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB41"
+          ]
+        },
+        {
+          "name": "vert nacré alumine",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB39"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Pastel {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Bleu pastel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB44"
+          ]
+        },
+        {
+          "name": "Jaune pastel",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75PL1KGB43"
+          ]
+        },
+        {
+          "name": "Orange pastel",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75PL1KGB45"
+          ]
+        },
+        {
+          "name": "Rose pastel",
+          "hex": "FFC0CB",
+          "codes": [
+            "RO1.75PL1KGB47"
+          ]
+        },
+        {
+          "name": "Rouge Terracotta pastel",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL1KGB49"
+          ]
+        },
+        {
+          "name": "Vert pastel",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB46"
+          ]
+        },
+        {
+          "name": "Violet pastel",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL1KGB48"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Pastel {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Bleu pastel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL2KGB44"
+          ]
+        },
+        {
+          "name": "Jaune pastel",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75PL2KGB43"
+          ]
+        },
+        {
+          "name": "Orange pastel",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75PL2KGB45"
+          ]
+        },
+        {
+          "name": "Rose pastel",
+          "hex": "FFC0CB",
+          "codes": [
+            "RO1.75PL2KGB47"
+          ]
+        },
+        {
+          "name": "Vert pastel",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL2KGB46"
+          ]
+        },
+        {
+          "name": "Violet pastel",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL2KGB48"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Pastel {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Bleu pastel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB44"
+          ]
+        },
+        {
+          "name": "Jaune pastel",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75PL0.5KGB43"
+          ]
+        },
+        {
+          "name": "Orange pastel",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75PL0.5KGB45"
+          ]
+        },
+        {
+          "name": "Rose pastel",
+          "hex": "FFC0CB",
+          "codes": [
+            "RO1.75PL0.5KGB47"
+          ]
+        },
+        {
+          "name": "Rouge terracotta pastel",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL0.5KGB49"
+          ]
+        },
+        {
+          "name": "Vert pastel",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB46"
+          ]
+        },
+        {
+          "name": "Violet pastel",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL0.5KGB48"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Standard {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 10000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75PL10KGB11"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL10KGB10"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Standard {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Beige Nacré",
+          "hex": "F5F5DC",
+          "codes": [
+            "RO1.75PL1KGB37"
+          ]
+        },
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75PL1KGB11"
+          ]
+        },
+        {
+          "name": "Bleu Nacré",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB38"
+          ]
+        },
+        {
+          "name": "Bleu Turquoise",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB19"
+          ]
+        },
+        {
+          "name": "Bleu ciel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB17"
+          ]
+        },
+        {
+          "name": "Bleu nuit",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL1KGB08"
+          ]
+        },
+        {
+          "name": "Bronze",
+          "hex": "CD7F32",
+          "codes": [
+            "RO1.75PL1KGB23"
+          ]
+        },
+        {
+          "name": "Gris aluminium",
+          "hex": "808080",
+          "codes": [
+            "RO1.75PL1KGB21"
+          ]
+        },
+        {
+          "name": "Gris argent",
+          "hex": "808080",
+          "codes": [
+            "RO1.75PL1KGB28"
+          ]
+        },
+        {
+          "name": "Jaune",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75PL1KGB06"
+          ]
+        },
+        {
+          "name": "Marron clair",
+          "hex": "8B4513",
+          "codes": [
+            "RO1.75PL1KGB31"
+          ]
+        },
+        {
+          "name": "Marron foncé",
+          "hex": "8B4513",
+          "codes": [
+            "RO1.75PL1KGB27"
+          ]
+        },
+        {
+          "name": "Naturel",
+          "hex": "F5DEB3",
+          "codes": [
+            "RO1.75PL1KGB00"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL1KGB10"
+          ]
+        },
+        {
+          "name": "Noir Bleuté",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL1KGB26"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75PL1KGB25"
+          ]
+        },
+        {
+          "name": "Rouge",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL1KGB12"
+          ]
+        },
+        {
+          "name": "Vert Fluo",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB24"
+          ]
+        },
+        {
+          "name": "Vert Nacré",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB36"
+          ]
+        },
+        {
+          "name": "Vert mai",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL1KGB16"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL1KGB18"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Standard {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75PL2KGB11"
+          ]
+        },
+        {
+          "name": "Bleu Nuit",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL2KGB08"
+          ]
+        },
+        {
+          "name": "Bleu ciel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL2KGB17"
+          ]
+        },
+        {
+          "name": "Bleu turquoise",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL2KGB19"
+          ]
+        },
+        {
+          "name": "Gris aluminium",
+          "hex": "808080",
+          "codes": [
+            "RO1.75PL2KGB21"
+          ]
+        },
+        {
+          "name": "Gris argent",
+          "hex": "808080",
+          "codes": [
+            "RO1.75PL2KGB28"
+          ]
+        },
+        {
+          "name": "Jaune",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75PL2KGB06"
+          ]
+        },
+        {
+          "name": "Marron clair",
+          "hex": "8B4513",
+          "codes": [
+            "RO1.75PL2KGB31"
+          ]
+        },
+        {
+          "name": "Marron foncé",
+          "hex": "8B4513",
+          "codes": [
+            "RO1.75PL2KGB27"
+          ]
+        },
+        {
+          "name": "Naturel",
+          "hex": "F5DEB3",
+          "codes": [
+            "RO1.75PL2KGB00"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL2KGB10"
+          ]
+        },
+        {
+          "name": "Orange fluo",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75PL2KGB25"
+          ]
+        },
+        {
+          "name": "Rouge",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL2KGB12"
+          ]
+        },
+        {
+          "name": "Rouge Terracotta",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL2KGB49"
+          ]
+        },
+        {
+          "name": "Vert Mai",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL2KGB16"
+          ]
+        },
+        {
+          "name": "Vert fluo",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL2KGB24"
+          ]
+        },
+        {
+          "name": "Vert militaire",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL2KGB42"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL2KGB18"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Standard {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO1.75PL0.5KGB11"
+          ]
+        },
+        {
+          "name": "Bleu Nuit",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB08"
+          ]
+        },
+        {
+          "name": "Bleu Turquoise",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB19"
+          ]
+        },
+        {
+          "name": "Bleu ciel",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB17"
+          ]
+        },
+        {
+          "name": "Bronze",
+          "hex": "CD7F32",
+          "codes": [
+            "RO1.75PL0.5KGB23"
+          ]
+        },
+        {
+          "name": "Gris aluminium",
+          "hex": "808080",
+          "codes": [
+            "RO1.75PL0.5KGB21"
+          ]
+        },
+        {
+          "name": "Gris argent",
+          "hex": "808080",
+          "codes": [
+            "RO1.75PL0.5KGB28"
+          ]
+        },
+        {
+          "name": "Jaune",
+          "hex": "FFFF00",
+          "codes": [
+            "RO1.75PL0.5KGB06"
+          ]
+        },
+        {
+          "name": "Marron clair",
+          "hex": "8B4513",
+          "codes": [
+            "RO1.75PL0.5KGB31"
+          ]
+        },
+        {
+          "name": "Marron foncé",
+          "hex": "8B4513",
+          "codes": [
+            "RO1.75PL0.5KGB27"
+          ]
+        },
+        {
+          "name": "Naturel",
+          "hex": "F5DEB3",
+          "codes": [
+            "RO1.75PL0.5KGB00"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL0.5KGB10"
+          ]
+        },
+        {
+          "name": "Noir Bleuté",
+          "hex": "000000",
+          "codes": [
+            "RO1.75PL0.5KGB26"
+          ]
+        },
+        {
+          "name": "Orange Fluo",
+          "hex": "FFA500",
+          "codes": [
+            "RO1.75PL0.5KGB25"
+          ]
+        },
+        {
+          "name": "Rouge",
+          "hex": "FF0000",
+          "codes": [
+            "RO1.75PL0.5KGB12"
+          ]
+        },
+        {
+          "name": "Vert Fluo",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB24"
+          ]
+        },
+        {
+          "name": "Vert Mai",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB16"
+          ]
+        },
+        {
+          "name": "Vert Militaire",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB42"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "800080",
+          "codes": [
+            "RO1.75PL0.5KGB18"
+          ]
+        },
+        {
+          "name": "beige nacré",
+          "hex": "F5F5DC",
+          "codes": [
+            "RO1.75PL0.5KGB37"
+          ]
+        },
+        {
+          "name": "bleu nacré",
+          "hex": "0000FF",
+          "codes": [
+            "RO1.75PL0.5KGB38"
+          ]
+        },
+        {
+          "name": "vert nacré",
+          "hex": "00FF00",
+          "codes": [
+            "RO1.75PL0.5KGB36"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    },
+    {
+      "name": "PLA Standard 2.85mm {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 10000
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "country_of_origin": "France",
+      "colors": [
+        {
+          "name": "Blanc",
+          "hex": "FFFFFF",
+          "codes": [
+            "RO3.00PL10KGB11"
+          ]
+        },
+        {
+          "name": "Noir",
+          "hex": "000000",
+          "codes": [
+            "RO3.00PL10KGB10"
+          ]
+        }
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ]
+    }
+  ]
+}

--- a/filaments/sovol.json
+++ b/filaments/sovol.json
@@ -1,0 +1,134 @@
+{
+  "manufacturer": "Sovol",
+  "filaments": [
+    {
+      "name": "Sovol PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        }
+      ]
+    },
+    {
+      "name": "Sovol PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Sovol PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/sparta3d.json
+++ b/filaments/sparta3d.json
@@ -1,0 +1,167 @@
+{
+  "manufacturer": "Sparta3D",
+  "filaments": [
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Luminous Blue Glow In The Dark",
+          "hex": "7c97ac"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Metal",
+          "hex": "7a4a00"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "ABS+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        75,
+        75
+      ],
+      "colors": [
+        {
+          "name": "Cherry Red",
+          "hex": "5b0613",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Cloud Gray",
+          "hex": "6f7378",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Dirty Gold",
+          "hex": "bb8e11",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Elegant Teal",
+          "hex": "148a77",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Fluorescent Blue",
+          "hex": "415daa",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Fluorescent Red",
+          "hex": "ca5858",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Galaxy Black",
+          "hex": "000000",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Obsidian Black",
+          "hex": "000000",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Old Copper",
+          "hex": "976049",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Seafoam Blue",
+          "hex": "457a78",
+          "pattern": "sparkle"
+        },
+        {
+          "name": "Storm Gray",
+          "hex": "2f3235",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Obsidian Black",
+          "hex": "000000",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    }
+  ]
+}

--- a/filaments/spectrum.json
+++ b/filaments/spectrum.json
@@ -15,12 +15,444 @@
 			"diameters": [ 1.75 ],
 			"extruder_temp_range": [ 250, 270 ],
 			"bed_temp_range": [60, 100],
+            "colors": [
+                { "name": "Traffic Black", "hex": "000000" },
+                { "name": "Arctic White", "hex": "ffffff" },
+                { "name": "Sulfur Yellow", "hex": "ffff00" },
+                { "name": "Transparent Green", "hex": "00ff00" }
+            ]
+		},
+        {
+			"name": "PLA Premium {color_name}",
+			"material": "PLA",
+			"density": 1.24,
+			"weights": [
+                    {
+                        "weight": 250,
+                        "spool_weight": 120,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 250,
+                        "spool_weight": 80,
+                        "spool_type": "cardboard"
+                    },
+                    {
+                        "weight": 500,
+                        "spool_weight": 240,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 750,
+                        "spool_weight": 240,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 1000,
+                        "spool_weight": 260,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 1000,
+                        "spool_weight": 180,
+                        "spool_type": "cardboard"
+                    },
+                    {
+                        "weight": 2000,
+                        "spool_weight": 600,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 2000,
+                        "spool_weight": 420,
+                        "spool_type": "cardboard"
+                    },
+                    {
+                        "weight": 4500,
+                        "spool_weight": 780,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 8000,
+                        "spool_weight": 1020,
+                        "spool_type": "plastic"
+                    }
+                ],
+			"diameters": [ 1.75 ],
+			"extruder_temp_range": [ 185, 215 ],
+			"bed_temp_range": [0, 45],
+            "colors": [
+                    {
+                        "name": "Translucent",
+                        "hex": "d8dfbb"
+                    },
+                    {
+                        "name": "Natural",
+                        "hex": "f1dfb9"
+                    },
+                    {
+                        "name": "Polar White",
+                        "hex": "F4F4F4"
+                    },
+                    {
+                        "name": "Arctic White",
+                        "hex": "F6F6F6"
+                    },
+                    {
+                        "name": "Light Grey",
+                        "hex": "D7D7D7"
+                    },
+                    {
+                        "name": "Ivory Beige",
+                        "hex": "E6D2B5"
+                    },
+                    {
+                        "name": "Bahama Yellow",
+                        "hex": "F6D32D"
+                    },
+                    {
+                        "name": "Dahlia Yellow",
+                        "hex": "F39C12"
+                    },
+                    {
+                        "name": "Lion Orange",
+                        "hex": "FFF610"
+                    },
+                    {
+                        "name": "Carrot Orange",
+                        "hex": "E35B0E"
+                    },
+                    {
+                        "name": "Fluorescent Orange",
+                        "hex": "f89375"
+                    },
+                    {
+                        "name": "Fox Orange",
+                        "hex": "E66100"
+                    },
+                    {
+                        "name": "True Red",
+                        "hex": "c74038"
+                    },
+                    {
+                        "name": "Bloody Red",
+                        "hex": "CC0000"
+                    },
+                    {
+                        "name": "Dragon Red",
+                        "hex": "B50000"
+                    },
+                    {
+                        "name": "Cherry Red",
+                        "hex": "A00020"
+                    },
+                    {
+                        "name": "Magenta",
+                        "hex": "C71585"
+                    },
+                    {
+                        "name": "Pink Panther",
+                        "hex": "FA3E90"
+                    },
+                    {
+                        "name": "Signal Violet",
+                        "hex": "A349A4"
+                    },
+                    {
+                        "name": "Lavender Violet",
+                        "hex": "9677a4"
+                    },
+                    {
+                        "name": "Royal Blue",
+                        "hex": "8B008B"
+                    },
+                    {
+                        "name": "Navy Blue",
+                        "hex": "4B0082"
+                    },
+                    {
+                        "name": "Pigeon Blue",
+                        "hex": "003366"
+                    },
+                    {
+                        "name": "Pacific Blue",
+                        "hex": "6A7BA2"
+                    },
+                    {
+                        "name": "Baby Blue",
+                        "hex": "3C89DD"
+                    },
+                    {
+                        "name": "Blue Lagoon",
+                        "hex": "008080"
+                    },
+                    {
+                        "name": "Pastel Turquoise",
+                        "hex": "40E0D0"
+                    },
+                    {
+                        "name": "Caribbean Blue",
+                        "hex": "375667"
+                    },
+                    {
+                        "name": "Chrysocolla Green",
+                        "hex": "008B8B"
+                    },
+                    {
+                        "name": "Flipflop Green",
+                        "hex": "228B22"
+                    },
+                    {
+                        "name": "Forest Green",
+                        "hex": "228b22"
+                    },
+                    {
+                        "name": "Oregano Green",
+                        "hex": "006400"
+                    },
+                    {
+                        "name": "Fluorescent Green",
+                        "hex": "1BF53E"
+                    },
+                    {
+                        "name": "Lime Green",
+                        "hex": "94DE13"
+                    },
+                    {
+                        "name": "Fluorescent Yellow",
+                        "hex": "DEF64C"
+                    },
+                    {
+                        "name": "Military Khaki",
+                        "hex": "6B4F3F"
+                    },
+                    {
+                        "name": "Pearl Gold",
+                        "hex": "d7a655"
+                    },
+                    {
+                        "name": "Golden Line",
+                        "hex": "C49E4B"
+                    },
+                    {
+                        "name": "Rust Copper",
+                        "hex": "8B4513"
+                    },
+                    {
+                        "name": "Pearl Bronze",
+                        "hex": "674c30"
+                    },
+                    {
+                        "name": "Old Gold",
+                        "hex": "988856"
+                    },
+                    {
+                        "name": "Chocolate Brown",
+                        "hex": "4B2E2E"
+                    },
+                    {
+                        "name": "Wizard Charcoal",
+                        "hex": "443f44"
+                    },
+                    {
+                        "name": "Wizard Green",
+                        "hex": "464335"
+                    },
+                    {
+                        "name": "Wizard Indigo",
+                        "hex": "30302f"
+                    },
+                    {
+                        "name": "Silver Star",
+                        "hex": "8D8F91"
+                    },
+                    {
+                        "name": "Dark Grey",
+                        "hex": "555D61"
+                    },
+                    {
+                        "name": "Anthracite Grey",
+                        "hex": "45494c"
+                    },
+                    {
+                        "name": "Pearl Grey",
+                        "hex": "7D7F7D"
+                    },
+                    {
+                        "name": "Deep Black",
+                        "hex": "1C1C1C"
+                    }
+                ]
+		},
+        {
+			"name": "PLA Pro {color_name}",
+			"material": "PLA",
+			"density": 1.22,
+			"weights": [
+                    {
+                        "weight": 250,
+                        "spool_weight": 120,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 250,
+                        "spool_weight": 80,
+                        "spool_type": "cardboard"
+                    },
+                    {
+                        "weight": 500,
+                        "spool_weight": 240,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 750,
+                        "spool_weight": 240,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 1000,
+                        "spool_weight": 260,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 1000,
+                        "spool_weight": 180,
+                        "spool_type": "cardboard"
+                    },
+                    {
+                        "weight": 2000,
+                        "spool_weight": 600,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 2000,
+                        "spool_weight": 420,
+                        "spool_type": "cardboard"
+                    },
+                    {
+                        "weight": 4500,
+                        "spool_weight": 780,
+                        "spool_type": "plastic"
+                    },
+                    {
+                        "weight": 8000,
+                        "spool_weight": 1020,
+                        "spool_type": "plastic"
+                    }
+                ],
+			"diameters": [ 1.75 ],
+			"extruder_temp_range": [ 185, 230 ],
+			"bed_temp_range": [0, 45],
 			"colors": [
-        { "name": "Traffic Black", "hex": "000000" },
-        { "name": "Arctic White", "hex": "ffffff" },
-        { "name": "Sulfur Yellow", "hex": "ffff00" },
-        { "name": "Transparent Green", "hex": "00ff00" }
-      ]
+                    {
+                        "name": "arctic white",
+                        "hex": "f6f6f6"
+                    },
+                    {
+                        "name": "polar white",
+                        "hex": "f4f4f4"
+                    },
+                    {
+                        "name": "light grey",
+                        "hex": "d7d7d7"
+                    },
+                    {
+                        "name": "ivory beige",
+                        "hex": "e6d2b5"
+                    },
+                    {
+                        "name": "coral",
+                        "hex": "e1d2b9"
+                    },
+                    {
+                        "name": "bahama yellow",
+                        "hex": "f6d32d"
+                    },
+                    {
+                        "name": "lion orange",
+                        "hex": "fff610"
+                    },
+                    {
+                        "name": "carrot orange",
+                        "hex": "e35b0e"
+                    },
+                    {
+                        "name": "bloody red",
+                        "hex": "cc0000"
+                    },
+                    {
+                        "name": "dragon red",
+                        "hex": "b50000"
+                    },
+                    {
+                        "name": "magenta",
+                        "hex": "c71585"
+                    },
+                    {
+                        "name": "pink panther",
+                        "hex": "fa3e90"
+                    },
+                    {
+                        "name": "lavender violet",
+                        "hex": "9677a4"
+                    },
+                    {
+                        "name": "navy blue",
+                        "hex": "8b008b"
+                    },
+                    {
+                        "name": "pacific blue",
+                        "hex": "003366"
+                    },
+                    {
+                        "name": "blue lagoon",
+                        "hex": "0072b2"
+                    },
+                    {
+                        "name": "pastel turquoise",
+                        "hex": "40e0d0"
+                    },
+                    {
+                        "name": "forest green",
+                        "hex": "228b22"
+                    },
+                    {
+                        "name": "lime green",
+                        "hex": "94de33"
+                    },
+                    {
+                        "name": "military khaki",
+                        "hex": "6b4f3f"
+                    },
+                    {
+                        "name": "pearl bronze",
+                        "hex": "674c30"
+                    },
+                    {
+                        "name": "chocolate brown",
+                        "hex": "4b2e2e"
+                    },
+                    {
+                        "name": "rust copper",
+                        "hex": "8b4513"
+                    },
+                    {
+                        "name": "pearl gold",
+                        "hex": "d7a655"
+                    },
+                    {
+                        "name": "silver star",
+                        "hex": "656968"
+                    },
+                    {
+                        "name": "dark grey",
+                        "hex": "555d61"
+                    },
+                    {
+                        "name": "deep black",
+                        "hex": "1c1c1c"
+                    }
+                ]
 		},
       		{
 			"name": "The Filament {color_name}",

--- a/filaments/splice3d.json
+++ b/filaments/splice3d.json
@@ -1,0 +1,159 @@
+{
+  "manufacturer": "Splice3D",
+  "filaments": [
+    {
+      "name": "Hf {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0f0f0f"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "5041be"
+        },
+        {
+          "name": "Spring Green",
+          "hex": "81f57f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Aquamarine Blue",
+          "hex": "afe3df"
+        },
+        {
+          "name": "Autumn Orange",
+          "hex": "ee9a3a"
+        },
+        {
+          "name": "Black",
+          "hex": "0d0d0d"
+        },
+        {
+          "name": "Blue Lilac",
+          "hex": "ad9ccd"
+        },
+        {
+          "name": "Bubblegum Pink",
+          "hex": "e4aad7"
+        },
+        {
+          "name": "Caribbean Blue",
+          "hex": "026677"
+        },
+        {
+          "name": "Charcoal Gray",
+          "hex": "6c7277"
+        },
+        {
+          "name": "Chocolate Brown",
+          "hex": "472516"
+        },
+        {
+          "name": "Copper",
+          "hex": "bb5528"
+        },
+        {
+          "name": "Fluorescent Orange",
+          "hex": "f37133"
+        },
+        {
+          "name": "Hot Magenta",
+          "hex": "ec4999"
+        },
+        {
+          "name": "Industrial Gray",
+          "hex": "bdb7b9"
+        },
+        {
+          "name": "Industrial Grey",
+          "hex": "5a5955"
+        },
+        {
+          "name": "Jungle Green",
+          "hex": "36820d"
+        },
+        {
+          "name": "Lively Yellow",
+          "hex": "ffc122"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "003366"
+        },
+        {
+          "name": "Nutty Brown",
+          "hex": "9d370b"
+        },
+        {
+          "name": "Poppy Red",
+          "hex": "ea1a1a"
+        },
+        {
+          "name": "Ryobyte Green",
+          "hex": "d4e15d"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "4e9fe6"
+        },
+        {
+          "name": "Spring Green",
+          "hex": "00ff7f"
+        },
+        {
+          "name": "White",
+          "hex": "fafafa"
+        },
+        {
+          "name": "Zinc Yellow",
+          "hex": "f2ed64"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/spool3d.json
+++ b/filaments/spool3d.json
@@ -1,0 +1,389 @@
+{
+  "manufacturer": "SPOOL3D",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0057b8"
+        },
+        {
+          "name": "Orange, Dark",
+          "hex": "fe5000"
+        },
+        {
+          "name": "Red",
+          "hex": "d50032"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PA6-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "028db0"
+        },
+        {
+          "name": "Green",
+          "hex": "08cb74"
+        }
+      ]
+    },
+    {
+      "name": "Neon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        210
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Neon Blue",
+          "hex": "009ace"
+        },
+        {
+          "name": "Neon Green",
+          "hex": "44d62c"
+        },
+        {
+          "name": "Neon Orange",
+          "hex": "ffaa4d"
+        },
+        {
+          "name": "Neon Pink",
+          "hex": "ff3eb5"
+        },
+        {
+          "name": "Neon Purple",
+          "hex": "ea27c2"
+        },
+        {
+          "name": "Neon Red",
+          "hex": "ff7276"
+        },
+        {
+          "name": "Neon Yellow",
+          "hex": "ffe900"
+        }
+      ]
+    },
+    {
+      "name": "PETG Matte {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black, Matte",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black 1.75mm",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "55bd00"
+        },
+        {
+          "name": "Orange, Dark",
+          "hex": "fe5000"
+        },
+        {
+          "name": "Pink",
+          "hex": "f04e98"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fce300"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "aa6b4a"
+        },
+        {
+          "name": "Gold",
+          "hex": "debf6f"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "3668b3"
+        },
+        {
+          "name": "Silver",
+          "hex": "abb5be"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Black 1.75mm 4.5kg",
+          "hex": "000305"
+        },
+        {
+          "name": "Blue",
+          "hex": "0057b8"
+        },
+        {
+          "name": "Blue 1.75mm",
+          "hex": "051594"
+        },
+        {
+          "name": "Dark Orange",
+          "hex": "fe5000"
+        },
+        {
+          "name": "Gold",
+          "hex": "8b6f4e"
+        },
+        {
+          "name": "Green",
+          "hex": "00b140"
+        },
+        {
+          "name": "Grey",
+          "hex": "7c868e"
+        },
+        {
+          "name": "Grey, Dark",
+          "hex": "54585a"
+        },
+        {
+          "name": "Grey, Light",
+          "hex": "d0d3d4"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8f1c"
+        },
+        {
+          "name": "Pastel Green",
+          "hex": "9de7d7"
+        },
+        {
+          "name": "Pastel Purple",
+          "hex": "bf9bde"
+        },
+        {
+          "name": "Red",
+          "hex": "d50032"
+        },
+        {
+          "name": "Red 1.75mm",
+          "hex": "fa0032"
+        },
+        {
+          "name": "Silver",
+          "hex": "8a8d8f"
+        },
+        {
+          "name": "Translucent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "fcfdfd"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fce300"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000305"
+        },
+        {
+          "name": "Red",
+          "hex": "fa0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/starplast.json
+++ b/filaments/starplast.json
@@ -1,0 +1,255 @@
+{
+  "manufacturer": "StarPlast",
+  "filaments": [
+    {
+      "name": "PETG Silk {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00007f"
+        },
+        {
+          "name": "Green",
+          "hex": "007a00"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Ruby",
+          "hex": "51262f"
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "4f8ac4"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Alluminium",
+          "hex": "606060"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "9e9e9e"
+        },
+        {
+          "name": "Orange",
+          "hex": "d9865f"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        225
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Aluminum",
+          "hex": "5e5c64"
+        },
+        {
+          "name": "beige",
+          "hex": "ded4ba"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Brown",
+          "hex": "aa5500"
+        },
+        {
+          "name": "Gray",
+          "hex": "969696"
+        },
+        {
+          "name": "Green",
+          "hex": "00aa00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffaa00"
+        },
+        {
+          "name": "Red",
+          "hex": "aa0000"
+        },
+        {
+          "name": "Turquoise",
+          "hex": "55ffff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Коричневый",
+          "hex": "804000"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Coral - Violet - Turquoise",
+          "hex": "f769ca"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "ff7800"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "00478f"
+        },
+        {
+          "name": "Ruby",
+          "hex": "9b111e"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/stlflix.json
+++ b/filaments/stlflix.json
@@ -1,0 +1,320 @@
+{
+  "manufacturer": "STLFLIX",
+  "filaments": [
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "ROSA",
+          "hex": "ffcbdb"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Azul",
+          "hex": "2171f2"
+        },
+        {
+          "name": "BEGE",
+          "hex": "ede8d0"
+        },
+        {
+          "name": "BRANCO",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Café com Leite",
+          "hex": "dcc79e"
+        },
+        {
+          "name": "Cinza Fosco",
+          "hex": "6a666a"
+        },
+        {
+          "name": "Coffee with Milk",
+          "hex": "7d583b"
+        },
+        {
+          "name": "Grey",
+          "hex": "898989"
+        },
+        {
+          "name": "Lavender",
+          "hex": "cb94f7"
+        },
+        {
+          "name": "LILÁS",
+          "hex": "915ff0"
+        },
+        {
+          "name": "PRETO MATTE",
+          "hex": "000000"
+        },
+        {
+          "name": "ROSA",
+          "hex": "f2b8c6"
+        },
+        {
+          "name": "VERDE",
+          "hex": "008000"
+        },
+        {
+          "name": "Verde Escuro",
+          "hex": "495844"
+        },
+        {
+          "name": "VERDE MENTA",
+          "hex": "b3ebf2"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "833302"
+        },
+        {
+          "name": "Copper",
+          "hex": "b83900"
+        },
+        {
+          "name": "DOURADO/GOLDEN",
+          "hex": "cdcf4f"
+        },
+        {
+          "name": "Pink Rose",
+          "hex": "e63b7a"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        195
+      ],
+      "colors": [
+        {
+          "name": "Azul Claro",
+          "hex": "b6efef"
+        },
+        {
+          "name": "Azul Esverdeado",
+          "hex": "1fa1c1"
+        },
+        {
+          "name": "Beige",
+          "hex": "f2d4c0"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0115ac"
+        },
+        {
+          "name": "Ciano",
+          "hex": "b6efef"
+        },
+        {
+          "name": "Dark Brown",
+          "hex": "61483f"
+        },
+        {
+          "name": "Gray",
+          "hex": "35393b"
+        },
+        {
+          "name": "Green",
+          "hex": "34bb52"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "00c7fc"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "f7bbd5"
+        },
+        {
+          "name": "Mármore Branco",
+          "hex": "f4f4f4"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8647"
+        },
+        {
+          "name": "Purple",
+          "hex": "862b7f"
+        },
+        {
+          "name": "Red",
+          "hex": "ea1f29"
+        },
+        {
+          "name": "Verde Escuro",
+          "hex": "788600"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fffc41"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue/Purple",
+          "hexes": [
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue/Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green/Blue",
+          "hexes": [
+            "008000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green/Yellow",
+          "hexes": [
+            "008000",
+            "ffff00"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Purple and Gold",
+          "hex": "874efe"
+        },
+        {
+          "name": "Purple/Gold",
+          "hexes": [
+            "800080",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red/Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/stronghero3d.json
+++ b/filaments/stronghero3d.json
@@ -1,0 +1,36 @@
+{
+    "manufacturer": "Stronghero3D",
+    "filaments": [
+        {
+            "name": "Stronghero3D Silk PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 210,
+            "bed_temp": 50,
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -64,7 +64,7 @@
                     "hex": "942192"
                 },
                 {
-                    "name": "Gray",
+                    "name": "Grey",
                     "hex": "808080"
                 },
                 {
@@ -162,7 +162,7 @@
                     "hex": "0000FF"
                 },
                 {
-                    "name": "Gray",
+                    "name": "Grey",
                     "hex": "808080"
                 },
                 {
@@ -208,6 +208,76 @@
                 {
                     "name": "Burgundy",
                     "hex": "3F2028"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU-95A",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 130,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Grey",
+                    "hex": "6C6C6C"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Red",
+                    "hex": "C51E25"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FB6D23"
+                }
+            ]
+        },
+        {
+            "name": "Transparent {color_name}",
+            "material": "TPU-95A",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 130,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 220,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "03BC4F"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FB6D23"
                 }
             ]
         },
@@ -284,6 +354,11 @@
                 {
                     "name": "Sunny Orange",
                     "hex": "D8631E"
+                },
+                {
+                    "name": "Clear",
+                    "hex": "ffffffaa",
+                    "translucent": true
                 }
             ]
         },
@@ -337,7 +412,7 @@
                     "hex": "942192"
                 },
                 {
-                    "name": "Gray",
+                    "name": "Grey",
                     "hex": "808080"
                 },
                 {
@@ -378,6 +453,47 @@
             ]
         },
         {
+            "name": "High Speed Matte PLA - {color_name}",
+            "material": "PLA",
+            "density": 1.26,
+            "finish": "matte",
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 220,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                260
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                { "name": "Black", "hex": "000000" },
+                { "name": "White", "hex": "ffffff" },
+                { "name": "Cherry Red", "hex": "e86b6e" },
+                { "name": "Chocolate", "hex": "b0521b" },
+                { "name": "Grey", "hex": "666c73" },
+                { "name": "Lemon Yellow", "hex": "fef966" },
+                { "name": "Mint Green", "hex": "a8d5ba" },
+                { "name": "Olive Green", "hex": "46792a" },
+                { "name": "Sakura Pink", "hex": "e3b5d9" },
+                { "name": "Sky Blue", "hex": "0cb7cc" },
+                { "name": "Sunny Orange", "hex": "ff7235" },
+                { "name": "CMYK Cyan", "hex": "88bfff" },
+                { "name": "CMYK Magenta", "hex": "da63c4" },
+                { "name": "CMYK White", "hex": "ffffff" },
+                { "name": "CMYK Yellow", "hex": "fef966" }
+            ]
+        },
+        {
             "name": "High Speed Matte PETG - {color_name}",
             "material": "PETG",
             "density": 1.26,
@@ -412,7 +528,7 @@
                 { "name": "Black", "hex": "151616" },
                 { "name": "Olive Green", "hex": "64794b" },
                 { "name": "Orange", "hex": "f55f35" },
-                { "name": "Red", "hex": "c72c2f" }                
+                { "name": "Red", "hex": "c72c2f" }
             ]
         },
         {
@@ -492,6 +608,121 @@
                     "hex": "564e44"
                 }
             ]
+        },
+        {
+            "name": "Silk Dual Color {color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 130,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 215,
+            "bed_temp": 55,
+            "finish": "glossy",
+            "multi_color_direction": "coaxial",
+            "colors": [
+                {
+                    "name": "Black Blue",
+                    "hexes": [
+                        "0F1217",
+                        "002789"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Meta {color_name}",
+            "material": "PLA",
+            "density": 1.22,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_weight": 130.0,
+                    "spool_type": "plastic"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                185,
+                225
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "75787B"
+                },
+                {
+                    "name": "Cherry Red",
+                    "hex": "ED374D"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "0AB4E5"
+                },
+                {
+                    "name": "Lemon Yellow",
+                    "hex": "FBF9AF"
+                },
+                {
+                    "name": "Mint Green",
+                    "hex": "03CCB5"
+                },
+                {
+                    "name": "Sakura Pink",
+                    "hex": "FDD4DE"
+                },
+                {
+                    "name": "Chocolate",
+                    "hex": "895A4E"
+                },
+                {
+                    "name": "Taro Purple",
+                    "hex": "AF98DF"
+                },
+                {
+                    "name": "Cream White",
+                    "hex": "EEE7D4"
+                },
+                {
+                    "name": "Apple Green",
+                    "hex": "A9EAA7"
+                },
+                {
+                    "name": "Ice Blue",
+                    "hex": "9FECF7"
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "5A6D3D"
+                },
+                {
+                    "name": "Sunny Orange",
+                    "hex": "FC8B4C"
+                }
+            ]
         }
     ]
 }
+

--- a/filaments/superfilament.json
+++ b/filaments/superfilament.json
@@ -1,0 +1,257 @@
+{
+  "manufacturer": "Super-Filament",
+  "filaments": [
+    {
+      "name": "PLA PRO (Standard) {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        { "name": "Black", "hex": "000000" },
+        { "name": "Gray", "hex": "7f7f7f" },
+        { "name": "Brown", "hex": "b97a57" },
+        { "name": "Olive", "hex": "9e9e5a" },
+        { "name": "Copper", "hex": "de9191" },
+        { "name": "Bronze", "hex": "a15d3d" },
+        { "name": "Gold", "hex": "ffc90e" },
+        { "name": "Yellow", "hex": "fff200" },
+        { "name": "Orange", "hex": "ff7f27" },
+        { "name": "Red", "hex": "ed1c24" },
+        { "name": "Pink", "hex": "f77bf7" },
+        { "name": "Violet", "hex": "7f00ff" },
+        { "name": "Blue", "hex": "005fe8" },
+        { "name": "Turquoise", "hex": "00a2e8" },
+        { "name": "Green", "hex": "22b14c" },
+        { "name": "Beige", "hex": "efe4b0" },
+        { "name": "White", "hex": "f6f6f6" },
+        { "name": "Natural", "hex": "f2f2f2" },
+        { "name": "Transparent", "hex": "f6f6f6" }
+      ]
+    },
+    {
+      "name": "PLA PRO+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        { "name": "Black", "hex": "000000" },
+        { "name": "Gray", "hex": "7f7f7f" },
+        { "name": "Yellow", "hex": "fff200" },
+        { "name": "Orange", "hex": "ff7f27" },
+        { "name": "Red", "hex": "ed1c24" },
+        { "name": "Blue", "hex": "005fe8" },
+        { "name": "Sky Blue", "hex": "0060e8" },
+        { "name": "Green", "hex": "22b14c" },
+        { "name": "White", "hex": "f6f6f6" }
+      ]
+    },
+    {
+      "name": "PLA PRO Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "finish": "matte",
+      "colors": [
+        { "name": "Black", "hex": "000000" },
+        { "name": "Orange", "hex": "ff7f27" },
+        { "name": "Red", "hex": "ed1c24" },
+        { "name": "Blue", "hex": "005fe8" },
+        { "name": "Green", "hex": "22b14c" },
+        { "name": "White", "hex": "f6f6f6" }
+      ]
+    },
+    {
+      "name": "PLA PRO Carbon {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "fill": "carbon fiber",
+      "colors": [
+        { "name": "Black", "hex": "000000" }
+      ]
+    },
+    {
+      "name": "PLA PRO Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "fill": "wood",
+      "colors": [
+        { "name": "Ivory", "hex": "dd9268" },
+        { "name": "Natural", "hex": "de9268" },
+        { "name": "Walnut", "hex": "444041" }
+      ]
+    },
+    {
+      "name": "PLA PRO Glow in the Dark {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "glow": true,
+      "colors": [
+        { "name": "Glow in the Dark", "hex": "01311c" }
+      ]
+    },
+    {
+      "name": "PLA PRO Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "pattern": "sparkle",
+      "colors": [
+        { "name": "Black", "hex": "000000" },
+        { "name": "Silver", "hex": "616161" },
+        { "name": "Blue", "hex": "005fe8" },
+        { "name": "Gold", "hex": "ffc90e" },
+        { "name": "Green", "hex": "22b14c" }
+      ]
+    },
+    {
+      "name": "PLA PRO Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "finish": "glossy",
+      "colors": [
+        { "name": "Silver", "hex": "616161" },
+        { "name": "Bronze", "hex": "a15d3d" },
+        { "name": "Copper", "hex": "de9191" },
+        { "name": "Green", "hex": "22b14c" },
+        { "name": "Pink", "hex": "f77bf7" },
+        { "name": "Gold", "hex": "ffc90e" },
+        { "name": "Blue", "hex": "005fe8" },
+        { "name": "White", "hex": "f6f6f6" },
+        { "name": "Rose", "hex": "ffaec9" },
+        { "name": "Red", "hex": "ed1c24" },
+        { "name": "Yellow", "hex": "fff200" }
+      ]
+    },
+    {
+      "name": "PLA PRO Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        { "weight": 1000.0 }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "pattern": "marble",
+      "colors": [
+        { "name": "Marble / Stone", "hex": "c3c3c3" }
+      ]
+    }
+  ]
+}

--- a/filaments/tagin3d.json
+++ b/filaments/tagin3d.json
@@ -1,0 +1,71 @@
+{
+  "manufacturer": "TAGin3D",
+  "filaments": [
+    {
+      "name": "TAGin3D PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 220],
+      "bed_temp_range": [40, 60],
+      "colors": [
+        {"name": "Black", "hex": "121212"},
+        {"name": "White", "hex": "F9F9F9"},
+        {"name": "Grey", "hex": "8A8A8A"},
+        {"name": "Red", "hex": "D31D1D"},
+        {"name": "Blue", "hex": "1D52D3"},
+        {"name": "Green", "hex": "1DD352"},
+        {"name": "Yellow", "hex": "D3D31D"}
+      ]
+    },
+    {
+      "name": "TAGin3D PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [70, 90],
+      "colors": [
+        {"name": "Black", "hex": "151515"},
+        {"name": "White", "hex": "FAFAFA"},
+        {"name": "Red", "hex": "C51A1A"},
+        {"name": "Blue", "hex": "1A4FC5"},
+        {"name": "Clear", "hex": "FFFFFF80"}
+      ]
+    },
+    {
+      "name": "TAGin3D ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 200,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 260],
+      "bed_temp_range": [90, 110],
+      "colors": [
+        {"name": "Black", "hex": "1A1A1A"},
+        {"name": "White", "hex": "FDFDFD"},
+        {"name": "Grey", "hex": "7E7E7E"}
+      ]
+    }
+  ]
+}

--- a/filaments/tecbears.json
+++ b/filaments/tecbears.json
@@ -1,0 +1,157 @@
+{
+  "manufacturer": "Tecbears",
+  "filaments": [
+    {
+      "name": "Tecbears PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a1b9a"
+        },
+        {
+          "name": "Pink",
+          "hex": "f48fb1"
+        }
+      ]
+    },
+    {
+      "name": "Tecbears PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Tecbears PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 230,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/tecor.json
+++ b/filaments/tecor.json
@@ -1,0 +1,842 @@
+{
+  "manufacturer": "TECOR",
+  "filaments": [
+    {
+      "name": "2 0 {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        235
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8040"
+        },
+        {
+          "name": "Red",
+          "hex": "e01b24"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9d243"
+        }
+      ]
+    },
+    {
+      "name": "95A Hf {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "454545"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Paper White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        105
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Temp {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow (Blue Green)",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Color Change Uv {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow Noctilucent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Fluorescent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Hot Pink",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Noctilucent Red",
+          "hex": "f82e27"
+        }
+      ]
+    },
+    {
+      "name": "HIPS {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "High Speed Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Storm Marble",
+          "hex": "9da4aa"
+        }
+      ]
+    },
+    {
+      "name": "Magic {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Sparkling Metallic Holographic Magic Pro Green",
+          "hex": "396552"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "c5c6d0",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 250
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Coffee",
+          "hex": "a25e0a"
+        },
+        {
+          "name": "Green",
+          "hex": "54bd65"
+        },
+        {
+          "name": "Grey",
+          "hex": "797b7c"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8040"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9d243"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "5a1c00"
+        },
+        {
+          "name": "Green",
+          "hex": "093e31"
+        },
+        {
+          "name": "Metal Like Aluminum",
+          "hex": "87919a"
+        },
+        {
+          "name": "Noctilucent Blue",
+          "hex": "21a1de"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        215,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Milky Green",
+          "hex": "bed6b2"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Brass",
+          "hex": "f1a050"
+        },
+        {
+          "name": "Red Copper",
+          "hex": "cb6d51"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "0a0a0a"
+        },
+        {
+          "name": "Blue",
+          "hex": "198bf9"
+        },
+        {
+          "name": "Bone White",
+          "hex": "e9d4b5"
+        },
+        {
+          "name": "Coffee",
+          "hex": "7a4a00"
+        },
+        {
+          "name": "Dark Purple",
+          "hex": "382565"
+        },
+        {
+          "name": "Forest Green",
+          "hex": "173904"
+        },
+        {
+          "name": "Fuchsia",
+          "hex": "e230b6"
+        },
+        {
+          "name": "Gray",
+          "hex": "6a6c6e"
+        },
+        {
+          "name": "Green",
+          "hex": "54bd65"
+        },
+        {
+          "name": "Lemon Yellow",
+          "hex": "fff44f"
+        },
+        {
+          "name": "Purple",
+          "hex": "8300b3"
+        },
+        {
+          "name": "Red",
+          "hex": "e01b24"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "fed2da"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Rainbow 04",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink Gold",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Sparkle {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Twinkle Blue",
+          "hex": "a9e1ff",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "111be3"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "e8b0d1"
+        },
+        {
+          "name": "Red",
+          "hex": "b50e20"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PVA",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "ffffc5"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "f0f2f5"
+        },
+        {
+          "name": "Red",
+          "hex": "e01b24"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/tecsonar.json
+++ b/filaments/tecsonar.json
@@ -1,0 +1,343 @@
+{
+  "manufacturer": "TECSONAR",
+  "filaments": [
+    {
+      "name": "85A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Chameleon {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Chameleon Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Purple",
+          "hex": "18001e"
+        }
+      ]
+    },
+    {
+      "name": "Matte Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red Blue",
+          "hex": "c80f0f"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Brown",
+          "hex": "60bafb"
+        },
+        {
+          "name": "Blue Red",
+          "hex": "6abcf6"
+        },
+        {
+          "name": "Blue White",
+          "hex": "38acff"
+        },
+        {
+          "name": "Green Brown",
+          "hex": "7da456"
+        },
+        {
+          "name": "Lollipop",
+          "hex": "00f5d8"
+        },
+        {
+          "name": "Purple Green",
+          "hex": "8ff788"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "7affa2"
+        },
+        {
+          "name": "Red Coral",
+          "hex": "ed66ff"
+        },
+        {
+          "name": "Red Orange",
+          "hex": "f6313b"
+        },
+        {
+          "name": "Yellow/Green",
+          "hexes": [
+            "ffff00",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Crystal Rainbow",
+          "hex": "9b86ff"
+        },
+        {
+          "name": "Crystal Rainbow White Green",
+          "hex": "ededed"
+        },
+        {
+          "name": "Ice Cream Color 1",
+          "hex": "dac1ac"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silk Blue, Silk Rose Red",
+          "hex": "7dc1f2"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Fairy Tale",
+          "hex": "f3d865"
+        },
+        {
+          "name": "green yellow blue",
+          "hex": "76d2e5"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Blue-Orange-Green",
+          "hex": "016ebc"
+        },
+        {
+          "name": "Copper/Purple/Green",
+          "hexes": [
+            "808080",
+            "800080",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold/Copper/Black",
+          "hexes": [
+            "ffd700",
+            "808080",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold/Copper/Blue",
+          "hexes": [
+            "ffd700",
+            "808080",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green Purple Copper",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Red-Purple-Gold",
+          "hex": "bc2f36"
+        },
+        {
+          "name": "Red-Yellow-Blue",
+          "hex": "b91313"
+        },
+        {
+          "name": "TriColor",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/tectonic3d.json
+++ b/filaments/tectonic3d.json
@@ -1,0 +1,166 @@
+{
+  "manufacturer": "Tectonic 3D",
+  "filaments": [
+    {
+      "name": "Aura ASA+ {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2300,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "ffffff",
+          "translucent": true
+        },
+        {
+          "name": "Graphite Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Traffic White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Bronze Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "d3d3d3"
+        },
+        {
+          "name": "Signal Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "NATO Green",
+          "hex": "2d3e2d"
+        }
+      ],
+      "country_of_origin": "Netherlands"
+    },
+    {
+      "name": "Kratir PET CF {color_name}",
+      "material": "PET-CF",
+      "density": 1.4,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2300,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        260,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ],
+      "country_of_origin": "Netherlands"
+    },
+    {
+      "name": "Kratir PA6/66 CF {color_name}",
+      "material": "PA-CF",
+      "density": 1.17,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2300,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        260,
+        300
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ],
+      "country_of_origin": "Netherlands"
+    },
+    {
+      "name": "Zephyr PA11 CF MC {color_name}",
+      "material": "PA11-CF",
+      "density": 0.85,
+      "weights": [
+        {
+          "weight": 750,
+          "spool_type": "plastic"
+        },
+        {
+          "weight": 2300,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75,
+        2.85
+      ],
+      "extruder_temp_range": [
+        250,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "101010"
+        }
+      ],
+      "country_of_origin": "Netherlands"
+    }
+  ]
+}

--- a/filaments/teqstone.json
+++ b/filaments/teqstone.json
@@ -1,0 +1,648 @@
+{
+    "manufacturer": "TEQStone",
+    "filaments": [
+        {
+            "name": "PLA Basic {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Beige (Bone White)",
+                    "hex": "E8DCC8"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "6B4423"
+                },
+                {
+                    "name": "Clear",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "Cyan (Water Blue)",
+                    "hex": "00AEEF"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF69B4"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "7B2D8E"
+                }
+            ]
+        },
+        {
+            "name": "Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                225
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Blue (Royal)",
+                    "hex": "0047AB"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                },
+                {
+                    "name": "Dark Purple",
+                    "hex": "4B0082"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "D4AF37"
+                },
+                {
+                    "name": "Green",
+                    "hex": "228B22"
+                },
+                {
+                    "name": "Pink (Magenta)",
+                    "hex": "FF00FF"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Multicolor",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "FF0000",
+                        "FF7F00",
+                        "FFFF00",
+                        "00FF00",
+                        "0000FF",
+                        "4B0082"
+                    ]
+                },
+                {
+                    "name": "Multicolor (Pastel)",
+                    "multi_color_direction": "longitudinal",
+                    "hexes": [
+                        "FFB6C1",
+                        "FFDAB9",
+                        "FFFACD",
+                        "98FB98",
+                        "ADD8E6",
+                        "DDA0DD"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Dual Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                225
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial",
+            "colors": [
+                {
+                    "name": "Black & Red",
+                    "hexes": [
+                        "000000",
+                        "CC0000"
+                    ]
+                },
+                {
+                    "name": "Blue & Green",
+                    "hexes": [
+                        "0047AB",
+                        "228B22"
+                    ]
+                },
+                {
+                    "name": "Gold & Copper",
+                    "hexes": [
+                        "D4AF37",
+                        "B87333"
+                    ]
+                },
+                {
+                    "name": "Gold & Purple",
+                    "hexes": [
+                        "D4AF37",
+                        "7B2D8E"
+                    ]
+                },
+                {
+                    "name": "Green & Red",
+                    "hexes": [
+                        "228B22",
+                        "CC0000"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Tri Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                225
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "finish": "glossy",
+            "multi_color_direction": "coaxial",
+            "colors": [
+                {
+                    "name": "Blue Green Orange",
+                    "hexes": [
+                        "0047AB",
+                        "228B22",
+                        "FF6600"
+                    ]
+                },
+                {
+                    "name": "Blue Purple Black",
+                    "hexes": [
+                        "0047AB",
+                        "7B2D8E",
+                        "000000"
+                    ]
+                },
+                {
+                    "name": "Gold Purple Black",
+                    "hexes": [
+                        "D4AF37",
+                        "7B2D8E",
+                        "000000"
+                    ]
+                },
+                {
+                    "name": "Gold Purple Red",
+                    "hexes": [
+                        "D4AF37",
+                        "7B2D8E",
+                        "CC0000"
+                    ]
+                },
+                {
+                    "name": "Gold Silver Copper",
+                    "hexes": [
+                        "D4AF37",
+                        "C0C0C0",
+                        "B87333"
+                    ]
+                },
+                {
+                    "name": "Red Gold Black",
+                    "hexes": [
+                        "CC0000",
+                        "D4AF37",
+                        "000000"
+                    ]
+                },
+                {
+                    "name": "Red Green Blue",
+                    "hexes": [
+                        "CC0000",
+                        "228B22",
+                        "0047AB"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Glow {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "glow": true,
+            "colors": [
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF99",
+                    "glow": true
+                },
+                {
+                    "name": "Green",
+                    "hex": "ADFF2F",
+                    "glow": true
+                },
+                {
+                    "name": "Blue (Bright Blue)",
+                    "hex": "4FC3F7",
+                    "glow": true
+                },
+                {
+                    "name": "Purple (Bluish Purple)",
+                    "hex": "9B59B6",
+                    "glow": true
+                },
+                {
+                    "name": "Rose Red",
+                    "hex": "FF6B8A",
+                    "glow": true
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFAA00",
+                    "glow": true
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF69B4",
+                    "glow": true
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5",
+                    "glow": true
+                }
+            ]
+        },
+        {
+            "name": "Marble {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "pattern": "marble",
+            "colors": [
+                {
+                    "name": "Brown",
+                    "hex": "8B6914",
+                    "pattern": "marble"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080",
+                    "pattern": "marble"
+                }
+            ]
+        },
+        {
+            "name": "Wood PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "fill": "wood",
+            "colors": [
+                {
+                    "name": "Brown",
+                    "hex": "8B5A2B"
+                },
+                {
+                    "name": "Walnut",
+                    "hex": "5C4033"
+                }
+            ]
+        },
+        {
+            "name": "PLA-CF {color_name}",
+            "material": "PLA-CF",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "fill": "carbon fiber",
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                }
+            ]
+        },
+        {
+            "name": "PETG {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                60,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Apple Green",
+                    "hex": "8DB600"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "6B4423"
+                },
+                {
+                    "name": "Cyan (Water Blue)",
+                    "hex": "00AEEF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "228B22"
+                },
+                {
+                    "name": "Light Skin",
+                    "hex": "FFDAB9"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF69B4"
+                }
+            ]
+        },
+        {
+            "name": "Metallic PETG {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                60,
+                100
+            ],
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Metallic Blue",
+                    "hex": "1E4D8C"
+                },
+                {
+                    "name": "Metallic Brown",
+                    "hex": "8B5A2B"
+                },
+                {
+                    "name": "Metallic Pink",
+                    "hex": "C71585"
+                },
+                {
+                    "name": "Metallic Silver",
+                    "hex": "A8A9AD"
+                }
+            ]
+        },
+        {
+            "name": "ABS {color_name}",
+            "material": "ABS",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                250
+            ],
+            "bed_temp_range": [
+                100,
+                120
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "ASA {color_name}",
+            "material": "ASA",
+            "density": 1.05,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                260,
+                280
+            ],
+            "bed_temp_range": [
+                90,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "228B22"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "7B2D8E"
+                }
+            ]
+        },
+        {
+            "name": "TPU 95A {color_name}",
+            "material": "TPU-95A",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Clear",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "Blue (Translucent)",
+                    "hex": "0066CC",
+                    "translucent": true
+                },
+                {
+                    "name": "Red (Translucent)",
+                    "hex": "CC0000",
+                    "translucent": true
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/thefilament.json
+++ b/filaments/thefilament.json
@@ -1,0 +1,3070 @@
+{
+  "manufacturer": "The Filament",
+  "filaments": [
+    {
+      "name": "ASA CF {color_name}",
+      "material": "ASA-CF",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        270
+      ],
+      "bed_temp_range": [
+        75,
+        100
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24215"
+          ],
+          "eans": [
+            "5907138401875"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24216"
+          ],
+          "eans": [
+            "5907138401882"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24121"
+          ],
+          "eans": [
+            "5907138401929"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24120"
+          ],
+          "eans": [
+            "5907138401912"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24217"
+          ],
+          "eans": [
+            "5907138401899"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        265
+      ],
+      "bed_temp_range": [
+        75,
+        100
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Grass Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24211"
+          ],
+          "eans": [
+            "5907138401714"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24214"
+          ],
+          "eans": [
+            "5907138401745"
+          ]
+        },
+        {
+          "name": "Pure Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24210"
+          ],
+          "eans": [
+            "5907138401707"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24212"
+          ],
+          "eans": [
+            "5907138401721"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24213"
+          ],
+          "eans": [
+            "5907138401738"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24209"
+          ],
+          "eans": [
+            "5907138401684"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        265
+      ],
+      "bed_temp_range": [
+        75,
+        100
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24194"
+          ],
+          "eans": [
+            "5907138401943"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24195"
+          ],
+          "eans": [
+            "5907138401950"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "HT-PLA {color_name}",
+      "material": "PLA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Camel Beige",
+          "hex": "F5F5DC",
+          "codes": [
+            "TF-24142"
+          ],
+          "eans": [
+            "5907138401820"
+          ]
+        },
+        {
+          "name": "Cobalt Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24138"
+          ],
+          "eans": [
+            "5907138401769"
+          ]
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24140"
+          ],
+          "eans": [
+            "5907138401783"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24143"
+          ],
+          "eans": [
+            "5907138401851"
+          ]
+        },
+        {
+          "name": "Light Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24141"
+          ],
+          "eans": [
+            "5907138401790"
+          ]
+        },
+        {
+          "name": "Tooling Dark Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24255"
+          ],
+          "eans": [
+            "5904433781701"
+          ]
+        },
+        {
+          "name": "Tooling Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24149"
+          ],
+          "eans": [
+            "5907138402605"
+          ]
+        },
+        {
+          "name": "Tooling Lime",
+          "hex": "808080",
+          "codes": [
+            "TF-24146"
+          ],
+          "eans": [
+            "5907138402568"
+          ]
+        },
+        {
+          "name": "Tooling Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24254"
+          ],
+          "eans": [
+            "5904433781695"
+          ]
+        },
+        {
+          "name": "Tooling Turquoise",
+          "hex": "40E0D0",
+          "codes": [
+            "TF-24148"
+          ],
+          "eans": [
+            "5907138402582"
+          ]
+        },
+        {
+          "name": "Tooling Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24144"
+          ],
+          "eans": [
+            "5907138401868"
+          ]
+        },
+        {
+          "name": "Vivid Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24139"
+          ],
+          "eans": [
+            "5907138401776"
+          ]
+        },
+        {
+          "name": "Warm White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24137"
+          ],
+          "eans": [
+            "5907138401752"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "HT-PLA {color_name}",
+      "material": "PLA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24196"
+          ],
+          "eans": [
+            "5907138402018"
+          ]
+        },
+        {
+          "name": "Warm White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24197"
+          ],
+          "eans": [
+            "5907138402025"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PETG CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.32,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        60,
+        75
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24108"
+          ],
+          "eans": [
+            "5907138401332"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24109"
+          ],
+          "eans": [
+            "5907138401349"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24113"
+          ],
+          "eans": [
+            "5907138401387"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24112"
+          ],
+          "eans": [
+            "5907138401370"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24111"
+          ],
+          "eans": [
+            "5907138401363"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24110"
+          ],
+          "eans": [
+            "5907138401356"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG Lite {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24245"
+          ],
+          "eans": [
+            "5907138404326"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24240"
+          ],
+          "eans": [
+            "5907138404289"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24243"
+          ],
+          "eans": [
+            "5907138404302"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24244"
+          ],
+          "eans": [
+            "5907138404319"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24239"
+          ],
+          "eans": [
+            "5907138404272"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24241"
+          ],
+          "eans": [
+            "5907138404258"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24238"
+          ],
+          "eans": [
+            "5907138404265"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24242"
+          ],
+          "eans": [
+            "5907138404296"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        60,
+        75
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Basalt Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24017"
+          ],
+          "eans": [
+            "5905991405214"
+          ]
+        },
+        {
+          "name": "Circuit Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24022"
+          ],
+          "eans": [
+            "5905991405269"
+          ]
+        },
+        {
+          "name": "Cloud Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24018"
+          ],
+          "eans": [
+            "5905991405221"
+          ]
+        },
+        {
+          "name": "Machinery Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24024"
+          ],
+          "eans": [
+            "5905991405283"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24015"
+          ],
+          "eans": [
+            "5905991405191"
+          ]
+        },
+        {
+          "name": "Performance Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24019"
+          ],
+          "eans": [
+            "5905991405238"
+          ]
+        },
+        {
+          "name": "Plasma Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24026"
+          ],
+          "eans": [
+            "5905991405306"
+          ]
+        },
+        {
+          "name": "Silver Aluminium",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24021"
+          ],
+          "eans": [
+            "5905991405252"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24016"
+          ],
+          "eans": [
+            "5905991405207"
+          ]
+        },
+        {
+          "name": "Sorbet Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24023"
+          ],
+          "eans": [
+            "5905991405276"
+          ]
+        },
+        {
+          "name": "Strawberry Pink",
+          "hex": "FFC0CB",
+          "codes": [
+            "TF-24025"
+          ],
+          "eans": [
+            "5905991405290"
+          ]
+        },
+        {
+          "name": "Technical Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24020"
+          ],
+          "eans": [
+            "5905991405245"
+          ]
+        },
+        {
+          "name": "Transparent Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24027"
+          ],
+          "eans": [
+            "5905991405313"
+          ]
+        },
+        {
+          "name": "Transparent Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24028"
+          ],
+          "eans": [
+            "5905991405320"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        60,
+        75
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24084"
+          ],
+          "eans": [
+            "5907138400922"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24085"
+          ],
+          "eans": [
+            "5907138400939"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        60,
+        75
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24090"
+          ],
+          "eans": [
+            "5907138400984"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24091"
+          ],
+          "eans": [
+            "5907138400991"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        55
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24094"
+          ],
+          "eans": [
+            "5907138401196"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24095"
+          ],
+          "eans": [
+            "5907138401202"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24100"
+          ],
+          "eans": [
+            "5907138401257"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24099"
+          ],
+          "eans": [
+            "5907138401240"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24098"
+          ],
+          "eans": [
+            "5907138401233"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24096"
+          ],
+          "eans": [
+            "5907138401219"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "800080",
+          "codes": [
+            "TF-24097"
+          ],
+          "eans": [
+            "5907138401226"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PLA HS {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        55
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Energy Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24035"
+          ],
+          "eans": [
+            "5905991405399"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24034"
+          ],
+          "eans": [
+            "5905991405382"
+          ]
+        },
+        {
+          "name": "Grid Beige",
+          "hex": "F5F5DC",
+          "codes": [
+            "TF-24038"
+          ],
+          "eans": [
+            "5905991405429"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24029"
+          ],
+          "eans": [
+            "5905991405337"
+          ]
+        },
+        {
+          "name": "Mirage Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24032"
+          ],
+          "eans": [
+            "5905991405368"
+          ]
+        },
+        {
+          "name": "Moss Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24039"
+          ],
+          "eans": [
+            "5905991405436"
+          ]
+        },
+        {
+          "name": "Moss Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24031"
+          ],
+          "eans": [
+            "5905991405351"
+          ]
+        },
+        {
+          "name": "Pure Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24037"
+          ],
+          "eans": [
+            "5905991405412"
+          ]
+        },
+        {
+          "name": "Quantum Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24040"
+          ],
+          "eans": [
+            "5905991405443"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24030"
+          ],
+          "eans": [
+            "5905991405344"
+          ]
+        },
+        {
+          "name": "Tuscany Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24036"
+          ],
+          "eans": [
+            "5905991405405"
+          ]
+        },
+        {
+          "name": "Winter Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24033"
+          ],
+          "eans": [
+            "5905991405375"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA Lite {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24224"
+          ],
+          "eans": [
+            "5907138403732"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24220"
+          ],
+          "eans": [
+            "5907138403695"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24222"
+          ],
+          "eans": [
+            "5907138403718"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24223"
+          ],
+          "eans": [
+            "5907138403725"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "FF00FF",
+          "codes": [
+            "TF-24233"
+          ],
+          "eans": [
+            "5907138413601"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24232"
+          ],
+          "eans": [
+            "5907138413595"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24219"
+          ],
+          "eans": [
+            "5907138403688"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24234"
+          ],
+          "eans": [
+            "5907138413618"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24218"
+          ],
+          "eans": [
+            "5907138403671"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24221"
+          ],
+          "eans": [
+            "5907138403701"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24200"
+          ],
+          "eans": [
+            "5907138401592"
+          ]
+        },
+        {
+          "name": "Camo Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24201"
+          ],
+          "eans": [
+            "5907138401608"
+          ]
+        },
+        {
+          "name": "Desert Beige",
+          "hex": "F5F5DC",
+          "codes": [
+            "TF-24202"
+          ],
+          "eans": [
+            "5907138401615"
+          ]
+        },
+        {
+          "name": "Jungle Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24203"
+          ],
+          "eans": [
+            "5907138401622"
+          ]
+        },
+        {
+          "name": "Military Olive",
+          "hex": "808080",
+          "codes": [
+            "TF-24199"
+          ],
+          "eans": [
+            "5907138401585"
+          ]
+        },
+        {
+          "name": "Night Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24205"
+          ],
+          "eans": [
+            "5907138401646"
+          ]
+        },
+        {
+          "name": "October Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24204"
+          ],
+          "eans": [
+            "5907138401639"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24198"
+          ],
+          "eans": [
+            "5907138401158"
+          ]
+        },
+        {
+          "name": "Stealth Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24208"
+          ],
+          "eans": [
+            "5907138401677"
+          ]
+        },
+        {
+          "name": "Trooper Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24206"
+          ],
+          "eans": [
+            "5907138401653"
+          ]
+        },
+        {
+          "name": "Urban Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24207"
+          ],
+          "eans": [
+            "5907138401660"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24193"
+          ],
+          "eans": [
+            "5907138401905"
+          ]
+        },
+        {
+          "name": "Stealth Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24192"
+          ],
+          "eans": [
+            "5907138401691"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Basalt Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24002"
+          ],
+          "eans": [
+            "5905991405092"
+          ]
+        },
+        {
+          "name": "Bison Brown",
+          "hex": "8B4513",
+          "codes": [
+            "TF-24010"
+          ],
+          "eans": [
+            "5907138400397"
+          ]
+        },
+        {
+          "name": "Circuit Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24007"
+          ],
+          "eans": [
+            "5905991405146"
+          ]
+        },
+        {
+          "name": "Cloud Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24003"
+          ],
+          "eans": [
+            "5905991405108"
+          ]
+        },
+        {
+          "name": "Machinery Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24012"
+          ],
+          "eans": [
+            "5905991405160"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24000"
+          ],
+          "eans": [
+            "5905991405078"
+          ]
+        },
+        {
+          "name": "Performance Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24004"
+          ],
+          "eans": [
+            "5905991405115"
+          ]
+        },
+        {
+          "name": "Plasma Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24014"
+          ],
+          "eans": [
+            "5905991405184"
+          ]
+        },
+        {
+          "name": "Silver Aluminium",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24006"
+          ],
+          "eans": [
+            "5905991405139"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24008"
+          ],
+          "eans": [
+            "5907138400373"
+          ]
+        },
+        {
+          "name": "Sorbet Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24011"
+          ],
+          "eans": [
+            "5905991405153"
+          ]
+        },
+        {
+          "name": "Strawberry Pink",
+          "hex": "FFC0CB",
+          "codes": [
+            "TF-24013"
+          ],
+          "eans": [
+            "5905991405177"
+          ]
+        },
+        {
+          "name": "Technical Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24005"
+          ],
+          "eans": [
+            "5905991405122"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24001"
+          ],
+          "eans": [
+            "5905991405085"
+          ]
+        },
+        {
+          "name": "Wood Ash",
+          "hex": "808080",
+          "codes": [
+            "TF-24009"
+          ],
+          "eans": [
+            "5907138400380"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 3000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24082"
+          ],
+          "eans": [
+            "5907138400908"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24083"
+          ],
+          "eans": [
+            "5907138400915"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 5000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24088"
+          ],
+          "eans": [
+            "5907138400960"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24089"
+          ],
+          "eans": [
+            "5907138400977"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ReFill ASA CF {color_name}",
+      "material": "ASA-CF",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        270
+      ],
+      "bed_temp_range": [
+        75,
+        100
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24174"
+          ],
+          "eans": [
+            "5907138402896"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24175"
+          ],
+          "eans": [
+            "5907138402902"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24178"
+          ],
+          "eans": [
+            "5907138402940"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24177"
+          ],
+          "eans": [
+            "5907138402933"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24176"
+          ],
+          "eans": [
+            "5907138402919"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "ReFill ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        265
+      ],
+      "bed_temp_range": [
+        75,
+        100
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Grass Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24170"
+          ],
+          "eans": [
+            "5907138402858"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24173"
+          ],
+          "eans": [
+            "5907138402889"
+          ]
+        },
+        {
+          "name": "Pure Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24169"
+          ],
+          "eans": [
+            "5907138402841"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24171"
+          ],
+          "eans": [
+            "5907138402865"
+          ]
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24172"
+          ],
+          "eans": [
+            "5907138402872"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24167"
+          ],
+          "eans": [
+            "5907138402827"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ReFill HT-PLA {color_name}",
+      "material": "PLA",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Camel Beige",
+          "hex": "F5F5DC",
+          "codes": [
+            "TF-24184"
+          ],
+          "eans": [
+            "5907138403268"
+          ]
+        },
+        {
+          "name": "Cobalt Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24180"
+          ],
+          "eans": [
+            "5907138403206"
+          ]
+        },
+        {
+          "name": "Dark Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24182"
+          ],
+          "eans": [
+            "5907138403220"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24185"
+          ],
+          "eans": [
+            "5907138403299"
+          ]
+        },
+        {
+          "name": "Light Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24183"
+          ],
+          "eans": [
+            "5907138403237"
+          ]
+        },
+        {
+          "name": "Tooling Dark Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24257"
+          ],
+          "eans": [
+            "5904433781718"
+          ]
+        },
+        {
+          "name": "Tooling Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24191"
+          ],
+          "eans": [
+            "5907138403367"
+          ]
+        },
+        {
+          "name": "Tooling Lime",
+          "hex": "808080",
+          "codes": [
+            "TF-24188"
+          ],
+          "eans": [
+            "5907138403329"
+          ]
+        },
+        {
+          "name": "Tooling Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24256"
+          ],
+          "eans": [
+            "5904433781725"
+          ]
+        },
+        {
+          "name": "Tooling Turquoise",
+          "hex": "40E0D0",
+          "codes": [
+            "TF-24190"
+          ],
+          "eans": [
+            "5907138403343"
+          ]
+        },
+        {
+          "name": "Tooling Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24186"
+          ],
+          "eans": [
+            "5907138403305"
+          ]
+        },
+        {
+          "name": "Vivid Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24181"
+          ],
+          "eans": [
+            "5907138403213"
+          ]
+        },
+        {
+          "name": "Warm White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24179"
+          ],
+          "eans": [
+            "5907138402643"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "ReFill PETG Lite {color_name}",
+      "material": "PETG",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24253"
+          ],
+          "eans": [
+            "5907138404401"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24248"
+          ],
+          "eans": [
+            "5907138404364"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24251"
+          ],
+          "eans": [
+            "5907138404388"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24252"
+          ],
+          "eans": [
+            "5907138404395"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24247"
+          ],
+          "eans": [
+            "5907138404357"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24249"
+          ],
+          "eans": [
+            "5907138404333"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24246"
+          ],
+          "eans": [
+            "5907138404340"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24250"
+          ],
+          "eans": [
+            "5907138404371"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ReFill PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        60,
+        75
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Basalt Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24058"
+          ],
+          "eans": [
+            "5905991406082"
+          ]
+        },
+        {
+          "name": "Cloud Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24059"
+          ],
+          "eans": [
+            "5905991406099"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24056"
+          ],
+          "eans": [
+            "5905991406068"
+          ]
+        },
+        {
+          "name": "Performance Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24060"
+          ],
+          "eans": [
+            "5905991406105"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24057"
+          ],
+          "eans": [
+            "5905991406075"
+          ]
+        },
+        {
+          "name": "Technical Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24061"
+          ],
+          "eans": [
+            "5905991406112"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ReFill PLA CF {color_name}",
+      "material": "PLA-CF",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        55
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24101"
+          ],
+          "eans": [
+            "5907138401264"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24102"
+          ],
+          "eans": [
+            "5907138401271"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24107"
+          ],
+          "eans": [
+            "5907138401325"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24106"
+          ],
+          "eans": [
+            "5907138401318"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24105"
+          ],
+          "eans": [
+            "5907138401301"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24103"
+          ],
+          "eans": [
+            "5907138401288"
+          ]
+        },
+        {
+          "name": "Violet",
+          "hex": "800080",
+          "codes": [
+            "TF-24104"
+          ],
+          "eans": [
+            "5907138401295"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "ReFill PLA HS {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        55
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Energy Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24076"
+          ],
+          "eans": [
+            "5905991406266"
+          ]
+        },
+        {
+          "name": "Fire Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24075"
+          ],
+          "eans": [
+            "5905991406259"
+          ]
+        },
+        {
+          "name": "Grid Beige",
+          "hex": "F5F5DC",
+          "codes": [
+            "TF-24079"
+          ],
+          "eans": [
+            "5905991406297"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24070"
+          ],
+          "eans": [
+            "5905991406204"
+          ]
+        },
+        {
+          "name": "Mirage Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24073"
+          ],
+          "eans": [
+            "5905991406235"
+          ]
+        },
+        {
+          "name": "Moss Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24080"
+          ],
+          "eans": [
+            "5905991406303"
+          ]
+        },
+        {
+          "name": "Moss Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24072"
+          ],
+          "eans": [
+            "5905991406228"
+          ]
+        },
+        {
+          "name": "Pure Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24078"
+          ],
+          "eans": [
+            "5905991406280"
+          ]
+        },
+        {
+          "name": "Quantum Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24081"
+          ],
+          "eans": [
+            "5905991406310"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24071"
+          ],
+          "eans": [
+            "5905991406211"
+          ]
+        },
+        {
+          "name": "Tuscany Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24077"
+          ],
+          "eans": [
+            "5905991406273"
+          ]
+        },
+        {
+          "name": "Winter Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24074"
+          ],
+          "eans": [
+            "5905991406242"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ReFill PLA Lite {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24231"
+          ],
+          "eans": [
+            "5907138403800"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24227"
+          ],
+          "eans": [
+            "5907138403763"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24229"
+          ],
+          "eans": [
+            "5907138403787"
+          ]
+        },
+        {
+          "name": "Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24230"
+          ],
+          "eans": [
+            "5907138403794"
+          ]
+        },
+        {
+          "name": "Magenta",
+          "hex": "FF00FF",
+          "codes": [
+            "TF-24236"
+          ],
+          "eans": [
+            "5907138413632"
+          ]
+        },
+        {
+          "name": "Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24235"
+          ],
+          "eans": [
+            "5907138413625"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24226"
+          ],
+          "eans": [
+            "5907138403756"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24237"
+          ],
+          "eans": [
+            "5907138413649"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24225"
+          ],
+          "eans": [
+            "5907138403749"
+          ]
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24228"
+          ],
+          "eans": [
+            "5907138403770"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "ReFill PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24158"
+          ],
+          "eans": [
+            "5907138402735"
+          ]
+        },
+        {
+          "name": "Camo Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24159"
+          ],
+          "eans": [
+            "5907138402742"
+          ]
+        },
+        {
+          "name": "Desert Beige",
+          "hex": "F5F5DC",
+          "codes": [
+            "TF-24160"
+          ],
+          "eans": [
+            "5907138402759"
+          ]
+        },
+        {
+          "name": "Jungle Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24161"
+          ],
+          "eans": [
+            "5907138402766"
+          ]
+        },
+        {
+          "name": "Military Olive",
+          "hex": "808080",
+          "codes": [
+            "TF-24157"
+          ],
+          "eans": [
+            "5907138402728"
+          ]
+        },
+        {
+          "name": "Night Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24163"
+          ],
+          "eans": [
+            "5907138402780"
+          ]
+        },
+        {
+          "name": "October Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24162"
+          ],
+          "eans": [
+            "5907138402773"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24150"
+          ],
+          "eans": [
+            "5907138402650"
+          ]
+        },
+        {
+          "name": "Stealth Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24166"
+          ],
+          "eans": [
+            "5907138402810"
+          ]
+        },
+        {
+          "name": "Trooper Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24164"
+          ],
+          "eans": [
+            "5907138402797"
+          ]
+        },
+        {
+          "name": "Urban Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24165"
+          ],
+          "eans": [
+            "5907138402803"
+          ]
+        }
+      ],
+      "finish": "matte"
+    },
+    {
+      "name": "ReFill PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        215
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Basalt Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24043"
+          ],
+          "eans": [
+            "5905991405962"
+          ]
+        },
+        {
+          "name": "Bison Brown",
+          "hex": "8B4513",
+          "codes": [
+            "TF-24051"
+          ],
+          "eans": [
+            "5907138400427"
+          ]
+        },
+        {
+          "name": "Circuit Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24048"
+          ],
+          "eans": [
+            "5905991406013"
+          ]
+        },
+        {
+          "name": "Cloud Grey",
+          "hex": "808080",
+          "codes": [
+            "TF-24044"
+          ],
+          "eans": [
+            "5905991405979"
+          ]
+        },
+        {
+          "name": "Machinery Orange",
+          "hex": "FFA500",
+          "codes": [
+            "TF-24053"
+          ],
+          "eans": [
+            "5905991406037"
+          ]
+        },
+        {
+          "name": "Midnight Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24041"
+          ],
+          "eans": [
+            "5905991405948"
+          ]
+        },
+        {
+          "name": "Performance Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24045"
+          ],
+          "eans": [
+            "5905991405986"
+          ]
+        },
+        {
+          "name": "Plasma Purple",
+          "hex": "800080",
+          "codes": [
+            "TF-24055"
+          ],
+          "eans": [
+            "5905991406051"
+          ]
+        },
+        {
+          "name": "Silver Aluminium",
+          "hex": "C0C0C0",
+          "codes": [
+            "TF-24047"
+          ],
+          "eans": [
+            "5905991406006"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24049"
+          ],
+          "eans": [
+            "5907138400403"
+          ]
+        },
+        {
+          "name": "Sorbet Yellow",
+          "hex": "FFFF00",
+          "codes": [
+            "TF-24052"
+          ],
+          "eans": [
+            "5905991406020"
+          ]
+        },
+        {
+          "name": "Strawberry Pink",
+          "hex": "FFC0CB",
+          "codes": [
+            "TF-24054"
+          ],
+          "eans": [
+            "5905991406044"
+          ]
+        },
+        {
+          "name": "Technical Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24046"
+          ],
+          "eans": [
+            "5905991405993"
+          ]
+        },
+        {
+          "name": "Traffic White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24042"
+          ],
+          "eans": [
+            "5905991405955"
+          ]
+        },
+        {
+          "name": "Wood Ash",
+          "hex": "808080",
+          "codes": [
+            "TF-24050"
+          ],
+          "eans": [
+            "5907138400410"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "TPU-82A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24126"
+          ],
+          "eans": [
+            "5907138401998"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24125"
+          ],
+          "eans": [
+            "5907138401981"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24124"
+          ],
+          "eans": [
+            "5907138401974"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24123"
+          ],
+          "eans": [
+            "5907138401967"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24122"
+          ],
+          "eans": [
+            "5907138401936"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "TPU-87A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24131"
+          ],
+          "eans": [
+            "5907138402063"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24130"
+          ],
+          "eans": [
+            "5907138402056"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24129"
+          ],
+          "eans": [
+            "5907138402049"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24128"
+          ],
+          "eans": [
+            "5907138402032"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24127"
+          ],
+          "eans": [
+            "5907138402001"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "TPU-95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        80
+      ],
+      "country_of_origin": "Poland",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "codes": [
+            "TF-24136"
+          ],
+          "eans": [
+            "5907138402131"
+          ]
+        },
+        {
+          "name": "Blue",
+          "hex": "0000FF",
+          "codes": [
+            "TF-24135"
+          ],
+          "eans": [
+            "5907138402124"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "00FF00",
+          "codes": [
+            "TF-24134"
+          ],
+          "eans": [
+            "5907138402117"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "FF0000",
+          "codes": [
+            "TF-24133"
+          ],
+          "eans": [
+            "5907138402100"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF",
+          "codes": [
+            "TF-24132"
+          ],
+          "eans": [
+            "5907138402070"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    }
+  ]
+}

--- a/filaments/threebees.json
+++ b/filaments/threebees.json
@@ -1,0 +1,1013 @@
+{
+    "manufacturer": "Threebees",
+    "filaments": [
+        {
+            "name": "Premium {color_name}",
+            "material": "PLA",
+            "density": 1.26,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Baby Yellow",
+                    "hex": "FDFD96"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Clear Blue",
+                    "hex": "0000FF",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Green",
+                    "hex": "00FF00",
+                    "translucent": true
+                },
+                {
+                    "name": "Deep Blue",
+                    "hex": "00008B"
+                },
+                {
+                    "name": "Deep Purple",
+                    "hex": "301934"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Leaves",
+                    "hex": "6B8E23"
+                },
+                {
+                    "name": "Light Blue",
+                    "hex": "ADD8E6"
+                },
+                {
+                    "name": "Light Gold",
+                    "hex": "CFAA52"
+                },
+                {
+                    "name": "Mint",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Neon Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Neon Pink",
+                    "hex": "FF6EC7"
+                },
+                {
+                    "name": "Neon Yellow",
+                    "hex": "CCFF00"
+                },
+                {
+                    "name": "Neutral",
+                    "hex": "F5F5DC"
+                },
+                {
+                    "name": "Night Blue",
+                    "hex": "191970"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Ox Blood",
+                    "hex": "4A0000"
+                },
+                {
+                    "name": "Pastel Yellow",
+                    "hex": "FAFA6E"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFC0CB"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Skin #1",
+                    "hex": "FFDBAC"
+                },
+                {
+                    "name": "Skin #2",
+                    "hex": "F1C27D"
+                },
+                {
+                    "name": "Skin #3",
+                    "hex": "E0AC69"
+                },
+                {
+                    "name": "Virgin",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                }
+            ]
+        },
+        {
+            "name": "BOND {color_name}",
+            "material": "PLA",
+            "density": 1.26,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "W {color_name}",
+            "material": "PLA",
+            "density": 1.26,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Azure Blue",
+                    "hex": "007FFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Mint",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Pink Milk",
+                    "hex": "F4C2C2"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Skin #2",
+                    "hex": "F1C27D"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow Divo",
+                    "hex": "FFD300"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.29,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 238,
+            "bed_temp": 85,
+            "colors": [
+                {
+                    "name": "Azure Blue",
+                    "hex": "007FFF"
+                },
+                {
+                    "name": "Baby Blue",
+                    "hex": "89CFF0"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Black Glitter",
+                    "hex": "000000",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Blue Boss",
+                    "hex": "1F3A93"
+                },
+                {
+                    "name": "Camping Green",
+                    "hex": "4B6F44"
+                },
+                {
+                    "name": "Caramel",
+                    "hex": "FFD59A"
+                },
+                {
+                    "name": "Clear Black",
+                    "hex": "000000",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Black Glitter",
+                    "hex": "000000",
+                    "translucent": true,
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Clear Blue",
+                    "hex": "0000FF",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Green",
+                    "hex": "00FF00",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Neon Pink",
+                    "hex": "FF6EC7",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Purple",
+                    "hex": "800080",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Red",
+                    "hex": "FF0000",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Red Glitter",
+                    "hex": "FF0000",
+                    "translucent": true,
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "B87333"
+                },
+                {
+                    "name": "Dark Olive",
+                    "hex": "556B2F"
+                },
+                {
+                    "name": "Deep Green",
+                    "hex": "006400"
+                },
+                {
+                    "name": "Deep Purple",
+                    "hex": "301934"
+                },
+                {
+                    "name": "Desert",
+                    "hex": "EDC9AF"
+                },
+                {
+                    "name": "Dragonfruit",
+                    "hex": "FF1493"
+                },
+                {
+                    "name": "Glow in the Dark B",
+                    "hex": "89CFF0",
+                    "glow": true
+                },
+                {
+                    "name": "Glow in the Dark G",
+                    "hex": "90EE90",
+                    "glow": true
+                },
+                {
+                    "name": "Glow in the Dark N",
+                    "hex": "F5F5DC",
+                    "glow": true
+                },
+                {
+                    "name": "Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Green My Guitar",
+                    "hex": "2E8B57"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Leaves",
+                    "hex": "6B8E23"
+                },
+                {
+                    "name": "Light Gold",
+                    "hex": "CFAA52"
+                },
+                {
+                    "name": "Mint",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Neon Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Neon Pink",
+                    "hex": "FF6EC7"
+                },
+                {
+                    "name": "Neon Yellow",
+                    "hex": "CCFF00"
+                },
+                {
+                    "name": "Night Blue",
+                    "hex": "191970"
+                },
+                {
+                    "name": "Ocean",
+                    "hex": "006994"
+                },
+                {
+                    "name": "Opaque Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Opaque Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Opaque Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Opaque Virgin",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Opaque Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Pastel Yellow",
+                    "hex": "FAFA6E"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFC0CB"
+                },
+                {
+                    "name": "Pink Milk",
+                    "hex": "F4C2C2"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Red Glitter",
+                    "hex": "FF0000",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Red Moonwalker",
+                    "hex": "8B0000"
+                },
+                {
+                    "name": "Rust",
+                    "hex": "B7410E"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Skin #1",
+                    "hex": "FFDBAC"
+                },
+                {
+                    "name": "Skin #2",
+                    "hex": "F1C27D"
+                },
+                {
+                    "name": "Skin #3",
+                    "hex": "E0AC69"
+                },
+                {
+                    "name": "Storm Grey",
+                    "hex": "717C89"
+                },
+                {
+                    "name": "Terra Cotta",
+                    "hex": "E2725B"
+                },
+                {
+                    "name": "Ultramarine",
+                    "hex": "3F00FF"
+                },
+                {
+                    "name": "Virgin",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Yellow Divo",
+                    "hex": "FFD300"
+                }
+            ]
+        },
+        {
+            "name": "High Flow {color_name}",
+            "material": "PETG",
+            "density": 1.3,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 245,
+            "bed_temp": 85,
+            "colors": [
+                {
+                    "name": "Baby Blue",
+                    "hex": "89CFF0"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Black Glitter",
+                    "hex": "000000",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Blue Boss",
+                    "hex": "1F3A93"
+                },
+                {
+                    "name": "Blue Pearl",
+                    "hex": "4F86C6"
+                },
+                {
+                    "name": "Clear Red",
+                    "hex": "FF0000",
+                    "translucent": true
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Mint",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Neon Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Opaque Virgin",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Ox Blood",
+                    "hex": "4A0000"
+                },
+                {
+                    "name": "Peach Pearl",
+                    "hex": "FFDAB9"
+                },
+                {
+                    "name": "Pink Milk",
+                    "hex": "F4C2C2"
+                },
+                {
+                    "name": "Purple Pearl",
+                    "hex": "9370DB"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Skin #3",
+                    "hex": "E0AC69"
+                },
+                {
+                    "name": "Storm Grey",
+                    "hex": "717C89"
+                },
+                {
+                    "name": "Virgin",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.038,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 260,
+            "bed_temp": 95,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Blue Boss",
+                    "hex": "1F3A93"
+                },
+                {
+                    "name": "Camping Green",
+                    "hex": "4B6F44"
+                },
+                {
+                    "name": "Caramel",
+                    "hex": "FFD59A"
+                },
+                {
+                    "name": "Dark Olive",
+                    "hex": "556B2F"
+                },
+                {
+                    "name": "Deep Blue",
+                    "hex": "00008B"
+                },
+                {
+                    "name": "Deep Green",
+                    "hex": "006400"
+                },
+                {
+                    "name": "Deep Purple",
+                    "hex": "301934"
+                },
+                {
+                    "name": "Desert",
+                    "hex": "EDC9AF"
+                },
+                {
+                    "name": "Green My Guitar",
+                    "hex": "2E8B57"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Mint",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Neon Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Neon Pink",
+                    "hex": "FF6EC7"
+                },
+                {
+                    "name": "Neon Yellow",
+                    "hex": "CCFF00"
+                },
+                {
+                    "name": "Night Blue",
+                    "hex": "191970"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Ox Blood",
+                    "hex": "4A0000"
+                },
+                {
+                    "name": "Pastel Blue",
+                    "hex": "AEC6CF"
+                },
+                {
+                    "name": "Pastel Purple",
+                    "hex": "B39EB5"
+                },
+                {
+                    "name": "Pastel Yellow",
+                    "hex": "FAFA6E"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFC0CB"
+                },
+                {
+                    "name": "Pink Milk",
+                    "hex": "F4C2C2"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Red Moonwalker",
+                    "hex": "8B0000"
+                },
+                {
+                    "name": "Storm Grey",
+                    "hex": "717C89"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Yellow Divo",
+                    "hex": "FFD300"
+                }
+            ]
+        },
+        {
+            "name": "High Temp {color_name}",
+            "material": "ABS",
+            "density": 1.03,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 265,
+            "bed_temp": 95,
+            "colors": [
+                {
+                    "name": "Baby Blue",
+                    "hex": "89CFF0"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Blue Boss",
+                    "hex": "1F3A93"
+                },
+                {
+                    "name": "Camping Green",
+                    "hex": "4B6F44"
+                },
+                {
+                    "name": "Caramel",
+                    "hex": "FFD59A"
+                },
+                {
+                    "name": "Dark Olive",
+                    "hex": "556B2F"
+                },
+                {
+                    "name": "Deep Blue",
+                    "hex": "00008B"
+                },
+                {
+                    "name": "Deep Green",
+                    "hex": "006400"
+                },
+                {
+                    "name": "Deep Purple",
+                    "hex": "301934"
+                },
+                {
+                    "name": "Desert",
+                    "hex": "EDC9AF"
+                },
+                {
+                    "name": "Green My Guitar",
+                    "hex": "2E8B57"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Mint",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Neon Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Neon Pink",
+                    "hex": "FF6EC7"
+                },
+                {
+                    "name": "Neon Yellow",
+                    "hex": "CCFF00"
+                },
+                {
+                    "name": "Night Blue",
+                    "hex": "191970"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Ox Blood",
+                    "hex": "4A0000"
+                },
+                {
+                    "name": "Pastel Purple",
+                    "hex": "B39EB5"
+                },
+                {
+                    "name": "Pastel Yellow",
+                    "hex": "FAFA6E"
+                },
+                {
+                    "name": "Pink Milk",
+                    "hex": "F4C2C2"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Red Moonwalker",
+                    "hex": "8B0000"
+                },
+                {
+                    "name": "Storm Grey",
+                    "hex": "717C89"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Yellow Divo",
+                    "hex": "FFD300"
+                }
+            ]
+        },
+        {
+            "name": "M2 {color_name}",
+            "material": "ABS",
+            "density": 1.02,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 270,
+            "bed_temp": 100,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU-95A",
+            "density": 1.15,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 230,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Azure Blue",
+                    "hex": "007FFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Skin #2",
+                    "hex": "F1C27D"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "TPU-85A",
+            "density": 1.12,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 230,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Neon Green",
+                    "hex": "39FF14"
+                },
+                {
+                    "name": "Skin #2",
+                    "hex": "F1C27D"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PC+PBT",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000.0,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 280,
+            "bed_temp": 100,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/thriftymake.json
+++ b/filaments/thriftymake.json
@@ -1,0 +1,192 @@
+{
+  "manufacturer": "ThriftyMake",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0056d6"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Orange",
+          "hex": "fd7c18"
+        },
+        {
+          "name": "Purple",
+          "hex": "a020f0"
+        },
+        {
+          "name": "Red",
+          "hex": "ff2600"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f5ec00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        225
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "285ff4"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Refill {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0042aa"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/tianse3d.json
+++ b/filaments/tianse3d.json
@@ -1,0 +1,182 @@
+{
+  "manufacturer": "Tianse-3D",
+  "filaments": [
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "white",
+          "hex": "ffffff"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        240
+      ],
+      "bed_temp_range": [
+        20,
+        20
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "749fe4"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Bleu",
+          "hex": "4444dd"
+        },
+        {
+          "name": "Coffee",
+          "hex": "6f4e37"
+        },
+        {
+          "name": "flourescent Pink",
+          "hex": "ff66b3"
+        },
+        {
+          "name": "Green",
+          "hex": "008080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silver",
+          "hex": "7a7a7a"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "006ebd"
+        },
+        {
+          "name": "Red",
+          "hex": "da3434"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Wood",
+          "hex": "8d4c02"
+        }
+      ],
+      "fill": "wood",
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/tm3d.json
+++ b/filaments/tm3d.json
@@ -1,0 +1,533 @@
+{
+  "manufacturer": "TM3D",
+  "filaments": [
+    {
+      "name": "ABS Premium {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        130,
+        130
+      ],
+      "colors": [
+        {
+          "name": "Iron Grey",
+          "hex": "1d2020"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "82d0e6"
+        },
+        {
+          "name": "Natural",
+          "hex": "e7e4d3"
+        },
+        {
+          "name": "Pastel Turquoise",
+          "hex": "a7d1c5"
+        },
+        {
+          "name": "Sulfur Yellow",
+          "hex": "f2e95f"
+        },
+        {
+          "name": "Yellow Gold",
+          "hex": "ebc542"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Traffic green",
+          "hex": "1e8658"
+        }
+      ]
+    },
+    {
+      "name": "ASA Premium {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        46,
+        46
+      ],
+      "colors": [
+        {
+          "name": "Ocean Blue",
+          "hex": "23475b"
+        }
+      ]
+    },
+    {
+      "name": "PETG Premium {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "6b5400"
+        },
+        {
+          "name": "Cream",
+          "hex": "ebe8da"
+        },
+        {
+          "name": "Iron Grey",
+          "hex": "51585b"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "52b2c3"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "c3c4c1"
+        },
+        {
+          "name": "Light Pink",
+          "hex": "f2a8b4"
+        },
+        {
+          "name": "Pure Orange",
+          "hex": "e1642f"
+        },
+        {
+          "name": "Shifting Blue",
+          "hex": "333c4d"
+        },
+        {
+          "name": "Signal Violet",
+          "hex": "742394"
+        },
+        {
+          "name": "Signal White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "0099c4"
+        },
+        {
+          "name": "Smokey Black",
+          "hex": "808080"
+        },
+        {
+          "name": "Traffic Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Traffic Blue",
+          "hex": "006793"
+        },
+        {
+          "name": "Traffic Green",
+          "hex": "36734b"
+        },
+        {
+          "name": "Traffic Red",
+          "hex": "c73a2f"
+        },
+        {
+          "name": "Traffic Yellow",
+          "hex": "ddac2c"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        46
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "275c7a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Premium {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        46
+      ],
+      "colors": [
+        {
+          "name": "Cream",
+          "hex": "eae8d6"
+        },
+        {
+          "name": "Fluorescent Orange",
+          "hex": "b85423"
+        },
+        {
+          "name": "Ocher Brown",
+          "hex": "9b6130"
+        },
+        {
+          "name": "Signal White",
+          "hex": "e6e5ea"
+        },
+        {
+          "name": "Tele Magenta",
+          "hex": "fc27b8"
+        },
+        {
+          "name": "Traffic Black",
+          "hex": "313132"
+        },
+        {
+          "name": "Traffic Blue",
+          "hex": "6d7eb0"
+        },
+        {
+          "name": "Traffic Green",
+          "hex": "1e8658"
+        },
+        {
+          "name": "Turquoise Green",
+          "hex": "1c9b82"
+        },
+        {
+          "name": "Ultramarine Blue",
+          "hex": "204580"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        45,
+        46
+      ],
+      "colors": [
+        {
+          "name": "Fluorescent Yellow",
+          "hex": "d5ff00"
+        },
+        {
+          "name": "Iron Grey",
+          "hex": "4b6068"
+        },
+        {
+          "name": "Leaf Green",
+          "hex": "214002"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "808080"
+        },
+        {
+          "name": "Mahogany Brown",
+          "hex": "3e2b22"
+        },
+        {
+          "name": "Traffic Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Traffic Green",
+          "hex": "50c28c"
+        },
+        {
+          "name": "Traffic Yellow",
+          "hex": "ffee2e"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Signal White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Traffic Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Tough {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Signal White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0012b3"
+        },
+        {
+          "name": "Fluo Orange",
+          "hex": "ed8833"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f9ea4e"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Cork",
+          "hex": "4c392c"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/toksen3d.json
+++ b/filaments/toksen3d.json
@@ -1,0 +1,682 @@
+{
+  "manufacturer": "Toksen3D",
+  "filaments": [
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        229,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "153a46"
+        },
+        {
+          "name": "Opal Gold Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Twilight Black",
+          "hex": "0d000d"
+        }
+      ]
+    },
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PETG",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Nebula Purple",
+          "hex": "433b80"
+        }
+      ]
+    },
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Glow in Dark - Qinghe",
+          "hex": "bae877"
+        },
+        {
+          "name": "Luminous Rose Red",
+          "hex": "fb814c"
+        }
+      ]
+    },
+    {
+      "name": "Gradient Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Macaroon",
+          "hex": "cbaeef"
+        }
+      ]
+    },
+    {
+      "name": "Matte Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black / Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / Red",
+          "hexes": [
+            "0000ff",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Grey+Black",
+          "hexes": [
+            "8a9399",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Pink and Sky blue",
+          "hex": "d5aeef"
+        },
+        {
+          "name": "Yellow/Pink",
+          "hexes": [
+            "ffff00",
+            "ffcc95"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Yellow/Sky Blue",
+          "hexes": [
+            "ffff00",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Matte Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Winter",
+          "hex": "9085ca"
+        }
+      ]
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black+Red+Orange",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        230
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Metal Abyssal Red",
+          "hex": "b03c3d"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        255
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "d5d5d5"
+        },
+        {
+          "name": "Wine Red",
+          "hex": "b03c3d"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue/Purple/Pink",
+          "hexes": [
+            "0000ff",
+            "800080",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87eeff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "ffda24"
+        },
+        {
+          "name": "Golden",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Dark Grey",
+          "hex": "616161"
+        },
+        {
+          "name": "Light Grey",
+          "hex": "bdbdbd"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "ff6f00"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black/ Blue",
+          "hexes": [
+            "000000",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/ Green",
+          "hexes": [
+            "000000",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/ Purple",
+          "hexes": [
+            "000000",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Black/ Red",
+          "hexes": [
+            "000000",
+            "ff0000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / Fuchsia",
+          "hexes": [
+            "0000ff",
+            "ff00ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Blue / Green",
+          "hexes": [
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold / Blue",
+          "hexes": [
+            "ffd700",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold / Green",
+          "hexes": [
+            "ffd700",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold / Peach Red",
+          "hexes": [
+            "ffd700",
+            "c93b8e"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Gold / Purple",
+          "hexes": [
+            "ffd700",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Sky Blue & Pink",
+          "hex": "9cc4ec"
+        },
+        {
+          "name": "Sky Blue / Purple",
+          "hexes": [
+            "78dd84",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Silk Gradient Rainbow Black Blue Green",
+          "hex": "4f636a"
+        },
+        {
+          "name": "Silk Gradient Rainbow Black Gold Silver",
+          "hex": "bfa657"
+        },
+        {
+          "name": "Silk Pla-jb-02 Rainbow",
+          "hex": "04a3c2"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Bamboo",
+          "hex": "6fe0a2"
+        },
+        {
+          "name": "Dreamy Crystal",
+          "hex": "d9a3d5"
+        },
+        {
+          "name": "Flame",
+          "hex": "ff5541"
+        },
+        {
+          "name": "Peach",
+          "hex": "e3727a"
+        },
+        {
+          "name": "Sky",
+          "hex": "75b6e0"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Sky Blue",
+          "hex": "8bb3da"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/torwell.json
+++ b/filaments/torwell.json
@@ -1,0 +1,222 @@
+{
+  "manufacturer": "Torwell",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        175,
+        220
+      ],
+      "bed_temp_range": [
+        20,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Skin",
+          "hex": "ffdbac"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/tronxy.json
+++ b/filaments/tronxy.json
@@ -1,0 +1,43 @@
+{
+    "manufacturer": "Tronxy",
+    "filaments": [
+        {
+            "name": "Tronxy PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/ttyt3d.json
+++ b/filaments/ttyt3d.json
@@ -1,0 +1,201 @@
+{
+  "manufacturer": "TTYT3D",
+  "filaments": [
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        225
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Multi Mixed Rainbow",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        235
+      ],
+      "bed_temp_range": [
+        35,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "3e91b6"
+        },
+        {
+          "name": "Blue-Purple Rainbow",
+          "hex": "cbaeef"
+        },
+        {
+          "name": "Bronze",
+          "hex": "cd7f32"
+        },
+        {
+          "name": "Chocolate Gold",
+          "hex": "a78c76"
+        },
+        {
+          "name": "Copper",
+          "hex": "cb6d51"
+        },
+        {
+          "name": "Cyan",
+          "hex": "aaffff"
+        },
+        {
+          "name": "Green",
+          "hex": "0dc494"
+        },
+        {
+          "name": "Multi Mixed Color",
+          "hex": "808080"
+        },
+        {
+          "name": "Orange",
+          "hex": "fe9228"
+        },
+        {
+          "name": "Purple",
+          "hex": "b950b0"
+        },
+        {
+          "name": "Rainbow",
+          "hex": "ff4133"
+        },
+        {
+          "name": "Red",
+          "hex": "e22400"
+        },
+        {
+          "name": "Rose Gold",
+          "hex": "e0bfb8"
+        },
+        {
+          "name": "Shine Copper",
+          "hex": "808080"
+        },
+        {
+          "name": "Shiny Fast Color Gradient Change Rainbow",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Silk Gold",
+          "hex": "cdab5c"
+        },
+        {
+          "name": "Silver",
+          "hex": "a8a9ad"
+        },
+        {
+          "name": "Turquoise Blue",
+          "hex": "25d2e3"
+        },
+        {
+          "name": "White",
+          "hex": "deddd4"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ebd11f"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Lime Green",
+          "hex": "6ce30f"
+        },
+        {
+          "name": "Solid Purple",
+          "hex": "bb8cfa"
+        },
+        {
+          "name": "Solid Sky Blue",
+          "hex": "71c5e8"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        205,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Purple to Blue",
+          "hex": "9f3ce2"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/tucabfil3d.json
+++ b/filaments/tucabfil3d.json
@@ -1,0 +1,246 @@
+{
+  "manufacturer": "Tucab Fil3D",
+  "filaments": [
+    {
+      "name": "Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "efbf04",
+          "pattern": "sparkle"
+        }
+      ],
+      "pattern": "sparkle"
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Granite Grey",
+          "hex": "cedce9",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Brown",
+          "hex": "895129"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Copper",
+          "hex": "c68346"
+        },
+        {
+          "name": "Gold",
+          "hex": "efbf04"
+        },
+        {
+          "name": "Gray",
+          "hex": "999999"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Metalic Black",
+          "hex": "2c2c2b"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Pink",
+          "hex": "da5ba1"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Violet",
+          "hex": "9100ff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "808080"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/twotrees.json
+++ b/filaments/twotrees.json
@@ -1,0 +1,43 @@
+{
+    "manufacturer": "TwoTrees",
+    "filaments": [
+        {
+            "name": "TwoTrees PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 200
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/ujoybio3d.json
+++ b/filaments/ujoybio3d.json
@@ -1,0 +1,602 @@
+{
+  "manufacturer": "Ujoybio3d",
+  "filaments": [
+    {
+      "name": "Hf {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Bark Blue",
+          "hex": "003870"
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "003870"
+        },
+        {
+          "name": "Iris Purple",
+          "hex": "7a0bd5"
+        },
+        {
+          "name": "Yellow-Orange",
+          "hex": "ec9c51"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        45,
+        240
+      ],
+      "bed_temp_range": [
+        35,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Brown",
+          "hex": "5c3317"
+        },
+        {
+          "name": "Cream White",
+          "hex": "f8f5e8"
+        },
+        {
+          "name": "DimGray",
+          "hex": "696969"
+        },
+        {
+          "name": "Green",
+          "hex": "00ff00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "556b2f"
+        },
+        {
+          "name": "Orange",
+          "hex": "ffa500"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffc0cb"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "1bb6cb"
+        },
+        {
+          "name": "Purple",
+          "hex": "c5338b"
+        }
+      ]
+    },
+    {
+      "name": "Metal {color_name}",
+      "material": "PLA",
+      "density": 1.32,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black Armor Green",
+          "hex": "38ada5"
+        },
+        {
+          "name": "Brilliant Rose Red",
+          "hex": "a45e65"
+        },
+        {
+          "name": "Bronze",
+          "hex": "ccb3a6"
+        },
+        {
+          "name": "Champagne Gold",
+          "hex": "dcccc1"
+        },
+        {
+          "name": "Copper",
+          "hex": "903a00"
+        },
+        {
+          "name": "Titanium Gray",
+          "hex": "767175"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        270
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "f5e6c8"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Christmas Green",
+          "hex": "1d4127"
+        },
+        {
+          "name": "Cobalt Blue",
+          "hex": "2555aa"
+        },
+        {
+          "name": "Coffee Brown",
+          "hex": "65361f"
+        },
+        {
+          "name": "Jade White",
+          "hex": "dfebe6"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff7611"
+        },
+        {
+          "name": "Pink",
+          "hex": "ffb4c8"
+        },
+        {
+          "name": "Purple",
+          "hex": "6496ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "80ffff"
+        },
+        {
+          "name": "Transparent",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffdc64"
+        }
+      ]
+    },
+    {
+      "name": "PETG+PLUS Pro {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Christmas Green",
+          "hex": "007007"
+        }
+      ]
+    },
+    {
+      "name": "PETG+PLUS {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Iris Purple",
+          "hex": "bb15d1"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Beige",
+          "hex": "f5f5dc"
+        },
+        {
+          "name": "Desert Yellow",
+          "hex": "e8ec83"
+        },
+        {
+          "name": "Grey",
+          "hex": "a6a6a6"
+        },
+        {
+          "name": "Light Khaki",
+          "hex": "c8b68a"
+        },
+        {
+          "name": "Lilac Purple",
+          "hex": "ae96d4"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "191970"
+        },
+        {
+          "name": "Mint Green",
+          "hex": "c7ffd8"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "000080"
+        },
+        {
+          "name": "Red",
+          "hex": "c1272d"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "ffc2f4"
+        },
+        {
+          "name": "Yellow",
+          "hex": "e2c100"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Copper",
+          "hex": "ffa86f"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffee78"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Titanium Gray",
+          "hex": "61616c"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        230
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Hyper Green",
+          "hex": "008000"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Pink Blue",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Metallic Copper",
+          "hex": "ecb684"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue Green",
+          "hex": "55a3de"
+        },
+        {
+          "name": "Blue Pink Dual",
+          "hex": "8c99de"
+        },
+        {
+          "name": "Pink Gold",
+          "hex": "d19b3e"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black Gold Purple",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue Green Purple",
+          "hex": "0159b2"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ultimaker.json
+++ b/filaments/ultimaker.json
@@ -1,0 +1,765 @@
+{
+  "manufacturer": "Ultimaker",
+  "filaments": [
+    {
+      "name": "S Series PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "True Green",
+          "hex": "008000"
+        },
+        {
+          "name": "True Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "True Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "True Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Pearl White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Transparent",
+          "hex": "e8e8e8",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "S Series Tough PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        210,
+        225
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "True Green",
+          "hex": "008000"
+        },
+        {
+          "name": "True Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "True Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        }
+      ]
+    },
+    {
+      "name": "S Series ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        225,
+        245
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "True Green",
+          "hex": "008000"
+        },
+        {
+          "name": "True Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "True Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Pearl Gold",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "S Series PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "True Green",
+          "hex": "008000"
+        },
+        {
+          "name": "True Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "True Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "True Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Transparent",
+          "hex": "e8e8e8",
+          "translucent": true
+        },
+        {
+          "name": "Green Translucent",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow Fluorescent",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "S Series CPE {color_name}",
+      "material": "CPE",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "True Green",
+          "hex": "008000"
+        },
+        {
+          "name": "True Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "True Yellow",
+          "hex": "ffd700"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        },
+        {
+          "name": "Transparent",
+          "hex": "e8e8e8",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "S Series CPE+ {color_name}",
+      "material": "CPE+",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        240,
+        265
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Transparent",
+          "hex": "e8e8e8",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "S Series Nylon {color_name}",
+      "material": "PA",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Transparent",
+          "hex": "e8e8e8",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "S Series PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Transparent",
+          "hex": "e8e8e8",
+          "translucent": true
+        }
+      ]
+    },
+    {
+      "name": "S Series TPU 95A {color_name}",
+      "material": "TPU-95A",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        }
+      ]
+    },
+    {
+      "name": "S Series PET CF {color_name}",
+      "material": "PET-CF",
+      "density": 1.29,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        250,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Gray",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066cc"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "S Series PVA {color_name}",
+      "material": "PVA",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Method PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        },
+        {
+          "name": "True Black",
+          "hex": "808080"
+        },
+        {
+          "name": "True Orange",
+          "hex": "ff6600"
+        },
+        {
+          "name": "True Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "True White",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Method ABS-R {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 650
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Natural",
+          "hex": "f5f0e1"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        }
+      ]
+    },
+    {
+      "name": "Method ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 650
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e3a"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Method PC-ABS FR {color_name}",
+      "material": "PC+ABS",
+      "density": 1.19,
+      "weights": [
+        {
+          "weight": 710
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ]
+    },
+    {
+      "name": "Method ABS CF {color_name}",
+      "material": "ABS-CF",
+      "density": 1.08,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        260,
+        280
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Method Nylon 12 CF {color_name}",
+      "material": "PA12-CF",
+      "density": 1.15,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "S Series Nylon CF Slide {color_name}",
+      "material": "PA-CF",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        270,
+        290
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "S Series PPS CF {color_name}",
+      "material": "PPS-CF",
+      "density": 1.35,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        2.85
+      ],
+      "extruder_temp_range": [
+        310,
+        330
+      ],
+      "bed_temp_range": [
+        100,
+        120
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        }
+      ],
+      "fill": "carbon fiber"
+    }
+  ]
+}

--- a/filaments/unitak3d.json
+++ b/filaments/unitak3d.json
@@ -1,0 +1,68 @@
+{
+  "manufacturer": "UniTak3D",
+  "filaments": [
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        },
+        {
+          "weight": 2000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        65
+      ],
+      "finish": "matte",
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Apple Green",
+          "hex": "8db600",
+          "codes": [
+            "B0FJL52LJX"
+          ]
+        },
+        {
+          "name": "Ash Grey",
+          "hex": "b2beb5",
+          "codes": [
+            "B0FJL39L61"
+          ]
+        },
+        {
+          "name": "Charcoal",
+          "hex": "36454f",
+          "codes": [
+            "B0FJKYM47K"
+          ]
+        },
+        {
+          "name": "Ivory White",
+          "hex": "fffff0",
+          "codes": [
+            "B0FJL533DX"
+          ]
+        },
+        {
+          "name": "Ivory White + Charcoal",
+          "hex": "d4d4c8",
+          "codes": [
+            "B0FJL9MWRK"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/verbatim.json
+++ b/filaments/verbatim.json
@@ -1,0 +1,175 @@
+{
+  "manufacturer": "Verbatim",
+  "filaments": [
+    {
+      "name": "Verbatim PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [200, 220],
+      "bed_temp": 60,
+      "tds_url": "https://3d-druckershop.com/mediafiles/Sonstiges/Datenblaetter/Filament/Verbatim/PLA_Datasheet_2018_EN.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "050505",
+          "codes": ["55318", "55327"]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": ["55315", "55328"]
+        },
+        {
+          "name": "Natural Transparent",
+          "hex": "dbfbff",
+          "translucent": true,
+          "codes": ["55317"]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": ["55320", "55330"]
+        },
+        {
+          "name": "Green",
+          "hex": "005900",
+          "codes": ["55324", "55334"]
+        },
+        {
+          "name": "Aluminium Grey",
+          "hex": "666666",
+          "codes": ["55319", "55329"]
+        },
+        {
+          "name": "Blue",
+          "hex": "1900ff",
+          "codes": ["55322", "55332"]
+        }
+      ]
+    },
+    {
+      "name": "Verbatim PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [60, 90],
+      "tds_url": "https://3d-druckershop.com/mediafiles/Sonstiges/Datenblaetter/Filament/Verbatim/PET_G_Datasheet_2018_EN.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "050505",
+          "codes": ["55052", "55060"]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": ["55050", "55058"]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": ["55053", "55061"]
+        },
+        {
+          "name": "Blue",
+          "hex": "1900ff",
+          "codes": ["55055", "55063"]
+        },
+        {
+          "name": "Clear",
+          "hex": "d9fff8",
+          "translucent": true,
+          "codes": ["55051", "55059"]
+        },
+        {
+          "name": "Red Transparent",
+          "hex": "a80000",
+          "translucent": true,
+          "codes": ["55054", "55062"]
+        },
+        {
+          "name": "Blue Transparent",
+          "hex": "1e16e0",
+          "translucent": true,
+          "codes": ["55056"]
+        },
+        {
+          "name": "Green Transparent",
+          "hex": "094709",
+          "translucent": true,
+          "codes": ["55057", "55065"]
+        }
+      ]
+    },
+    {
+      "name": "Verbatim ABS {color_name}",
+      "material": "ABS",
+      "density": 1.05,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 500,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [1.75, 2.85],
+      "extruder_temp_range": [220, 260],
+      "bed_temp_range": [0, 100],
+      "tds_url": "https://3d-druckershop.com/mediafiles/Sonstiges/Datenblaetter/Filament/Verbatim/ABS_Datasheet_2018_EN.pdf",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "050505",
+          "codes": ["55026", "55033"]
+        },
+        {
+          "name": "White",
+          "hex": "ffffff",
+          "codes": ["55027", "55034"]
+        },
+        {
+          "name": "Natural Milky",
+          "hex": "fff0ba",
+          "translucent": true,
+          "codes": ["55028", "55035"]
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000",
+          "codes": ["55030"]
+        },
+        {
+          "name": "Green",
+          "hex": "005900",
+          "codes": ["55031"]
+        },
+        {
+          "name": "Aluminium Grey",
+          "hex": "666666",
+          "codes": ["55032", "55036"]
+        },
+        {
+          "name": "Blue",
+          "hex": "1900ff",
+          "codes": ["55029"]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/voxelab.json
+++ b/filaments/voxelab.json
@@ -1,0 +1,653 @@
+{
+  "manufacturer": "Voxelab",
+  "filaments": [
+    {
+      "name": "ABS Pro {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Gray",
+          "hex": "28333d"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "ASA-CF",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        285,
+        290
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Marsala",
+          "hex": "550226"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "032c49"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PETG-CF",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        60,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Dusty Pink",
+          "hex": "ad8292"
+        },
+        {
+          "name": "Grass Green",
+          "hex": "698d7a"
+        },
+        {
+          "name": "Marsala",
+          "hex": "4e3b3d"
+        },
+        {
+          "name": "Midnight Blue",
+          "hex": "000e1c"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PLA-CF",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        55
+      ],
+      "colors": [
+        {
+          "name": "Midnight Blue",
+          "hex": "000035"
+        },
+        {
+          "name": "Volcanic Rock Gray",
+          "hex": "56596a"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Chameleon {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Abyssal Red",
+          "hex": "543459"
+        },
+        {
+          "name": "Burnt Titanium/Abyssel Red",
+          "hex": "1b4665"
+        },
+        {
+          "name": "Yellow/Green Gradient",
+          "hexes": [
+            "ffff00",
+            "808080"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Galaxy {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Galaxy Purple",
+          "hex": "5c5573"
+        }
+      ]
+    },
+    {
+      "name": "Glow {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Luminous Purple",
+          "hex": "9e73dd"
+        }
+      ]
+    },
+    {
+      "name": "High Speed Marble {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Marble Black",
+          "hex": "444143"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA+",
+      "density": 0.23,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        210
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Abyssal Purple",
+          "hex": "5d27a0"
+        },
+        {
+          "name": "Abyssal Red",
+          "hex": "6d233a"
+        },
+        {
+          "name": "Army Green",
+          "hex": "61775f"
+        },
+        {
+          "name": "Burnt Titanium & Abyssal Red",
+          "hex": "6d233a"
+        },
+        {
+          "name": "Ice Clear",
+          "hex": "f7f7f8"
+        },
+        {
+          "name": "Phantom Blue",
+          "hex": "1a3171"
+        },
+        {
+          "name": "Witch Green",
+          "hex": "11c85a"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Aurora Green",
+          "hex": "196318"
+        },
+        {
+          "name": "Burnt Titanium",
+          "hex": "000040"
+        },
+        {
+          "name": "Luminous Blue",
+          "hex": "5faac9"
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "831100"
+        },
+        {
+          "name": "Ultramarine Blue",
+          "hex": "152c91"
+        }
+      ]
+    },
+    {
+      "name": "High Speed {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        270
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Burnt Titanium",
+          "hex": "2f5b60"
+        }
+      ]
+    },
+    {
+      "name": "PETG Pro {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        240
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Gradient Silver and Blue",
+          "hex": "8bccfa"
+        },
+        {
+          "name": "Metal Rainbow",
+          "hex": "a1a05f"
+        },
+        {
+          "name": "Rainbow Candy",
+          "hex": "ffc0cb"
+        },
+        {
+          "name": "Silk Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Silver",
+          "hex": "aeaeae"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "000b5c"
+        },
+        {
+          "name": "Nebula Purple",
+          "hex": "25003d"
+        },
+        {
+          "name": "Purple",
+          "hex": "521b92"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Pro {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        25
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Grey",
+          "hex": "34424b"
+        },
+        {
+          "name": "Purple",
+          "hex": "61187c"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        25,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Baby blue",
+          "hex": "0573e1"
+        },
+        {
+          "name": "Green",
+          "hex": "52d548"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "f0a800"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        170,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Orange",
+          "hex": "e08634"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/wanhao.json
+++ b/filaments/wanhao.json
@@ -1,0 +1,201 @@
+{
+  "manufacturer": "Wanhao",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        220
+      ],
+      "bed_temp_range": [
+        0,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "708090"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Purple",
+          "hex": "800080"
+        },
+        {
+          "name": "Gold",
+          "hex": "ffd700"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "translucent": true
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff",
+          "translucent": true
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_weight": 220,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        250
+      ],
+      "bed_temp_range": [
+        80,
+        120
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0000ff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "ffff00"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8c00"
+        },
+        {
+          "name": "Green",
+          "hex": "008000"
+        }
+      ],
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/wellshow.json
+++ b/filaments/wellshow.json
@@ -1,0 +1,157 @@
+{
+  "manufacturer": "Wellshow",
+  "filaments": [
+    {
+      "name": "PC {color_name}",
+      "material": "PC",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "4b5320"
+        },
+        {
+          "name": "Blue",
+          "hex": "1c57b2"
+        },
+        {
+          "name": "Gray",
+          "hex": "3d3d3d"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        210
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Christmas Green",
+          "hex": "808080"
+        },
+        {
+          "name": "Gold Silk",
+          "hex": "c4bd97"
+        },
+        {
+          "name": "Metallic Red",
+          "hex": "a62c2b"
+        },
+        {
+          "name": "silk gold and rose red",
+          "hex": "ffc853"
+        }
+      ],
+      "country_of_origin": "China"
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Cold Gray",
+          "hex": "888991"
+        },
+        {
+          "name": "Latte Brown/Light Brown",
+          "hex": "cfb498"
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0"
+        },
+        {
+          "name": "Wood Brown",
+          "hex": "c99c6e"
+        }
+      ],
+      "country_of_origin": "China"
+    }
+  ]
+}

--- a/filaments/winkle.json
+++ b/filaments/winkle.json
@@ -1,0 +1,1225 @@
+{
+  "manufacturer": "Winkle",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Glacier White",
+          "hex": "f0f8ff",
+          "codes": [
+            "abs-winkle-filament-glacier-white-0250-kg-175-mm"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "abs-winkle-filament-0250-kg-175-mm-jet-black"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "codes": [
+            "abs-winkle-filament-0250-kg-175-mm-natural"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.07,
+      "weights": [
+        {
+          "weight": 250
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        235,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        110
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Ash Gray",
+          "hex": "b2beb5",
+          "codes": [
+            "asa-winkle-filament-0250-kg-175-mm-ash-gray"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "asa-winkle-filament-0250-kg-175-mm-jet-black"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "codes": [
+            "asa-winkle-filament-0250-kg-175-mm-natural"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG CF {color_name}",
+      "material": "PETG-CF",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 300
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Carbon Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "winkle-carbon-fiber-petg-filament-175-mm-0300-kg-carbon-black"
+          ]
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 300
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Amber",
+          "hex": "808080",
+          "codes": [
+            "winkle-crystal-petg-filament-175-mm-0300-kg-amber"
+          ]
+        },
+        {
+          "name": "Aquamarine blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "winkle-crystal-petg-filament-175-mm-0300-kg-aquamarine-blue"
+          ]
+        },
+        {
+          "name": "Ash Gray",
+          "hex": "b2beb5",
+          "codes": [
+            "winkle-petg-filament-175-mm-ash-gray-0300-kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "rpetg-filament-en13501-1-fr-winkle-175-mm-1-kg-black"
+          ]
+        },
+        {
+          "name": "Deep Mauve",
+          "hex": "e0b0ff",
+          "codes": [
+            "winkle-crystal-petg-filament-175-mm-0300-kg-deep-mauve"
+          ]
+        },
+        {
+          "name": "Devil Red",
+          "hex": "cc0000",
+          "codes": [
+            "winkle-petg-filament-175-mm-0300-kg-devil-red"
+          ]
+        },
+        {
+          "name": "Glacier White",
+          "hex": "f0f8ff",
+          "codes": [
+            "winkle-petg-filament-glacier-white-175-mm-0300-kg"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "winkle-petg-filament-175-mm-jet-black-0300-kg"
+          ]
+        },
+        {
+          "name": "Lemon Yellow",
+          "hex": "fff44f",
+          "codes": [
+            "winkle-petg-filament-175-mm-0300-kg-lemon-yellow"
+          ]
+        },
+        {
+          "name": "Lime",
+          "hex": "808080",
+          "codes": [
+            "winkle-crystal-petg-filament-175-mm-0300-kg-lime"
+          ]
+        },
+        {
+          "name": "PETG Pack 10 Kg Mystery",
+          "hex": "808080",
+          "codes": [
+            "petg-pack-10-kg-mystery"
+          ]
+        },
+        {
+          "name": "PETG Prototype Winkle Filament",
+          "hex": "808080",
+          "codes": [
+            "prototype-winkle-petg-filament-175-mm-transparent-1-kg"
+          ]
+        },
+        {
+          "name": "Pine Green",
+          "hex": "01796f",
+          "codes": [
+            "winkle-petg-filament-175-mm-0300-kg-pine-green"
+          ]
+        },
+        {
+          "name": "Random Color",
+          "hex": "808080",
+          "codes": [
+            "winkle-recycled-petg-filament-175-mm-0300-kg-random-color"
+          ]
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "4169e1",
+          "codes": [
+            "winkle-petg-filament-175-mm-0300-kg-royal-blue"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "winkle-petg-filament-175-mm-0300-kg-silver"
+          ]
+        },
+        {
+          "name": "Technical Polypropylene Pack. Free PETG Coil",
+          "hex": "808080",
+          "codes": [
+            "technical-polypropylene-pack-free-petg-coil"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "codes": [
+            "winkle-petg-filament-175-mm-transparent-0300-kg"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "rpetg-filament-en13501-1-fr-winkle-175-mm-1-kg-white"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA HD {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 300
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Alien Green",
+          "hex": "2e7d32",
+          "codes": [
+            "glow-winkle-hd-pla-glow-winkle-filament-175-mm-0300-kg-alien-green"
+          ]
+        },
+        {
+          "name": "Army Green",
+          "hex": "2e7d32",
+          "codes": [
+            "pla-hd-glitter-particles-winkle-pla-hd-glitter-filament-175-mm-0300-kg-army-green"
+          ]
+        },
+        {
+          "name": "Ash Gray",
+          "hex": "b2beb5",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-ash-gray-0300-kg"
+          ]
+        },
+        {
+          "name": "Avocado Green",
+          "hex": "568203",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-avocado-green-0300-kg"
+          ]
+        },
+        {
+          "name": "BLUE GRANITE",
+          "hex": "1b4e9b",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-blue-granite"
+          ]
+        },
+        {
+          "name": "BRICK",
+          "hex": "808080",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-brick"
+          ]
+        },
+        {
+          "name": "Banana Yellow",
+          "hex": "fdd835",
+          "codes": [
+            "pla-hd-pastel-winkle-pla-filament-175-mm-0300-kg-banana-yellow"
+          ]
+        },
+        {
+          "name": "Beige",
+          "hex": "d4c4a8",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-beige"
+          ]
+        },
+        {
+          "name": "Blue Night",
+          "hex": "1b4e9b",
+          "codes": [
+            "pla-hd-glitter-particles-winkle-pla-hd-glitter-filament-175-mm-0300-kg-blue-night"
+          ]
+        },
+        {
+          "name": "Brown Acacia",
+          "hex": "a0522d",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-brown-acacia"
+          ]
+        },
+        {
+          "name": "CONCRETE",
+          "hex": "808080",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-concrete"
+          ]
+        },
+        {
+          "name": "Canary Yellow",
+          "hex": "ffef00",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-canary-yellow-0300-kg"
+          ]
+        },
+        {
+          "name": "Cloud blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "pla-hd-pastel-winkle-pla-filament-175-mm-0300-kg-cloud-blue"
+          ]
+        },
+        {
+          "name": "Copper",
+          "hex": "b87333",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-copper"
+          ]
+        },
+        {
+          "name": "Coral",
+          "hex": "808080",
+          "codes": [
+            "pla-hd-glitter-particles-winkle-pla-hd-glitter-filament-175-mm-0300-kg-coral"
+          ]
+        },
+        {
+          "name": "Cotton Candy Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "pla-hd-pastel-winkle-pla-filament-175-mm-0300-kg-cotton-candy-pink"
+          ]
+        },
+        {
+          "name": "Dark Bronze",
+          "hex": "808080",
+          "codes": [
+            "winkle-interference-hd-pla-filament-175-mm-0300-kg-dark-bronze"
+          ]
+        },
+        {
+          "name": "Devil Red",
+          "hex": "cc0000",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-devil-red"
+          ]
+        },
+        {
+          "name": "Ebony Brown",
+          "hex": "3d2314",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-ebony-brown"
+          ]
+        },
+        {
+          "name": "Ecotisa Green",
+          "hex": "228b22",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-ecotisa-green"
+          ]
+        },
+        {
+          "name": "Electric Green",
+          "hex": "2e7d32",
+          "codes": [
+            "winkle-fluorescent-hd-pla-fluorescent-pla-filament-175-mm-0300-kg-electric-green"
+          ]
+        },
+        {
+          "name": "Electric Orange",
+          "hex": "f57c00",
+          "codes": [
+            "winkle-fluorescent-hd-pla-fluorescent-pla-filament-175-mm-0300-kg-electric-orange"
+          ]
+        },
+        {
+          "name": "Electric Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "winkle-fluorescent-hd-pla-fluorescent-pla-filament-175-mm-0300-kg-electric-pink"
+          ]
+        },
+        {
+          "name": "Electric Yellow",
+          "hex": "fdd835",
+          "codes": [
+            "winkle-fluorescent-hd-pla-fluorescent-pla-filament-175-mm-0300-kg-electric-yellow"
+          ]
+        },
+        {
+          "name": "Emerald Green",
+          "hex": "2e7d32",
+          "codes": [
+            "winkle-interference-hd-pla-filament-175-mm-0300-kg-emerald-green"
+          ]
+        },
+        {
+          "name": "Galaxy Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "pla-hd-glitter-particles-winkle-pla-hd-glitter-filament-175-mm-0300-kg-galaxy-black"
+          ]
+        },
+        {
+          "name": "Galaxy Blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "winkle-interference-hd-pla-filament-175-mm-0300-kg-galaxy-blue"
+          ]
+        },
+        {
+          "name": "Ghost white",
+          "hex": "f8f8ff",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-1-kg-ghost-white"
+          ]
+        },
+        {
+          "name": "Glacier White",
+          "hex": "f0f8ff",
+          "codes": [
+            "hd-winkle-pla-filament-glacier-white-175-mm-0300-kg"
+          ]
+        },
+        {
+          "name": "Gold",
+          "hex": "daa520",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-gold"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-jet-black-0300-kg"
+          ]
+        },
+        {
+          "name": "Mahogany Brown",
+          "hex": "6d2e1f",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-mahogany-brown"
+          ]
+        },
+        {
+          "name": "Marble",
+          "hex": "e8e4df",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-marble"
+          ]
+        },
+        {
+          "name": "Mauve",
+          "hex": "e0b0ff",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-mauve"
+          ]
+        },
+        {
+          "name": "Mother-of-pearl",
+          "hex": "f0e6d8",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-mother-of-pearl"
+          ]
+        },
+        {
+          "name": "Nemo Orange",
+          "hex": "ff6600",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-nemo-orange"
+          ]
+        },
+        {
+          "name": "PLA HD Lithophane Pack 1.75mm, 300g + 1kg Transition Filament",
+          "hex": "808080",
+          "codes": [
+            "pack-litofanias-pla-hd-winkle-175mm-pack-litofanias-300g-1kg-transicion"
+          ]
+        },
+        {
+          "name": "Pacific Blue",
+          "hex": "1e90ff",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-pacific-blue"
+          ]
+        },
+        {
+          "name": "Pink Bubblegum",
+          "hex": "ff85a2",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-pink-bubblegum"
+          ]
+        },
+        {
+          "name": "Purple",
+          "hex": "800080",
+          "codes": [
+            "pla-hd-glitter-particles-winkle-pla-hd-glitter-filament-175-mm-0300-kg-purple"
+          ]
+        },
+        {
+          "name": "Purple Winkle",
+          "hex": "9966cc",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-purple-winkle"
+          ]
+        },
+        {
+          "name": "QUARTZ",
+          "hex": "808080",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-quartz"
+          ]
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "4169e1",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-royal-blue"
+          ]
+        },
+        {
+          "name": "Sand",
+          "hex": "c2b280",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-sand"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-silver"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-0300-kg-sky-blue"
+          ]
+        },
+        {
+          "name": "Soft Lilac",
+          "hex": "808080",
+          "codes": [
+            "pla-hd-pastel-winkle-pla-filament-175-mm-0300-kg-soft-lilac"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "codes": [
+            "hd-winkle-pla-filament-175-mm-transparent-0300-kg"
+          ]
+        },
+        {
+          "name": "Turmeric Yellow",
+          "hex": "fdd835",
+          "codes": [
+            "pla-hd-pastel-winkle-pla-filament-175-mm-0300-kg-turmeric-yellow"
+          ]
+        },
+        {
+          "name": "Turquoise Blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "pla-hd-pastel-winkle-pla-filament-175-mm-0300-kg-turquoise-blue"
+          ]
+        },
+        {
+          "name": "Violet Agate",
+          "hex": "808080",
+          "codes": [
+            "winkle-interference-hd-pla-filament-175-mm-0300-kg-violet-agate"
+          ]
+        },
+        {
+          "name": "YELLOW MARBLE",
+          "hex": "fdd835",
+          "codes": [
+            "texture-winkle-hd-pla-filament-175-mm-0300-kg-yellow-marble"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA HS {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Ash Gray",
+          "hex": "b2beb5",
+          "codes": [
+            "pla-high-speed-winkle-filament-175-mm-1-kg-ash-gray"
+          ]
+        },
+        {
+          "name": "Avocado Green",
+          "hex": "568203",
+          "codes": [
+            "pla-high-speed-winkle-filament-175-mm-1-kg-avocado-green"
+          ]
+        },
+        {
+          "name": "Canary Yellow",
+          "hex": "ffef00",
+          "codes": [
+            "pla-high-speed-winkle-filament-175-mm-1-kg-canary-yellow"
+          ]
+        },
+        {
+          "name": "Devil Red",
+          "hex": "cc0000",
+          "codes": [
+            "pla-high-speed-winkle-filament-175-mm-1-kg-devil-red"
+          ]
+        },
+        {
+          "name": "Glacier White",
+          "hex": "f0f8ff",
+          "codes": [
+            "pla-high-speed-winkle-filament-glacier-white-175-mm-1-kg"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "pla-high-speed-winkle-filament-175-mm-1-kg-jet-black"
+          ]
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "87ceeb",
+          "codes": [
+            "pla-high-speed-winkle-filament-175-mm-1-kg-sky-blue"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 300
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "ALEMANIA",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-alemania"
+          ]
+        },
+        {
+          "name": "ARGENTINA",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-argentina"
+          ]
+        },
+        {
+          "name": "AURORA BOREALIS",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-aurora-borealis"
+          ]
+        },
+        {
+          "name": "COLOMBIA",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-colombia"
+          ]
+        },
+        {
+          "name": "DUBAI CHOCOLATE",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-dubai-chocolate"
+          ]
+        },
+        {
+          "name": "ESPAÑA",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-espana"
+          ]
+        },
+        {
+          "name": "FRANCIA, PAISES BAJOS, EEUU",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-francia-paises-bajos-eeuu"
+          ]
+        },
+        {
+          "name": "ITALIA, MEXICO",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-italia-mexico"
+          ]
+        },
+        {
+          "name": "Irish green",
+          "hex": "2e7d32",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-irish-green"
+          ]
+        },
+        {
+          "name": "King Gold",
+          "hex": "daa520",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-king-gold"
+          ]
+        },
+        {
+          "name": "METAMORPHOSIS",
+          "hex": "ff0080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-metamorphosis"
+          ]
+        },
+        {
+          "name": "Mercury Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-mercury-silver"
+          ]
+        },
+        {
+          "name": "Old Copper",
+          "hex": "b87333",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-old-copper"
+          ]
+        },
+        {
+          "name": "POLONIA, AUSTRIA, JAPON, MALTA, DINAMARCA, SUIZA, QATAR, TURQUIA, PERU, SUIZA",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-polonia-austria-japon-malta-dinamarca-suiza-qatar-turquia-peru-suiza"
+          ]
+        },
+        {
+          "name": "PORTUGAL, MARRUECOS",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-portugal-marruecos"
+          ]
+        },
+        {
+          "name": "Ruby Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-ruby-pink"
+          ]
+        },
+        {
+          "name": "Ruby Red",
+          "hex": "c41e2a",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-ruby-red"
+          ]
+        },
+        {
+          "name": "SUECIA, UCRANIA",
+          "hex": "808080",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-suecia-ucrania"
+          ]
+        },
+        {
+          "name": "Smile Blue by Maria",
+          "hex": "1b4e9b",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-1-kg-smile-blue-by-maria"
+          ]
+        },
+        {
+          "name": "Snow White",
+          "hex": "f5f5f5",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-snow-white"
+          ]
+        },
+        {
+          "name": "Steel Blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-steel-blue"
+          ]
+        },
+        {
+          "name": "White Gold",
+          "hex": "f5f5f5",
+          "codes": [
+            "silk-winkle-pla-filament-175-mm-0300-kg-white-gold"
+          ]
+        },
+        {
+          "name": "Yellow-Green",
+          "hex": "2e7d32",
+          "codes": [
+            "pla-silk-tricolor-winkle-pla-filament-175-mm-1kg-175-mm-1-kg-yellow-green"
+          ]
+        }
+      ],
+      "finish": "glossy"
+    },
+    {
+      "name": "PLA UL94 {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "pla-ul94-v0-winkle-filament-175-mm-0750-kg-black"
+          ]
+        },
+        {
+          "name": "Gray",
+          "hex": "808080",
+          "codes": [
+            "pla-ul94-v0-winkle-filament-175-mm-0750-kg-gray"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "pla-ul94-v0-winkle-filament-175-mm-0750-kg-white"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 300
+        },
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "3D pen pack with PLA for children and adults",
+          "hex": "808080",
+          "codes": [
+            "3d-pen-pack-with-pla-for-children-and-adults"
+          ]
+        },
+        {
+          "name": "Ash Gray",
+          "hex": "b2beb5",
+          "codes": [
+            "pla-850-winkle-filament-175-mm-ash-gray-0300-kg"
+          ]
+        },
+        {
+          "name": "Avocado Green",
+          "hex": "568203",
+          "codes": [
+            "pla-pro-winkle-filament-175-mm-avocado-green-0300-kg"
+          ]
+        },
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "tough-winkle-pla-filament-175-mm-0300-kg-black"
+          ]
+        },
+        {
+          "name": "Canary Yellow",
+          "hex": "ffef00",
+          "codes": [
+            "pla-pro-winkle-filament-175-mm-canary-yellow-0300-kg"
+          ]
+        },
+        {
+          "name": "Cobalt Blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "mate-winkle-pla-filament-175-mm-1-kg-cobalt-blue"
+          ]
+        },
+        {
+          "name": "Cream White",
+          "hex": "f5f5f5",
+          "codes": [
+            "mate-winkle-pla-filament-175-mm-1-kg-cream-white"
+          ]
+        },
+        {
+          "name": "Dark Blue",
+          "hex": "1b4e9b",
+          "codes": [
+            "tough-winkle-pla-filament-175-mm-0300-kg-dark-blue"
+          ]
+        },
+        {
+          "name": "Devil Red",
+          "hex": "cc0000",
+          "codes": [
+            "pla-pro-winkle-filament-175-mm-0300-kg-devil-red"
+          ]
+        },
+        {
+          "name": "Glacier White",
+          "hex": "f0f8ff",
+          "codes": [
+            "pla-850-winkle-filament-glacier-white-175-mm-0300-kg"
+          ]
+        },
+        {
+          "name": "Graphite Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "mate-winkle-pla-filament-175-mm-1-kg-graphite-black"
+          ]
+        },
+        {
+          "name": "Iron Gray",
+          "hex": "808080",
+          "codes": [
+            "tough-winkle-pla-filament-175-mm-0300-kg-iron-gray"
+          ]
+        },
+        {
+          "name": "Jet Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "pla-850-winkle-filament-175-mm-jet-black-0300-kg"
+          ]
+        },
+        {
+          "name": "Maple",
+          "hex": "808080",
+          "codes": [
+            "wood-winkle-pla-filament-175-mm-0300-kg-maple"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "codes": [
+            "tough-winkle-pla-filament-175-mm-natural-0300-kg"
+          ]
+        },
+        {
+          "name": "PLA Pack 10 Kg Mystery",
+          "hex": "808080",
+          "codes": [
+            "pla-pack-10-kg-mystery"
+          ]
+        },
+        {
+          "name": "Pacific Blue",
+          "hex": "1e90ff",
+          "codes": [
+            "pla-pro-winkle-filament-175-mm-0300-kg-pacific-blue"
+          ]
+        },
+        {
+          "name": "Pack Filament PLA Mate Home Decor. Free extra spool",
+          "hex": "808080",
+          "codes": [
+            "pack-filament-pla-mate-home-decor-free-extra-spool"
+          ]
+        },
+        {
+          "name": "Pine",
+          "hex": "808080",
+          "codes": [
+            "wood-winkle-pla-filament-175-mm-0300-kg-pine"
+          ]
+        },
+        {
+          "name": "Random Color",
+          "hex": "808080",
+          "codes": [
+            "winkle-recycled-pla-filament-175-mm-0300-kg-random-color"
+          ]
+        },
+        {
+          "name": "Raspberry Red",
+          "hex": "c41e2a",
+          "codes": [
+            "mate-winkle-pla-filament-175-mm-1-kg-raspberry-red"
+          ]
+        },
+        {
+          "name": "Smoke Gray",
+          "hex": "808080",
+          "codes": [
+            "mate-winkle-pla-filament-175-mm-1-kg-smoke-gray"
+          ]
+        },
+        {
+          "name": "Transparent",
+          "hex": "ffffff",
+          "codes": [
+            "pla-850-winkle-filament-175-mm-1-kg-transparent"
+          ]
+        },
+        {
+          "name": "Wood PLA Filament Pack. Free extra spool",
+          "hex": "c4a574",
+          "codes": [
+            "wood-pla-filament-pack-free-extra-spool"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PP {color_name}",
+      "material": "PP",
+      "density": 0.9,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "country_of_origin": "Spain",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "pp-polypropylene-winkle-filament-175-mm-black-700-g"
+          ]
+        },
+        {
+          "name": "Natural",
+          "hex": "e8dcc8",
+          "codes": [
+            "pp-polypropylene-winkle-filament-175-mm-natural-700-g"
+          ]
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5",
+          "codes": [
+            "pp-polypropylene-winkle-filament-175-mm-white-700-g"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/xingtongzhilian.json
+++ b/filaments/xingtongzhilian.json
@@ -1,0 +1,422 @@
+{
+  "manufacturer": "Xingtongzhilian",
+  "filaments": [
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marble Black",
+          "hex": "b5b0b0",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "Matte Tri Color {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Red-Golg-Purple",
+          "hex": "ff0000"
+        }
+      ]
+    },
+    {
+      "name": "Multicolor Multicolor {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Purple - Blue",
+          "hex": "c800ff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "grey",
+          "hex": "575757"
+        },
+        {
+          "name": "Pink",
+          "hex": "e66bcf"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fbff24"
+        }
+      ]
+    },
+    {
+      "name": "PETG+PLUS {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        55,
+        55
+      ],
+      "colors": [
+        {
+          "name": "red",
+          "hex": "bd0000"
+        },
+        {
+          "name": "white",
+          "hex": "fafafa"
+        },
+        {
+          "name": "Green",
+          "hex": "00fc00"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Bronze",
+          "hex": "cd7f32"
+        },
+        {
+          "name": "Gold",
+          "hex": "a29d0b"
+        },
+        {
+          "name": "Golden",
+          "hex": "f5e532"
+        },
+        {
+          "name": "Silk Blue",
+          "hex": "0095ff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        30,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff3533"
+        },
+        {
+          "name": "Blue",
+          "hex": "4474e4"
+        },
+        {
+          "name": "Pink",
+          "hex": "f4a3f5"
+        },
+        {
+          "name": "Transparent",
+          "hex": "bfbfbf"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "yellow",
+          "hex": "ede60c"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Silk {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        65,
+        65
+      ],
+      "colors": [
+        {
+          "name": "Blue-Green-Purple",
+          "hex": "1285f8"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "00f900"
+        },
+        {
+          "name": "white",
+          "hex": "fafafa"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Red/Gold",
+          "hexes": [
+            "ff0000",
+            "ffd700"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        230
+      ],
+      "bed_temp_range": [
+        45,
+        45
+      ],
+      "colors": [
+        {
+          "name": "Blue-Red-Green",
+          "hex": "0000ff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "PETG+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        230
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Clear",
+          "hex": "ffffff"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/xzn.json
+++ b/filaments/xzn.json
@@ -1,0 +1,248 @@
+{
+  "manufacturer": "XZN",
+  "filaments": [
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "B0DWMZWY52"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "B0CZRYHW7M"
+          ]
+        },
+        {
+          "name": "Dark Green Bronze",
+          "hex": "4a5d23",
+          "codes": [
+            "B0CZRZ3B98"
+          ]
+        },
+        {
+          "name": "Pink",
+          "hex": "ff69b4",
+          "codes": [
+            "B0CZRZ58V3"
+          ]
+        },
+        {
+          "name": "Royal Blue",
+          "hex": "4169e1",
+          "codes": [
+            "B0CZRXG6JV"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Silk Rainbow PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "finish": "glossy",
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Rainbow",
+          "hexes": [
+            "ff0000",
+            "ff8800",
+            "ffff00",
+            "00ff00",
+            "0000ff",
+            "8b00ff"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "B0FRXFTGW9"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Gradient PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        70
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Blue Purple Black",
+          "hexes": [
+            "0000ff",
+            "800080",
+            "000000"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "B0DWMJPP6Z"
+          ]
+        },
+        {
+          "name": "Red Blue Green",
+          "hexes": [
+            "cc0000",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "B0DWMKFQ32"
+          ]
+        },
+        {
+          "name": "Red Gold Purple",
+          "hexes": [
+            "cc0000",
+            "daa520",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal",
+          "codes": [
+            "B0DWMLM9SH"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        90
+      ],
+      "country_of_origin": "China",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a",
+          "codes": [
+            "B0CZRY989T"
+          ]
+        },
+        {
+          "name": "Clear",
+          "hex": "ffffff",
+          "codes": [
+            "B0CZRXVFMN"
+          ]
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32",
+          "codes": [
+            "B0DWN6QD18"
+          ]
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a",
+          "codes": [
+            "B0DWN8M7YC"
+          ]
+        },
+        {
+          "name": "Silver",
+          "hex": "c0c0c0",
+          "codes": [
+            "B0CZRY2B8F"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/yousu.json
+++ b/filaments/yousu.json
@@ -1,0 +1,43 @@
+{
+    "manufacturer": "YOUSU",
+    "filaments": [
+        {
+            "name": "YOUSU PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 220
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/yoyi.json
+++ b/filaments/yoyi.json
@@ -1,0 +1,227 @@
+{
+  "manufacturer": "YOYI",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 800
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        35,
+        35
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "TPU",
+      "density": 1.21,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "fb23af"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 400
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        240
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "808080"
+        },
+        {
+          "name": "Blue",
+          "hex": "4808f7"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "38acff"
+        }
+      ]
+    },
+    {
+      "name": "Silk Like {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "5d91c6"
+        },
+        {
+          "name": "olive green",
+          "hex": "808000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Transparent Red",
+          "hex": "c52600"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Translucent Clear",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        210,
+        240
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Living Coral",
+          "hex": "e01b24"
+        },
+        {
+          "name": "Red",
+          "hex": "e22400"
+        },
+        {
+          "name": "Translucence Yellow",
+          "hex": "fff995"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Natural Wood",
+          "hex": "808080"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/yuaneang.json
+++ b/filaments/yuaneang.json
@@ -1,0 +1,469 @@
+{
+  "manufacturer": "Yuaneang",
+  "filaments": [
+    {
+      "name": "85A {color_name}",
+      "material": "TPU",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        200,
+        220
+      ],
+      "bed_temp_range": [
+        80,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "ASA {color_name}",
+      "material": "ASA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        270
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Marble {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        200
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Marble",
+          "hex": "c9c9c9",
+          "pattern": "marble"
+        }
+      ],
+      "pattern": "marble"
+    },
+    {
+      "name": "PA {color_name}",
+      "material": "PA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "colors": [
+        {
+          "name": "Grey",
+          "hex": "646464"
+        }
+      ]
+    },
+    {
+      "name": "PLA Matte {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Army Green",
+          "hex": "044f00"
+        },
+        {
+          "name": "Military Brown",
+          "hex": "4f361f"
+        },
+        {
+          "name": "Sunrise Orange",
+          "hex": "e67451"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        180,
+        220
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Macaroon Rainbow",
+          "hex": "808080"
+        },
+        {
+          "name": "Mini Color Rainbow",
+          "hex": "39857c"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        40,
+        60
+      ],
+      "colors": [
+        {
+          "name": "black",
+          "hex": "808080"
+        },
+        {
+          "name": "BLUE",
+          "hex": "3000db"
+        },
+        {
+          "name": "Dragon Liver Wood",
+          "hex": "57312c"
+        },
+        {
+          "name": "GREEN",
+          "hex": "79f769"
+        },
+        {
+          "name": "Imitative Wood",
+          "hex": "808080"
+        },
+        {
+          "name": "Mixed Trees",
+          "hex": "a37d60"
+        },
+        {
+          "name": "ORANGE",
+          "hex": "ee823a"
+        },
+        {
+          "name": "PINK",
+          "hex": "f96cb7"
+        },
+        {
+          "name": "Purple",
+          "hex": "e633c5"
+        },
+        {
+          "name": "RED",
+          "hex": "ff0000"
+        },
+        {
+          "name": "SILVER",
+          "hex": "c0cbd3"
+        },
+        {
+          "name": "Skin",
+          "hex": "e3ab9d"
+        },
+        {
+          "name": "White",
+          "hex": "c6ffff"
+        },
+        {
+          "name": "WOOD",
+          "hex": "f5c08e"
+        },
+        {
+          "name": "YELLOW",
+          "hex": "e6f769"
+        }
+      ]
+    },
+    {
+      "name": "Rainbow {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        255
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Candy Color",
+          "hex": "808080"
+        },
+        {
+          "name": "Early Spring",
+          "hex": "808080"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Silk Triple {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        200
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black/Blue/Purple",
+          "hexes": [
+            "000000",
+            "0000ff",
+            "800080"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Green / Purple / Copper",
+          "hexes": [
+            "008000",
+            "800080",
+            "79f769"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / Blue / Green",
+          "hexes": [
+            "ff0000",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Red / Yellow / Blue",
+          "hexes": [
+            "ff0000",
+            "ffff00",
+            "0000ff"
+          ],
+          "multi_color_direction": "longitudinal"
+        },
+        {
+          "name": "Yellow / Blue / Green",
+          "hexes": [
+            "ffff00",
+            "0000ff",
+            "008000"
+          ],
+          "multi_color_direction": "longitudinal"
+        }
+      ]
+    },
+    {
+      "name": "Wood {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        210
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Dark Wood",
+          "hex": "9c7727"
+        },
+        {
+          "name": "Light Wood",
+          "hex": "808080"
+        },
+        {
+          "name": "Red Wood",
+          "hex": "808080"
+        },
+        {
+          "name": "Wood",
+          "hex": "808080"
+        }
+      ],
+      "fill": "wood"
+    }
+  ]
+}

--- a/filaments/yumi.json
+++ b/filaments/yumi.json
@@ -1,0 +1,203 @@
+{
+  "manufacturer": "YUMI",
+  "filaments": [
+    {
+      "name": "95A {color_name}",
+      "material": "TPU",
+      "density": 1.2,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        250
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Blue",
+          "hex": "0a32d1"
+        },
+        {
+          "name": "Green",
+          "hex": "4cce1c"
+        },
+        {
+          "name": "Orange",
+          "hex": "e1890e"
+        },
+        {
+          "name": "Red",
+          "hex": "e81111"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        40,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Gold Copper",
+          "hex": "ffaa00"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ Matte {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Macaron Kinder",
+          "hex": "91633b"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Blanc",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Caramel Beurre Salé",
+          "hex": "b07240"
+        },
+        {
+          "name": "Skin",
+          "hex": "ffc4ab"
+        },
+        {
+          "name": "Slate Grey",
+          "hex": "919191"
+        },
+        {
+          "name": "Vert Militaire",
+          "hex": "125e13"
+        },
+        {
+          "name": "Violet",
+          "hex": "951891"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fffb00"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        185,
+        220
+      ],
+      "bed_temp_range": [
+        70,
+        70
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "c0c0c0"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/yxpolyer.json
+++ b/filaments/yxpolyer.json
@@ -1,0 +1,555 @@
+{
+  "manufacturer": "yxpolyer",
+  "filaments": [
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Grey Beige",
+          "hex": "9d8a75"
+        }
+      ]
+    },
+    {
+      "name": "ABS+PLUS {color_name}",
+      "material": "ABS+PLUS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PA-CF",
+      "density": 1.14,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Cf {color_name}",
+      "material": "PC-CF",
+      "density": 1.16,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        240,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ],
+      "fill": "carbon fiber"
+    },
+    {
+      "name": "Esd {color_name}",
+      "material": "ABS",
+      "density": 1.061,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        90,
+        90
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        30,
+        40
+      ],
+      "colors": [
+        {
+          "name": "Brown, Food-Grade Soft PLA",
+          "hex": "ac724d"
+        },
+        {
+          "name": "Mint Green, Food Safe Soft",
+          "hex": "9cdad1"
+        },
+        {
+          "name": "Pink, Food-Grade Soft PLA",
+          "hex": "f794bc"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Flexible {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Orange, Food-Grade Soft PLA",
+          "hex": "fb9609"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PA {color_name}",
+      "material": "PA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        250,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "d5d8dc"
+        }
+      ]
+    },
+    {
+      "name": "PA6 {color_name}",
+      "material": "PA6",
+      "density": 1.13,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        280
+      ],
+      "bed_temp_range": [
+        80,
+        80
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Red",
+          "hex": "6f0000"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        240
+      ],
+      "bed_temp_range": [
+        30,
+        30
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Blue",
+          "hex": "009ef1"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fffc41"
+        }
+      ]
+    },
+    {
+      "name": "PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        195,
+        235
+      ],
+      "bed_temp_range": [
+        60,
+        60
+      ],
+      "colors": [
+        {
+          "name": "Azure Blue",
+          "hex": "007dfa"
+        },
+        {
+          "name": "Brick Red - Food Safe",
+          "hex": "953738"
+        },
+        {
+          "name": "Brown - Food Safe",
+          "hex": "865743"
+        },
+        {
+          "name": "Cool Gray - Food Safe",
+          "hex": "b7b7b7"
+        },
+        {
+          "name": "Flex White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Gold - Food Safe",
+          "hex": "cf9755"
+        },
+        {
+          "name": "Green - Food Safe",
+          "hex": "16a84d"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        },
+        {
+          "name": "Orange - Food Safe",
+          "hex": "ff8806"
+        },
+        {
+          "name": "Pastel Blue (Sky Blue) - Food Safe",
+          "hex": "5abae2"
+        },
+        {
+          "name": "Pastel Green-Food Safe",
+          "hex": "96dd99"
+        },
+        {
+          "name": "Pastel Pink - Food Safe",
+          "hex": "e7d2ff"
+        },
+        {
+          "name": "Pure White - Food Safe",
+          "hex": "ffffff"
+        },
+        {
+          "name": "Raven Black - Food Safe",
+          "hex": "000000"
+        },
+        {
+          "name": "Silver - Food Safe",
+          "hex": "c2c2c2"
+        },
+        {
+          "name": "Skin - Food Safe",
+          "hex": "f2d3be"
+        },
+        {
+          "name": "Yellow - Food Safe",
+          "hex": "f0e936"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        235
+      ],
+      "bed_temp_range": [
+        50,
+        50
+      ],
+      "colors": [
+        {
+          "name": "Black and Gold",
+          "hex": "faf200"
+        }
+      ]
+    },
+    {
+      "name": "Support {color_name}",
+      "material": "HIPS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Breakaway White",
+          "hex": "ffffff"
+        },
+        {
+          "name": "White",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Support {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "ffffff"
+        }
+      ]
+    },
+    {
+      "name": "Translucent {color_name}",
+      "material": "ABS",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "08aa29"
+        },
+        {
+          "name": "Orange",
+          "hex": "ff8000"
+        }
+      ]
+    },
+    {
+      "name": "Transparent {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        220,
+        260
+      ],
+      "bed_temp_range": [
+        100,
+        100
+      ],
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "ff0000"
+        }
+      ]
+    }
+  ]
+}

--- a/filaments/ziro.json
+++ b/filaments/ziro.json
@@ -1,0 +1,62 @@
+{
+    "manufacturer": "Ziro",
+    "filaments": [
+        {
+            "name": "Ziro PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 55,
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                }
+            ]
+        },
+        {
+            "name": "Ziro Matte PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 205,
+            "bed_temp": 55,
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Matte Black",
+                    "hex": "1C1C1C"
+                },
+                {
+                    "name": "Matte White",
+                    "hex": "F5F5F5"
+                }
+            ]
+        }
+    ]
+}

--- a/filaments/zyltech.json
+++ b/filaments/zyltech.json
@@ -1,0 +1,112 @@
+{
+  "manufacturer": "Zyltech",
+  "filaments": [
+    {
+      "name": "Zyltech PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        190,
+        220
+      ],
+      "bed_temp_range": [
+        50,
+        60
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Red",
+          "hex": "c41e2a"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Green",
+          "hex": "2e7d32"
+        },
+        {
+          "name": "Yellow",
+          "hex": "fdd835"
+        },
+        {
+          "name": "Orange",
+          "hex": "f57c00"
+        },
+        {
+          "name": "Grey",
+          "hex": "808080"
+        },
+        {
+          "name": "Purple",
+          "hex": "6a1b9a"
+        },
+        {
+          "name": "Natural",
+          "hex": "e8e0d0"
+        }
+      ]
+    },
+    {
+      "name": "Zyltech PETG {color_name}",
+      "material": "PETG",
+      "density": 1.27,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "plastic"
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp_range": [
+        230,
+        250
+      ],
+      "bed_temp_range": [
+        70,
+        85
+      ],
+      "country_of_origin": "USA",
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "1a1a1a"
+        },
+        {
+          "name": "White",
+          "hex": "f5f5f5"
+        },
+        {
+          "name": "Blue",
+          "hex": "1b4e9b"
+        },
+        {
+          "name": "Clear",
+          "hex": "eaeaea",
+          "translucent": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR imports a large batch of community filament definitions and selected updates from the community-maintained database.

### Scope

- Adds many new manufacturer files under `filaments/`.
- Updates selected existing manufacturer files where the community database has additional compatible data.
- Fixes schema compatibility issues found during validation, including the Buddy3D PLA+ Lithophane name placeholder.

### Review notes

This is intentionally a broad catalog import. The automated checks verify JSON schema compatibility and that the combined `filaments.json` can be generated, but they do not prove every color value or product detail against manufacturer sources. Maintainer review should still focus on data quality, source confidence, and whether this should be split into smaller batches before merge.

### Validation
Ran locally after the latest fix:

```powershell
check-jsonschema --schemafile materials.schema.json materials.json
check-jsonschema --schemafile filaments.schema.json filaments\*.json
python scripts\compile_filaments.py
```

All commands passed locally. GitHub Actions also reports `validate` and `compile` as passing on the latest commit.