### PR TITLE
feat(data): add MatterHackers MH Build Series PLA

### DIFF
--- a/filaments/matterhackers.json
+++ b/filaments/matterhackers.json
@@ -1,0 +1,120 @@
+{
+	"manufacturer": "MatterHackers",
+	"filaments": [
+		{
+			"name": "MH Build Series PLA {color_name}",
+			"material": "PLA",
+			"density": 1.25,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_type": "plastic"
+				}
+			],
+			"diameters": [ 1.75 ],
+			"extruder_temp_range": [ 190, 220 ],
+			"bed_temp_range": [ 25, 55 ],
+			"colors": [
+				{ "name": "Black", "hex": "1a1a1a" },
+				{ "name": "White", "hex": "f5f5f5" },
+				{ "name": "Gray", "hex": "808080" },
+				{ "name": "Red", "hex": "c41e2a" },
+				{ "name": "Royal Blue", "hex": "2e56f1" },
+				{ "name": "Yellow", "hex": "fdd835" },
+				{ "name": "Orange", "hex": "f57c00" },
+				{ "name": "Light Blue", "hex": "1adafb" },
+				{ "name": "Purple", "hex": "6a1b9a" },
+				{ "name": "Blue", "hex": "044786" },
+				{ "name": "Silver", "hex": "abacb0" },
+				{ "name": "Forest Green", "hex": "11784f" },
+				{ "name": "Pink", "hex": "ff72b6" },
+				{ "name": "Navy Blue", "hex": "1d2a56" },
+				{ "name": "Brown", "hex": "6e4325" },
+				{ "name": "Rose Pink", "hex": "f29ab2" },
+				{ "name": "Tan", "hex": "e6ba83" },
+				{ "name": "Olive Green", "hex": "77815c" },
+				{ "name": "Ruby Red", "hex": "b32031" },
+				{ "name": "Pearl White", "hex": "f1eee5" },
+				{ "name": "Lime Green", "hex": "9aed51" },
+				{ "name": "Porcelain White", "hex": "f4f1e8" },
+				{ "name": "Green", "hex": "2e7d32" },
+				{ "name": "Magenta", "hex": "c80181" },
+				{ "name": "Gold", "hex": "ffcb47" },
+				{ "name": "Natural", "hex": "dfdfd3" },
+				{ "name": "Glow in the Dark", "hex": "9bdd77", "glow": true },
+				{ "name": "Clear", "hex": "d8dde0", "translucent": true },
+				{ "name": "RGB Blue", "hex": "0057ff" },
+				{ "name": "RGB Green", "hex": "00a651" },
+				{ "name": "RGB Red", "hex": "f23b30" },
+				{ "name": "Blush Pink", "hex": "e8a2a7" },
+				{ "name": "Dusty Blue", "hex": "7896b3" },
+				{ "name": "Periwinkle Purple", "hex": "8d78c6" },
+				{ "name": "Matcha Green", "hex": "a8b979" },
+				{ "name": "Sky Blue", "hex": "74cceb" },
+				{ "name": "Grass Green", "hex": "4fb43f" },
+				{ "name": "Bone White", "hex": "e8dfcb" },
+				{ "name": "Light Yellow", "hex": "f3e79b" },
+				{ "name": "Lilac", "hex": "c6a4d8" },
+				{ "name": "Apricot", "hex": "f1a66a" },
+				{ "name": "Pine Green", "hex": "1f6b4f" },
+				{ "name": "Mandarin Orange", "hex": "f07a35" },
+				{ "name": "Jade Green", "hex": "32a77d" },
+				{ "name": "Light Khaki", "hex": "c6b990" },
+				{ "name": "Mint Green", "hex": "8dd7b4" }
+			]
+		},
+		{
+			"name": "MH Build Series PLA {color_name}",
+			"material": "PLA",
+			"density": 1.25,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_type": "plastic"
+				}
+			],
+			"diameters": [ 2.85 ],
+			"extruder_temp_range": [ 190, 220 ],
+			"bed_temp_range": [ 25, 55 ],
+			"colors": [
+				{ "name": "Black", "hex": "1a1a1a" },
+				{ "name": "White", "hex": "f5f5f5" },
+				{ "name": "Gray", "hex": "808080" },
+				{ "name": "Red", "hex": "c41e2a" },
+				{ "name": "Orange", "hex": "f57c00" },
+				{ "name": "Purple", "hex": "6a1b9a" },
+				{ "name": "Yellow", "hex": "fdd835" },
+				{ "name": "Light Blue", "hex": "1adafb" },
+				{ "name": "Blue", "hex": "044786" },
+				{ "name": "Lime Green", "hex": "9aed51" },
+				{ "name": "Pink", "hex": "ff72b6" },
+				{ "name": "Green", "hex": "2e7d32" },
+				{ "name": "Forest Green", "hex": "11784f" },
+				{ "name": "Brown", "hex": "6e4325" },
+				{ "name": "Magenta", "hex": "c80181" },
+				{ "name": "Tan", "hex": "e6ba83" },
+				{ "name": "Olive Green", "hex": "77815c" },
+				{ "name": "Natural", "hex": "dfdfd3" }
+			]
+		},
+		{
+			"name": "MH Build Series PLA {color_name}",
+			"material": "PLA",
+			"density": 1.25,
+			"weights": [
+				{
+					"weight": 1000,
+					"spool_type": "cardboard"
+				}
+			],
+			"diameters": [ 1.75 ],
+			"extruder_temp_range": [ 190, 220 ],
+			"bed_temp_range": [ 25, 55 ],
+			"colors": [
+				{ "name": "Black", "hex": "1a1a1a" },
+				{ "name": "Gray", "hex": "808080" },
+				{ "name": "White", "hex": "f5f5f5" }
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Add current MatterHackers MH Build Series PLA plastic and cardboard spool variants using the existing upstream schema. The definitions are split by packaging and diameter so compilation cannot invent unsupported color/package/diameter combinations.

All product identity and specification data was rechecked against live first-party MatterHackers pages. Density is 1.25 g/cm³, the general extrusion recommendation is 205±15 °C (represented as 190–220 °C), and the heated-bed recommendation is 40±15 °C (represented as 25–55 °C).

The color HEX values are conservative representative swatches matched to the first-party product imagery; MatterHackers does not publish manufacturer HEX values on these product pages.

## Exact variants/packages added

- Plastic, 1.75 mm, 1 kg — 46 colors: Black, White, Gray, Red, Royal Blue, Yellow, Orange, Light Blue, Purple, Blue, Silver, Forest Green, Pink, Navy Blue, Brown, Rose Pink, Tan, Olive Green, Ruby Red, Pearl White, Lime Green, Porcelain White, Green, Magenta, Gold, Natural, Glow in the Dark, Clear, RGB Blue, RGB Green, RGB Red, Blush Pink, Dusty Blue, Periwinkle Purple, Matcha Green, Sky Blue, Grass Green, Bone White, Light Yellow, Lilac, Apricot, Pine Green, Mandarin Orange, Jade Green, Light Khaki, Mint Green.
- Plastic, 2.85 mm, 1 kg — 18 colors: Black, White, Gray, Red, Orange, Purple, Yellow, Light Blue, Blue, Lime Green, Pink, Green, Forest Green, Brown, Magenta, Tan, Olive Green, Natural.
- Cardboard, 1.75 mm, 1 kg — 3 colors: Black, Gray, White.

Blue and Royal Blue are separate live 1.75 mm products. Royal Blue is not inferred for 2.85 mm. MatterHackers' current spelling is Gray.

Source definitions: 3. Compiled MatterHackers records: 67 (46 + 18 + 3), all with unique IDs.

## Official first-party sources

- [MH Build Series PLA catalog](https://www.matterhackers.com/store/c/mh-build-series-pla)
- [Black plastic 1.75 mm / 1 kg product and technical specifications](https://www.matterhackers.com/store/l/175mm-pla-filament-black-1-kg/sk/MY6CYEZM)
- [Black plastic 2.85 mm / 1 kg product](https://www.matterhackers.com/store/l/300mm-pla-filament-black-1-kg/sk/MSEWRUAW)
- [Blue 1.75 mm product](https://www.matterhackers.com/store/l/175mm-pla-filament-blue-1-kg/sk/M-MQF-QZ5S)
- [Royal Blue 1.75 mm product](https://www.matterhackers.com/store/l/royal-blue-pla-filament-175mm/sk/M-7M8-AN1R)
- [Gray 1.75 mm product](https://www.matterhackers.com/store/l/gray-mh-build-series-pla-filament-175mm-1kg/sk/M-PL0-Q8ZD)
- [MH Build Series PLA cardboard catalog](https://www.matterhackers.com/store/c/mh-build-series-pla-cardboard-spools)
- [Black cardboard 1.75 mm / 1 kg product](https://www.matterhackers.com/store/l/black-mh-build-series-pla-filament-175mm-1kg-cardboard/sk/MNCJPEK5)
- [Gray cardboard 1.75 mm / 1 kg product](https://www.matterhackers.com/store/l/gray-mh-build-series-pla-filament-cardboard-spool-175mm-1kg/sk/MYMKG0ZU)
- [White cardboard 1.75 mm / 1 kg product](https://www.matterhackers.com/store/l/white-mh-build-series-pla-filament-cardboard-spool-175mm-1kg/sk/MJ3YZPRY)

## Deliberate omissions

- All refills, including the Silver refill. The current upstream schema has no explicit refill semantic, so refills are not encoded as plastic, cardboard, or null.
- Any 2.85 mm color not exposed by the current live 2.85 mm product selector; in particular, no Royal Blue, Silver, or historical 2.85 mm refill assumptions.
- PETG, ABS, ASA, TPU, Tough PLA, Silky PLA, matte PLA, and high-speed PLA product families.
- Community-only metadata such as SKU/code, EAN, country of origin, SDS/TDS URLs, and refill compatibility fields.

## Validation

- `python -m check_jsonschema --schemafile materials.schema.json materials.json` — passed
- `python -m check_jsonschema --schemafile filaments.schema.json filaments/*.json` — passed
- `python scripts/compile_filaments.py` — passed
- Manual compiled-record audit — 67 MatterHackers records; 67 unique MatterHackers IDs; 7,024 total compiled IDs and 7,024 globally unique IDs; no unintended packaging or diameter combinations
- `git diff --check` — passed

Fixes #197