### PR TITLE
Add Polymaker Fiberon ASA-CF08

### DIFF
--- a/filaments/polymaker.json
+++ b/filaments/polymaker.json
@@ -2,6 +2,55 @@
     "manufacturer": "Polymaker",
     "filaments": [
       {
+        "name": "Fiberon\u2122 ASA-CF08 {color_name}",
+        "material": "ASA",
+        "density": 1.09,
+        "weights": [
+          {
+            "weight": 500.0,
+            "spool_weight": 190.0,
+            "spool_type": "cardboard"
+          }
+        ],
+        "diameters": [
+          1.75
+        ],
+        "extruder_temp_range": [
+          260,
+          280
+        ],
+        "bed_temp_range": [
+          90,
+          100
+        ],
+        "colors": [
+          {
+            "name": "Black",
+            "hex": "000000"
+          },
+          {
+            "name": "Dark Grey",
+            "hex": "4D5E70"
+          },
+          {
+            "name": "Light Grey",
+            "hex": "ADC4D6"
+          },
+          {
+            "name": "Navy Blue",
+            "hex": "30548E"
+          },
+          {
+            "name": "Dark Red",
+            "hex": "855261"
+          },
+          {
+            "name": "Desert Sand",
+            "hex": "CEB69C"
+          }
+        ]
+      },
+      {
         "name": "Fiberon\u2122 PA12-CF10 {color_name}",
         "material": "PA",
         "density": 1.06,


### PR DESCRIPTION
Adds **Fiberon™ ASA-CF08**, Polymaker's 8% carbon-fibre reinforced ASA. It sits with the three Fiberon entries already in `polymaker.json`, in alphabetical order ahead of `PA12-CF10`.

### Where each value comes from

| Field | Value | Source |
|---|---|---|
| `density` | 1.09 g/cm³ | [TDS](https://fiberon.polymaker.com/wp-content/uploads/TDS_FIBERON-ASA-CF08_V1.0_EN.pdf) — ISO 1183 / GB/T 1033, at 23 °C |
| `extruder_temp_range` | 260–280 °C | [Product page](https://fiberon.polymaker.com/product/asa-cf08/) |
| `bed_temp_range` | 90–100 °C | Same, which also notes an enclosure is recommended |
| `diameters` | 1.75 mm only | Store lists no other diameter |
| `weights` | 500 g, 190 g cardboard | 500 g/190 g/cardboard matches all three existing Fiberon entries |
| `colors` | 6 | The vendor's own published swatch hex values on the Polymaker store |

Colour names and hexes, matching the store SKUs:

| Colour | Hex | SKU |
|---|---|---|
| Black | `000000` | FF02001 |
| Dark Grey | `4D5E70` | FF02005 |
| Light Grey | `ADC4D6` | FF02004 |
| Navy Blue | `30548E` | FF02003 |
| Dark Red | `855261` | FF02007 |
| Desert Sand | `CEB69C` | FF02006 |

### Why 3 kg is not included

The product page advertises "500g, 3kg", but only **Black** actually has a 3 kg SKU (FF02002) — checked on both the US and Canadian stores. Since weights and colours expand as a cross product, adding 3 kg here would produce five combinations that aren't sold.

Per the README's note on this ("either you will have to live with the database having invalid entries or you can split up the filament object into multiple ones"), the tidy fix would be a second filament object for 3 kg in Black alone. I've left that out because I have no verified empty-spool weight for the Fiberon 3 kg spool, and it can't safely be inferred: Fiberon's 500 g spool is 190 g while PolyLite's 1 kg spool is 140 g, so the 425 g used for PolyLite 3 kg spools elsewhere in this file clearly doesn't transfer. Happy to add it if you know the figure.

### Checks

Ran the CI steps locally — `check-jsonschema` against `filaments.schema.json` passes, and `scripts/compile_filaments.py` expands the entry to the expected 6 combinations:

```
Fiberon™ ASA-CF08 Black         500.0g spool=190.0g d=1.75 density=1.09 hex=000000
Fiberon™ ASA-CF08 Dark Grey     500.0g spool=190.0g d=1.75 density=1.09 hex=4D5E70
Fiberon™ ASA-CF08 Dark Red      500.0g spool=190.0g d=1.75 density=1.09 hex=855261
Fiberon™ ASA-CF08 Desert Sand   500.0g spool=190.0g d=1.75 density=1.09 hex=CEB69C
Fiberon™ ASA-CF08 Light Grey    500.0g spool=190.0g d=1.75 density=1.09 hex=ADC4D6
Fiberon™ ASA-CF08 Navy Blue     500.0g spool=190.0g d=1.75 density=1.09 hex=30548E
```
