### PR TITLE
feat(data): add Tronxy PLA

### DIFF
--- a/filaments/tronxy.json
+++ b/filaments/tronxy.json
@@ -1,0 +1,44 @@
+{
+    "manufacturer": "Tronxy",
+    "filaments": [
+        {
+            "name": "Tronxy PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                180,
+                210
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- add Tronxy PLA in Red, White, Black, Grey, and Blue
- use the official 1.75 mm, 1 kg configuration and 180–210 °C nozzle range
- omit unsupported bed and empty-spool metadata

## Official sources

- [Tronxy PLA product](https://tronxy3dprinter.com/products/tronxy-3d-printer-new-1-75mm-pla-filament-original-manufactured-by-tronxy)
- [Official Shopify variant feed](https://tronxy3dprinter.com/products/tronxy-3d-printer-new-1-75mm-pla-filament-original-manufactured-by-tronxy.js)

Density follows the repository PLA material default. Hex values are representative database swatches.

## Validation

- `python -m json.tool filaments\\tronxy.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\\tronxy.json`
- `python scripts\\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --check`

Supersedes the Tronxy portion of #277.
