### PR TITLE
feat: preserve SDS and TDS URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Run compiler tests
+        run: python3 -m unittest discover -s tests -v
       - name: Compile filaments
         run: python3 scripts/compile_filaments.py
       - uses: actions/upload-artifact@v4

--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -214,6 +214,16 @@
                                 }
                             }
                         }
+                    },
+                    "sds_url": {
+                        "$comment": "Link to the Safety Data Sheet (SDS).",
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "tds_url": {
+                        "$comment": "Link to the Technical Data Sheet (TDS).",
+                        "type": "string",
+                        "format": "uri"
                     }
                 }
             }

--- a/scripts/compile_filaments.py
+++ b/scripts/compile_filaments.py
@@ -61,6 +61,8 @@ class Filament(TypedDict):
     pattern: NotRequired[Pattern | None]
     translucent: NotRequired[bool]
     glow: NotRequired[bool]
+    sds_url: NotRequired[str]
+    tds_url: NotRequired[str]
 
 
 SPOOL_TYPE_MAP = {
@@ -108,6 +110,8 @@ def expand_filament_data(manufacturer: str, data: Filament) -> Iterator[dict]:
     pattern = data.get("pattern", None)
     translucent = data.get("translucent", False)
     glow = data.get("glow", False)
+    sds_url = data.get("sds_url", None)
+    tds_url = data.get("tds_url", None)
 
     for weight_obj in weights:
         weight = weight_obj["weight"]
@@ -192,6 +196,8 @@ def expand_filament_data(manufacturer: str, data: Filament) -> Iterator[dict]:
                     "pattern": color_pattern,
                     "translucent": color_translucent,
                     "glow": color_glow,
+                    "sds_url": sds_url,
+                    "tds_url": tds_url,
                 }
 
 

--- a/tests/test_compile_filaments.py
+++ b/tests/test_compile_filaments.py
@@ -1,0 +1,27 @@
+import unittest
+
+from scripts.compile_filaments import expand_filament_data
+
+
+class FilamentDocumentLinkTests(unittest.TestCase):
+    def test_document_links_are_preserved_in_compiled_output(self):
+        filament = {
+            "name": "PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [{"weight": 1000}],
+            "diameters": [1.75],
+            "colors": [{"name": "Red", "hex": "FF0000"}],
+            "sds_url": "https://example.com/pla-sds.pdf",
+            "tds_url": "https://example.com/pla-tds.pdf",
+        }
+
+        compiled = list(expand_filament_data("Example", filament))
+
+        self.assertEqual(len(compiled), 1)
+        self.assertEqual(compiled[0]["sds_url"], filament["sds_url"])
+        self.assertEqual(compiled[0]["tds_url"], filament["tds_url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- allow optional `sds_url` and `tds_url` fields in filament source data
- preserve both links in the compiled database output
- add a regression test and run it in CI

## Why

This extracts the document-link metadata work from the former large PR #277 into a focused change. It provides the SpoolmanDB data-layer groundwork for Donkie/Spoolman#395. Import and UI handling in Spoolman remain a separate app-side change; this PR adds external links only and no file hosting.

## Validation

- `python -m json.tool filaments.schema.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\\*.json`
- `python -m unittest discover -s tests -v`
- `python scripts\\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --check`

Supersedes the SDS/TDS metadata portion of #277.
