### PR TITLE
Add Duramic 3D PLA+ and PETG filaments

### DIFF
--- a/filaments/duramic3d.json
+++ b/filaments/duramic3d.json
@@ -1,0 +1,50 @@
+{
+  "manufacturer": "Duramic 3D",
+  "filaments": [
+    {
+      "name": "Duramic 3D PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000,
+          "spool_type": "cardboard"
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [210, 230],
+      "bed_temp_range": [25, 60],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"},
+        {"name": "Yellow", "hex": "F0F010"}
+      ]
+    },
+    {
+      "name": "Duramic 3D PETG {color_name}",
+      "material": "PETG",
+      "density": 1.25,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [230, 250],
+      "bed_temp_range": [70, 80],
+      "colors": [
+        {"name": "Black", "hex": "101010"},
+        {"name": "White", "hex": "F2F2F2"},
+        {"name": "Grey", "hex": "808080"},
+        {"name": "Red", "hex": "C01010"},
+        {"name": "Blue", "hex": "1010C0"},
+        {"name": "Green", "hex": "10C010"},
+        {"name": "Yellow", "hex": "F0F010"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a focused, manufacturer-scoped Duramic 3D source file with verified PLA+ and PETG definitions.

### PLA+

- 1.75 mm, 1 kg cardboard spool
- Density: 1.22 g/cm3
- Nozzle: 210-230 C
- Bed: 25-60 C
- Black, White, Grey, Red, Blue, Green, and Yellow

### PETG

- 1.75 mm, 1 kg
- Density: 1.25 g/cm3
- Nozzle: 230-250 C from the current product page
- Bed: 70-80 C
- Black, White, Grey, Red, Blue, Green, and Yellow

## Sources

- https://duramic3d.com/collections/pla-plus/products/duramic-3d-premium-pla-pla-plus-filament
- https://duramic3d.com/products/duramic-3d-petg-filament
- https://duramic3d.com/pages/download
- https://cdn.shopifycdn.net/s/files/1/0279/4933/4599/files/Duramic_PLA_Plus_TDS_EN_V1.1.pdf?v=1629881206
- https://cdn.shopifycdn.net/s/files/1/0279/4933/4599/files/Duramic_PETG_TDS_V4-G105.pdf?v=1629881207

The current PETG product page gives 240 +/- 10 C, so this PR uses 230-250 C instead of the older 2019 TDS maximum of 240 C.

## Deliberate omissions

- Empty-spool weights are omitted because no official source was found.
- PETG spool material is omitted because the page says only "1kg Spool"; cardboard is explicit only for PLA+.
- Country of origin is omitted because the available sources do not establish the manufacturing country.
- Duramic publishes color names and product images, but not numeric swatch values. The required hex values are representative database swatches, not claimed manufacturer color codes.
- Additional variants are left for a later source-checked pass.

## Validation

- `python -m json.tool filaments/duramic3d.json`
- JSON Schema validation of all 54 filament source files and `materials.json`
- `python scripts/compile_filaments.py`
- `git diff --check`
