### PR TITLE
Add current Buddy3D filament definitions

### DIFF
--- a/filaments/buddy3d.json
+++ b/filaments/buddy3d.json
@@ -1,0 +1,135 @@
+{
+  "manufacturer": "Buddy3D",
+  "filaments": [
+    {
+      "name": "Buddy3D PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp": 215,
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [50, 60],
+      "colors": [
+        {"name": "Beige", "hex": "F2EFBF"}
+      ]
+    },
+    {
+      "name": "Buddy3D PLA Glitter {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp": 215,
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [50, 60],
+      "pattern": "sparkle",
+      "colors": [
+        {"name": "Dark Green", "hex": "42754F"},
+        {"name": "Red", "hex": "FF006A"}
+      ]
+    },
+    {
+      "name": "Buddy3D PLA Pearl {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp": 215,
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [50, 60],
+      "colors": [
+        {"name": "Blue", "hex": "3548D4"},
+        {"name": "Green", "hex": "2EA656"}
+      ]
+    },
+    {
+      "name": "Buddy3D PLA Silk {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp": 215,
+      "extruder_temp_range": [200, 230],
+      "bed_temp_range": [50, 60],
+      "colors": [
+        {"name": "Dark gold", "hex": "DBC63D"},
+        {"name": "Ice Blue", "hex": "96DEFF"},
+        {"name": "Pink", "hex": "FC62B9"},
+        {"name": "Rose", "hex": "F08BC9"},
+        {"name": "Ultra Violet", "hex": "A328D4"}
+      ]
+    },
+    {
+      "name": "Buddy3D PLA+ {color_name}",
+      "material": "PLA+",
+      "density": 1.25,
+      "finish": "matte",
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp_range": [190, 210],
+      "bed_temp": 60,
+      "translucent": true,
+      "colors": [
+        {"name": "Lithophane White", "hex": "FFFFFF"}
+      ]
+    },
+    {
+      "name": "Buddy3D ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp": 255,
+      "extruder_temp_range": [240, 265],
+      "bed_temp": 100,
+      "bed_temp_range": [80, 110],
+      "colors": [
+        {"name": "Green", "hex": "22D133"},
+        {"name": "Natural", "hex": "EBEDDA"}
+      ]
+    },
+    {
+      "name": "Buddy3D ABS ESD {color_name}",
+      "material": "ABS+ESD",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [1.75],
+      "extruder_temp": 255,
+      "extruder_temp_range": [240, 265],
+      "bed_temp": 100,
+      "bed_temp_range": [80, 110],
+      "colors": [
+        {"name": "Black", "hex": "000000"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a focused Buddy3D manufacturer file using the current Prusa catalog, official product metadata, and attached TDS documents.

This produces 14 compiled records:

- PLA Beige
- PLA Glitter Dark Green and Red (`sparkle`)
- PLA Pearl Blue and Green
- PLA Silk Dark gold, Ice Blue, Pink, Rose, and Ultra Violet
- PLA+ Lithophane White (`matte`, `translucent`)
- ABS Green and Natural
- ABS ESD Black

## Verified specifications

- Standard/special PLA: density 1.24 g/cm3, 1 kg, 1.75 mm, 215 C target, 200-230 C nozzle range, 50-60 C bed
- PLA+ Lithophane: density 1.25 g/cm3, 1 kg, 1.75 mm, 190-210 C nozzle, 60 C bed
- ABS: density 1.04 g/cm3, 750 g, 1.75 mm, 255 C target, 240-265 C nozzle range, 100 C target and current product-page 80-110 C bed range
- ABS ESD: density 1.12 g/cm3 with the same weight, diameter, and print setup as the current product page/TDS

All hex values are provided by Prusa's official product metadata rather than estimated from images.

## Official sources

- Catalog: https://www.prusa3d.com/category/buddy3d/
- PLA Beige: https://www.prusa3d.com/product/buddy3d-pla-beige-1kg/
- PLA Glitter: https://www.prusa3d.com/product/buddy3d-pla-glitter-dark-green-1kg/
- PLA Pearl: https://www.prusa3d.com/product/buddy3d-pla-pearl-blue-1kg/
- PLA Silk: https://www.prusa3d.com/product/buddy3d-pla-silk-dark-gold-1kg/
- PLA+ Lithophane: https://www.prusa3d.com/product/buddy3d-pla-lithophane-1kg/
- ABS: https://www.prusa3d.com/product/buddy3d-abs-natural-750g/
- ABS ESD: https://www.prusa3d.com/product/buddy3d-abs-esd-black-750g/
- PLA TDS: https://www.prusa3d.com/file/2626589/technical-data-sheet.pdf
- PLA+ TDS: https://www.prusa3d.com/file/3724716/technical-data-sheet.pdf
- ABS TDS: https://www.prusa3d.com/file/2626592/buddy3d-abs-technical-data-sheet.pdf
- ABS ESD TDS: https://www.prusa3d.com/file/2626594/technical-data-sheet.pdf

## Deliberate omissions

- ABS FR is omitted because the currently attached public file is an SDS and does not establish the required density.
- Archived PETG/ASA and other legacy variants absent from the current Buddy3D catalog are left for a separate historical-source pass.
- Spool type and tare weight are omitted because the official pages do not establish them.
- Silk/Pearl finish flags are omitted because they are not explicitly stated as `matte` or `glossy`.
- Document-link and country fields are outside the current upstream schema.

## Validation

- `python -m json.tool filaments/buddy3d.json`
- JSON Schema validation of all 54 filament source files and `materials.json`
- `python scripts/compile_filaments.py`
- Verified 14 compiled Buddy3D records and unique IDs
- `git diff --check`
