### PR TITLE
feat(data): add SainSmart TPU 95A

### DIFF
--- a/filaments/sainsmart.json
+++ b/filaments/sainsmart.json
@@ -1,0 +1,44 @@
+{
+    "manufacturer": "SainSmart",
+    "filaments": [
+        {
+            "name": "SainSmart TPU 95A {color_name}",
+            "material": "TPU",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                220
+            ],
+            "bed_temp_range": [
+                40,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- add SainSmart TPU 95A in Black, White, Red, and Blue
- use the official 200–220 °C nozzle and 40–60 °C bed ranges
- omit unsupported empty-spool metadata

## Official source

- [SainSmart TPU 95A](https://www.sainsmart.com/products/tpu-filament-1-75mm-95a)

Density follows the repository TPU material default. Hex values are representative database swatches for the official color names.

## Validation

- `python -m json.tool filaments\\sainsmart.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\\sainsmart.json`
- `python scripts\\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --check`

Supersedes the SainSmart portion of #277.
