### PR TITLE
feat(data): add Kingroon filaments

### DIFF
--- a/filaments/kingroon.json
+++ b/filaments/kingroon.json
@@ -1,0 +1,177 @@
+{
+    "manufacturer": "Kingroon",
+    "filaments": [
+        {
+            "name": "Kingroon PLA Basic {color_name}",
+            "material": "PLA",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                210
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Skin",
+                    "hex": "F1C27D"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFC0CB"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "8B4513"
+                }
+            ]
+        },
+        {
+            "name": "Kingroon PETG {color_name}",
+            "material": "PETG",
+            "density": 1.28,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "87CEEB"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "FFFFFF",
+                    "translucent": true
+                },
+                {
+                    "name": "Grass Green",
+                    "hex": "7CFC00"
+                },
+                {
+                    "name": "Mint Green",
+                    "hex": "98FF98"
+                },
+                {
+                    "name": "Light Apricot",
+                    "hex": "FDD5B1"
+                },
+                {
+                    "name": "Cyan-Blue",
+                    "hex": "00B7EB"
+                },
+                {
+                    "name": "Light Pink",
+                    "hex": "FFB6C1"
+                },
+                {
+                    "name": "Dark Green",
+                    "hex": "006400"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Add current, source-backed Kingroon PLA Basic and PETG definitions as one focused manufacturer PR.

## Data added

- PLA Basic: 1.75 mm, 1 kg, density 1.23 g/cm3, nozzle 190-210 C, bed 50-70 C
- PLA colors: White, Orange, Black, Gray, Red, Blue, Skin, Pink, Silver, Yellow, Purple, Transparent, Green, Brown
- PETG: 1.75 mm, 1 kg, density 1.28 g/cm3, nozzle 230-250 C, bed 70-90 C
- PETG colors: White, Black, Gray, Red, Yellow, Blue, Sky Blue, Green, Orange, Silver, Transparent, Grass Green, Mint Green, Light Apricot, Cyan-Blue, Light Pink, Dark Green
- Transparent variants are marked translucent

## Official sources

- PLA Basic: https://kingroon.com/products/kingroon-pla-basic
- PETG: https://kingroon.com/products/10kg-petg-filament-1-75mm-3d-print-materials

The PETG URL has a legacy 10 kg slug, but the current official page explicitly offers 1 kg variants and publishes the settings/density used here.

## Deliberately omitted

- No spool tare weight or spool material: the exact products do not publish stable values.
- The PETG 10 kg bulk selection is not modeled as one spool.
- Hex values are representative database swatches because Kingroon publishes variant names/images, not exact color codes.

## Validation

- `python -m json.tool filaments\kingroon.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\kingroon.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\*.json`
- `python scripts\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --cached --check`