### PR TITLE
feat: preserve filament country of origin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Run compiler tests
+        run: python3 -m unittest discover -s tests -v
       - name: Compile filaments
         run: python3 scripts/compile_filaments.py
       - uses: actions/upload-artifact@v4

--- a/filaments.schema.json
+++ b/filaments.schema.json
@@ -214,6 +214,10 @@
                                 }
                             }
                         }
+                    },
+                    "country_of_origin": {
+                        "$comment": "Country where the filament was manufactured.",
+                        "type": "string"
                     }
                 }
             }

--- a/scripts/compile_filaments.py
+++ b/scripts/compile_filaments.py
@@ -61,6 +61,7 @@ class Filament(TypedDict):
     pattern: NotRequired[Pattern | None]
     translucent: NotRequired[bool]
     glow: NotRequired[bool]
+    country_of_origin: NotRequired[str]
 
 
 SPOOL_TYPE_MAP = {
@@ -108,6 +109,7 @@ def expand_filament_data(manufacturer: str, data: Filament) -> Iterator[dict]:
     pattern = data.get("pattern", None)
     translucent = data.get("translucent", False)
     glow = data.get("glow", False)
+    country_of_origin = data.get("country_of_origin", None)
 
     for weight_obj in weights:
         weight = weight_obj["weight"]
@@ -192,6 +194,7 @@ def expand_filament_data(manufacturer: str, data: Filament) -> Iterator[dict]:
                     "pattern": color_pattern,
                     "translucent": color_translucent,
                     "glow": color_glow,
+                    "country_of_origin": country_of_origin,
                 }
 
 

--- a/tests/test_compile_filaments.py
+++ b/tests/test_compile_filaments.py
@@ -1,0 +1,27 @@
+import unittest
+
+from scripts.compile_filaments import expand_filament_data
+
+
+class FilamentOriginTests(unittest.TestCase):
+    def test_country_of_origin_is_preserved_in_compiled_output(self):
+        filament = {
+            "name": "PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [{"weight": 1000}],
+            "diameters": [1.75],
+            "colors": [{"name": "Red", "hex": "FF0000"}],
+            "country_of_origin": "Germany",
+        }
+
+        compiled = list(expand_filament_data("Example", filament))
+
+        self.assertEqual(len(compiled), 1)
+        self.assertEqual(
+            compiled[0]["country_of_origin"], filament["country_of_origin"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- allow an optional `country_of_origin` field in filament source data
- preserve the manufacturing country in compiled database output
- add a regression test and run it in CI

## Why

This extracts country-of-origin metadata from the former large PR #277 into a focused change. The field describes where the filament was manufactured, not merely where the brand is based.

## Validation

- `python -m json.tool filaments.schema.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\\*.json`
- `python -m unittest discover -s tests -v`
- `python scripts\\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --check`

Supersedes the country-of-origin metadata portion of #277.
