### PR TITLE
feat(data): add YOUSU PLA

### DIFF
--- a/filaments/yousu.json
+++ b/filaments/yousu.json
@@ -1,0 +1,58 @@
+{
+    "manufacturer": "YOUSU",
+    "filaments": [
+        {
+            "name": "YOUSU PLA {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75,
+                2.85
+            ],
+            "extruder_temp_range": [
+                190,
+                240
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Glow Green",
+                    "hex": "7FFF00",
+                    "glow": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Add a focused, source-backed YOUSU PLA definition.

## Data added

- Material: PLA
- Net weight: 1 kg
- Diameters: 1.75 mm and 2.85 mm
- Density: 1.24 g/cm3
- Nozzle range: 190-240 C
- Colors: Black, White, Red, Orange, Green, Blue, Gray, Glow Green
- Glow Green is marked with the `glow` property

## Official sources

- Product: https://www.ysfilament.com/products/yousu3d-pla-3d-printer-filament-material-hatchbox-filament-supplier-175mm-3dfilament-compatible-with-makerbot-raise3d-flashforge-prusa-ultimaker-snapmaker-creality-3d-filament-supplier-1
- TDS: https://ysfilament.com/u_file/2206/14/file/YOUSUPLATDS-081b.pdf

## Deliberately omitted

- No bed temperature: the TDS says none is needed, or 60 C only if applicable, so there is no unconditional recommendation to encode.
- No spool tare/material: YOUSU does not publish these. The listed 1.35 kg is gross shipping weight and is not used as filament or spool weight.
- Hex values are representative database swatches because YOUSU publishes color names/images, not exact color codes.

## Validation

- `python -m json.tool filaments\yousu.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\yousu.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\*.json`
- `python scripts\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --cached --check`