### PR TITLE
feat(data): add Inslogic filaments

### DIFF
--- a/filaments/inslogic.json
+++ b/filaments/inslogic.json
@@ -1,0 +1,282 @@
+{
+    "manufacturer": "Inslogic",
+    "filaments": [
+        {
+            "name": "PLA Pro {color_name}",
+            "material": "PLA",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 232
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                195,
+                220
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "101820"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "A7A8A9"
+                },
+                {
+                    "name": "Red",
+                    "hex": "CD001A"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F8E600"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FF6A14"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0032A0"
+                },
+                {
+                    "name": "Bone White",
+                    "hex": "F1F0E8"
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "67823A"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00AA13"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "623412"
+                },
+                {
+                    "name": "Beige",
+                    "hex": "F3DFD5"
+                }
+            ]
+        },
+        {
+            "name": "Matte PLA {color_name}",
+            "material": "PLA",
+            "density": 1.3,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 232
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                205,
+                245
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "finish": "matte",
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "0032A0"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "101820"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "A7A8A9"
+                },
+                {
+                    "name": "Red",
+                    "hex": "CD001A"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F8E600"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00AA13"
+                }
+            ]
+        },
+        {
+            "name": "PETG Pro {color_name}",
+            "material": "PETG",
+            "density": 1.26,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 232
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                270
+            ],
+            "bed_temp_range": [
+                60,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Red",
+                    "hex": "CD001A"
+                },
+                {
+                    "name": "Black",
+                    "hex": "101820"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "A7A8A9"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0032A0"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F8E600"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "00A3E0"
+                },
+                {
+                    "name": "Mint Green",
+                    "hex": "11BBA9"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FF6A13"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00B140"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "E4007E"
+                }
+            ]
+        },
+        {
+            "name": "High-Speed PLA Pro {color_name}",
+            "material": "PLA",
+            "density": 1.26,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 232
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                260
+            ],
+            "bed_temp_range": [
+                50,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "101820"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "A7A8A9"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0032A0"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "F8E600"
+                },
+                {
+                    "name": "Red",
+                    "hex": "CD001A"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00AA13"
+                }
+            ]
+        },
+        {
+            "name": "ASA {color_name}",
+            "material": "ASA",
+            "density": 1.05,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 232
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                250,
+                280
+            ],
+            "bed_temp_range": [
+                80,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "F6F5F2"
+                },
+                {
+                    "name": "Black",
+                    "hex": "201F1F"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds five current Inslogic filament families, covering 39 compiled color variants:

- PLA Pro (12 colors)
- Matte PLA (7 colors)
- PETG Pro (11 colors)
- High-Speed PLA Pro (7 colors)
- ASA (2 colors)

This data was extracted from an independently maintained Community dataset, then revalidated against current first-party Inslogic product pages and technical documentation before being adapted to the present Donkie/SpoolmanDB schema.

Fixes #296.

## Official sources

- [Inslogic filament catalog](https://store.inslogic3d.com/collections/filament)
- [PLA Pro](https://store.inslogic3d.com/products/pla-pro-filament)
- [Matte PLA](https://store.inslogic3d.com/products/matte-pla-filament)
- [PETG Pro](https://store.inslogic3d.com/products/petg-pro-filament)
- [PETG Pro TDS](https://cdn.shopify.com/s/files/1/0822/8611/7163/files/Inslogic_PETG_Pro_Filament_Technical_Data_Sheet_TDS.pdf?v=1739875791)
- [High-Speed PLA Pro](https://store.inslogic3d.com/products/high-speed-pla-pro-filament)
- [ASA](https://store.inslogic3d.com/products/asa-filament)

## Deliberate omissions

- Refill variants are omitted because the current schema has no explicit refill semantic and the spooled/refill offerings can share the same net weight.
- `spool_type` is omitted because the current reusable spool is a composite of reusable plastic sides and a cardboard coil; a single material enum would be ambiguous. The manufacturer-published combined tare is retained as `spool_weight`.
- Product URLs, TDS/SDS URLs, SKUs/codes, EANs, and country of origin are omitted because the current upstream schema does not support them.
- The wider engineering and aesthetic catalog is left for later focused, first-party-verified batches rather than importing older Community values wholesale.

No schema or compiler changes are included, and no unsupported Community extensions are present.

## Validation

- Validated `materials.json` and all 54 filament source files against the current upstream JSON schemas using `jsonschema`.
- Ran `python scripts/compile_filaments.py` successfully.
- Confirmed exactly 39 new Inslogic compiled records with unique generated IDs.
- Ran `git diff --check` successfully.