### PR TITLE
feat(data): add GratKit filaments

### DIFF
--- a/filaments/gratkit.json
+++ b/filaments/gratkit.json
@@ -1,0 +1,132 @@
+{
+    "manufacturer": "GratKit",
+    "filaments": [
+        {
+            "name": "GratKit Basic PLA {color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                }
+            ]
+        },
+        {
+            "name": "GratKit Basic PETG {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_type": "cardboard"
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                240
+            ],
+            "bed_temp_range": [
+                75,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Clear",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Transparent-Yellow",
+                    "hex": "FFFF00",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent-Blue",
+                    "hex": "0000FF",
+                    "translucent": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Add source-backed GratKit Basic PLA and Basic PETG definitions as one focused manufacturer PR.

## Data added

- Basic PLA: 1.75 mm, 1 kg cardboard spool, density 1.25 g/cm3, nozzle 190-210 C, bed 50-60 C
- PLA colors: Black, White, Grey, Red, Blue, Green, Orange, Purple, Yellow
- Basic PETG: 1.75 mm, 1 kg cardboard spool, density 1.27 g/cm3, nozzle 220-240 C, bed 75-80 C
- PETG colors: Black, White, Grey, Clear, Red, Blue, Green, Yellow, Transparent-Yellow, Transparent-Blue
- Clear/transparent PETG variants are marked translucent

## Official sources

- PLA product: https://gratkit.com/products/gratkit-pla-3d-printing-filament-1-75mm-3d-printing-material-1kg
- PLA TDS: https://forums.gratkit.com/d/36-filament-tdsgratkit-standard-pla
- PETG product: https://gratkit.com/products/gratkit-petg-3d-printing-filament-1-75mm-basic-petg-1kg
- PETG TDS: https://cdn.shopify.com/s/files/1/0549/2650/8112/files/TDS_PETG.pdf?v=1750658694

## Deliberately omitted

- No spool tare weight: GratKit does not publish one.
- No 2/6/10 kg PETG spool entries: those selections are ambiguous multipacks rather than clearly documented single-spool weights.
- No SDS/TDS URL fields yet: their schema/compiler support is proposed separately in #282.
- Hex values are representative database swatches because GratKit publishes color names/images, not exact color codes.

## Validation

- `python -m json.tool filaments\gratkit.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\gratkit.json`
- `python scripts\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --cached --check`