### PR TITLE
feat(data): add Amolen filaments

### DIFF
--- a/filaments/amolen.json
+++ b/filaments/amolen.json
@@ -1,0 +1,73 @@
+{
+    "manufacturer": "Amolen",
+    "filaments": [
+        {
+            "name": "Amolen PLA Silk Basic {color_name}",
+            "material": "PLA",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                30,
+                65
+            ],
+            "finish": "glossy",
+            "colors": [
+                {
+                    "name": "Silk Gold",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Silk Silver Grey",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Silk Red Copper",
+                    "hex": "B87333"
+                }
+            ]
+        },
+        {
+            "name": "Amolen PLA Wood {color_name}",
+            "material": "PLA",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                180,
+                210
+            ],
+            "bed_temp_range": [
+                30,
+                65
+            ],
+            "fill": "wood",
+            "colors": [
+                {
+                    "name": "Walnut Wood",
+                    "hex": "5C4033"
+                },
+                {
+                    "name": "Bamboo Wood",
+                    "hex": "E1C699"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Add source-backed Amolen PLA Silk Basic and PLA Wood definitions as one focused manufacturer PR.

## Data added

- PLA Silk Basic: 1.75 mm, 1 kg, density 1.27 g/cm3, nozzle 210-240 C, bed 30-65 C, glossy finish
- Silk variants: Silk Gold, Silk Silver Grey, Silk Red Copper
- PLA Wood: 1.75 mm, 1 kg, density 1.23 g/cm3, nozzle 180-210 C, bed 30-65 C, wood fill
- Wood variants: Walnut Wood, Bamboo Wood

## Official sources

- PLA Silk Basic: https://www.amolen.com/products/pla-silk-basic
- PLA Wood: https://www.amolen.com/products/pla-wood

## Corrections from the broad import

- Replace midpoint temperatures with the current official ranges.
- Correct densities from generic PLA values to Amolen's published values.
- Use the exact current product/variant names.
- Remove the unsupported `matte` finish from PLA Wood.
- Remove unsupported spool tare weights and cardboard-spool claim.

## Deliberately omitted

- No spool tare or spool material: Amolen does not publish these for the exact products.
- Shopify's 1500 g fulfillment weight is not treated as filament or spool weight.
- The remaining current variants are left for a later swatch-reviewed update.
- Included hexes are representative database swatches because Amolen does not publish exact color codes.

## Validation

- `python -m json.tool filaments\amolen.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\amolen.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments\*.json`
- `python scripts\compile_filaments.py`
- `git -c core.whitespace=cr-at-eol diff --cached --check`
