### PR TITLE
feat(data): add RepRapper PLA

### DIFF
--- a/filaments/reprapper.json
+++ b/filaments/reprapper.json
@@ -1,0 +1,40 @@
+{
+    "manufacturer": "RepRapper",
+    "filaments": [
+        {
+            "name": "RepRapper PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- add RepRapper PLA in Black, White, Gray, Red, and Blue
- use the official 1.75 mm and 1 kg product configuration
- omit unsupported temperature and empty-spool metadata

## Official source

- [RepRapper PLA](https://www.reprappertech.com/products/reprapper-pla-3d-printer-filament-175mm-%C2%B1-003mm-22lb-1kg%2C-fit-most-fdm-printer-3d-pen)

Density follows the repository PLA material default. Hex values are representative database swatches. The product page states that no heated bed is required but does not provide an exact bed temperature.

## Validation

- `python -m json.tool filaments\\reprapper.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\\reprapper.json`
- `python scripts\\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --check`

Supersedes the RepRapper portion of #277.
