### PR TITLE
Add Snapmaker filament database

### DIFF
--- a/filaments/snapmaker.json
+++ b/filaments/snapmaker.json
@@ -1,0 +1,886 @@
+{
+  "manufacturer": "Snapmaker",
+  "filaments": [
+    {
+      "name": "TPU 90A {color_name}",
+      "material": "TPU-90A",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 220,
+      "bed_temp": 50,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "16161A"
+        },
+        {
+          "name": "Gray",
+          "hex": "B2B4B2"
+        },
+        {
+          "name": "White",
+          "hex": "F8F8F5"
+        }
+      ]
+    },
+    {
+      "name": "Silk Dual-Color PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 230,
+      "bed_temp": 50,
+      "finish": "glossy",
+      "multi_color_direction": "coaxial",
+      "colors": [
+        {
+          "name": "Sunset Ember",
+          "hexes": [
+            "D9A63A",
+            "CC434F"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Aurora Gold",
+          "hexes": [
+            "D9A63A",
+            "9675CD"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Solar Alloy",
+          "hexes": [
+            "D9A63A",
+            "C4C7D9"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Mint Lemonade",
+          "hexes": [
+            "ECED17",
+            "44ADE5"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Sea Glass",
+          "hexes": [
+            "44ADE5",
+            "18CCAF"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "Ice Lake",
+          "hexes": [
+            "C4C7D9",
+            "44ADE5"
+          ],
+          "multi_color_direction": "coaxial"
+        },
+        {
+          "name": "City Billboard",
+          "hexes": [
+            "CBF914",
+            "D623AA"
+          ],
+          "multi_color_direction": "coaxial"
+        }
+      ]
+    },
+    {
+      "name": "PETG HF {color_name}",
+      "material": "PETG",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 240,
+      "bed_temp": 80,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "16171B"
+        },
+        {
+          "name": "White",
+          "hex": "F4F9FF"
+        },
+        {
+          "name": "Light Gray",
+          "hex": "ACB8C5"
+        },
+        {
+          "name": "Red",
+          "hex": "FF1523"
+        },
+        {
+          "name": "Orange",
+          "hex": "FB7E1B"
+        },
+        {
+          "name": "Cobalt Blue",
+          "hex": "0049B8"
+        },
+        {
+          "name": "Silver Gray",
+          "hex": "7C818E"
+        },
+        {
+          "name": "Violet",
+          "hex": "493AB2"
+        },
+        {
+          "name": "Deep Purple",
+          "hex": "473378"
+        },
+        {
+          "name": "Cocoa Brown",
+          "hex": "6B504C"
+        }
+      ]
+    },
+    {
+      "name": "Silk PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 230,
+      "bed_temp": 50,
+      "finish": "glossy",
+      "colors": [
+        {
+          "name": "Gold",
+          "hex": "F6CE1B"
+        },
+        {
+          "name": "Silver",
+          "hex": "BCC2C8"
+        },
+        {
+          "name": "Copper",
+          "hex": "AF6B4C"
+        },
+        {
+          "name": "Garnet Red",
+          "hex": "C1443F"
+        },
+        {
+          "name": "Pearl Pink",
+          "hex": "EFC2CA"
+        },
+        {
+          "name": "Sapphire Blue",
+          "hex": "768EC7"
+        }
+      ]
+    },
+    {
+      "name": "TPU 95A HF {color_name}",
+      "material": "TPU-95A",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 240,
+      "bed_temp": 35,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Silver Gray",
+          "hex": "9E9E9E"
+        },
+        {
+          "name": "Brown",
+          "hex": "865B41"
+        },
+        {
+          "name": "Bright Blue",
+          "hex": "0683EF"
+        },
+        {
+          "name": "Red",
+          "hex": "EE2A20"
+        },
+        {
+          "name": "Dark Gray",
+          "hex": "595E69"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFC72C"
+        },
+        {
+          "name": "Green",
+          "hex": "33A15A"
+        }
+      ]
+    },
+    {
+      "name": "SnapSpeed PLA {color_name}",
+      "material": "PLA",
+      "density": 1.23,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 220,
+      "bed_temp": 55,
+      "colors": [
+        {
+          "name": "Pink",
+          "hex": "FFC0CB"
+        },
+        {
+          "name": "Cream",
+          "hex": "FFF5E0"
+        },
+        {
+          "name": "Cool White",
+          "hex": "D9DFE5"
+        },
+        {
+          "name": "Magenta",
+          "hex": "F24574"
+        },
+        {
+          "name": "Bright Yellow",
+          "hex": "F8F81C"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "AFC33C"
+        },
+        {
+          "name": "Blue Gray",
+          "hex": "94B7C9"
+        },
+        {
+          "name": "Warm Beige",
+          "hex": "C19E86"
+        },
+        {
+          "name": "Cocoa Brown",
+          "hex": "674B47"
+        },
+        {
+          "name": "Pearl White",
+          "hex": "E2DEDB"
+        },
+        {
+          "name": "Grey",
+          "hex": "8C9099"
+        },
+        {
+          "name": "Green",
+          "hex": "2D9E59"
+        },
+        {
+          "name": "Blue",
+          "hex": "003776"
+        },
+        {
+          "name": "Orange",
+          "hex": "F97429"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F4C032"
+        },
+        {
+          "name": "Purple",
+          "hex": "6C5BB1"
+        },
+        {
+          "name": "Brown",
+          "hex": "6F4C2F"
+        },
+        {
+          "name": "Black",
+          "hex": "080A0D"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "5EBDDB"
+        },
+        {
+          "name": "Red",
+          "hex": "E72F1D"
+        }
+      ]
+    },
+    {
+      "name": "Matte PLA {color_name}",
+      "material": "PLA",
+      "density": 1.31,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 210,
+      "bed_temp": 60,
+      "finish": "matte",
+      "colors": [
+        {
+          "name": "Butter Cream",
+          "hex": "FEE5A5"
+        },
+        {
+          "name": "Latte Brown",
+          "hex": "D3B7A7"
+        },
+        {
+          "name": "Lavender Purple",
+          "hex": "AE96D4"
+        },
+        {
+          "name": "Mocha Brown",
+          "hex": "775C50"
+        },
+        {
+          "name": "Lime Green",
+          "hex": "D4E458"
+        },
+        {
+          "name": "Olive Green",
+          "hex": "68724D"
+        },
+        {
+          "name": "Steel Blue",
+          "hex": "2E4462"
+        },
+        {
+          "name": "Sky Blue",
+          "hex": "56B7E6"
+        },
+        {
+          "name": "Terracotta Red",
+          "hex": "D84B2E"
+        },
+        {
+          "name": "Periwinkle",
+          "hex": "ADB4E6"
+        },
+        {
+          "name": "Watermelon Red",
+          "hex": "FC6371"
+        },
+        {
+          "name": "Violet Purple",
+          "hex": "6600CC"
+        },
+        {
+          "name": "Celestial Blue",
+          "hex": "8BD5EE"
+        },
+        {
+          "name": "Sakura Pink",
+          "hex": "F3D6E5"
+        },
+        {
+          "name": "Ivory White",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Sunburst Yellow",
+          "hex": "F0BE02"
+        },
+        {
+          "name": "Carbon Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Lava Orange",
+          "hex": "F78E0E"
+        },
+        {
+          "name": "Pine Green",
+          "hex": "519F61"
+        },
+        {
+          "name": "Engine Red",
+          "hex": "DE1619"
+        },
+        {
+          "name": "Moss Mist",
+          "hex": "BEC9A5"
+        },
+        {
+          "name": "Ash Grey",
+          "hex": "485155"
+        },
+        {
+          "name": "Marine Blue",
+          "hex": "0078BF"
+        }
+      ]
+    },
+    {
+      "name": "PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 200,
+      "bed_temp": 55,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ]
+    },
+    {
+      "name": "PETG {color_name}",
+      "material": "PETG",
+      "density": 1.26,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 240,
+      "bed_temp": 75,
+      "colors": [
+        {
+          "name": "Red",
+          "hex": "E60000"
+        },
+        {
+          "name": "Blue",
+          "hex": "0066FF"
+        }
+      ]
+    },
+    {
+      "name": "ABS {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 260,
+      "bed_temp": 90,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ]
+    },
+    {
+      "name": "ABS (RFID) {color_name}",
+      "material": "ABS",
+      "density": 1.04,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 260,
+      "bed_temp": 90,
+      "colors": [
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        },
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "FFB81C"
+        },
+        {
+          "name": "Red",
+          "hex": "DE4343"
+        },
+        {
+          "name": "Green",
+          "hex": "3A913F"
+        },
+        {
+          "name": "Orange",
+          "hex": "FF6A13"
+        },
+        {
+          "name": "Purple",
+          "hex": "6E3FA3"
+        },
+        {
+          "name": "Light Blue",
+          "hex": "5BC2E7"
+        },
+        {
+          "name": "Navy Blue",
+          "hex": "002677"
+        },
+        {
+          "name": "Dark Gray",
+          "hex": "54585A"
+        }
+      ]
+    },
+    {
+      "name": "PVA {color_name}",
+      "material": "PVA",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 220,
+      "bed_temp": 55,
+      "colors": [
+        {
+          "name": "Natural",
+          "hex": "F0E8C8"
+        }
+      ]
+    },
+    {
+      "name": "TPU {color_name}",
+      "material": "TPU-95A",
+      "density": 1.22,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 220,
+      "bed_temp": 40,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        },
+        {
+          "name": "Yellow",
+          "hex": "F5CE00"
+        }
+      ]
+    },
+    {
+      "name": "Glow-in-the-dark PLA {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 220,
+      "bed_temp": 60,
+      "glow": true,
+      "colors": [
+        {
+          "name": "Green",
+          "hex": "3CB371"
+        }
+      ]
+    },
+    {
+      "name": "Wood PLA {color_name}",
+      "material": "PLA",
+      "density": 1.17,
+      "weights": [
+        {
+          "weight": 750
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 200,
+      "bed_temp": 50,
+      "fill": "wood",
+      "colors": [
+        {
+          "name": "Oak",
+          "hex": "C0A086"
+        },
+        {
+          "name": "Maple",
+          "hex": "F2C6A2"
+        },
+        {
+          "name": "Walnut",
+          "hex": "775C50"
+        },
+        {
+          "name": "Rosewood",
+          "hex": "AE7575"
+        }
+      ]
+    },
+    {
+      "name": "Breakaway Support {color_name}",
+      "material": "PLA",
+      "density": 1.24,
+      "weights": [
+        {
+          "weight": 500
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 225,
+      "bed_temp": 55,
+      "colors": [
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ]
+    },
+    {
+      "name": "Nylon {color_name}",
+      "material": "PA",
+      "density": 1.12,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 260,
+      "bed_temp": 45,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Black High Flow TPU95 {color_name}",
+      "material": "TPU-95A",
+      "density": 1.216,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 215,
+      "bed_temp": 30,
+      "colors": [
+        {
+          "name": "Black",
+          "hex": "000000"
+        }
+      ]
+    },
+    {
+      "name": "Wood PLA (RFID) {color_name}",
+      "material": "PLA",
+      "density": 1.17,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 220,
+      "bed_temp": 55,
+      "fill": "wood",
+      "colors": [
+        {
+          "name": "Oak",
+          "hex": "C0A086"
+        },
+        {
+          "name": "Maple",
+          "hex": "F2C6A2"
+        },
+        {
+          "name": "Walnut",
+          "hex": "775C50"
+        },
+        {
+          "name": "Rosewood",
+          "hex": "AE7575"
+        }
+      ]
+    },
+    {
+      "name": "PETG Translucent {color_name}",
+      "material": "PETG",
+      "density": 1.3,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 240,
+      "bed_temp": 80,
+      "translucent": true,
+      "colors": [
+        {
+          "name": "Translucent Teal",
+          "hex": "3DD1CE"
+        },
+        {
+          "name": "Translucent Blue",
+          "hex": "338CC4"
+        },
+        {
+          "name": "Translucent Gray",
+          "hex": "7F8896"
+        },
+        {
+          "name": "Translucent Green",
+          "hex": "537A37"
+        },
+        {
+          "name": "Translucent Brown",
+          "hex": "92713F"
+        },
+        {
+          "name": "Translucent Orange",
+          "hex": "FB8D02"
+        },
+        {
+          "name": "Translucent Pink",
+          "hex": "E68FBD"
+        },
+        {
+          "name": "Translucent Purple",
+          "hex": "D480EF"
+        }
+      ]
+    },
+    {
+      "name": "ASA (RFID) {color_name}",
+      "material": "ASA",
+      "density": 1.13,
+      "weights": [
+        {
+          "weight": 1000
+        }
+      ],
+      "diameters": [
+        1.75
+      ],
+      "extruder_temp": 260,
+      "bed_temp": 90,
+      "colors": [
+        {
+          "name": "Yellow",
+          "hex": "FFE800"
+        },
+        {
+          "name": "Red",
+          "hex": "AF231C"
+        },
+        {
+          "name": "Dark Gray",
+          "hex": "53565A"
+        },
+        {
+          "name": "Black",
+          "hex": "161618"
+        },
+        {
+          "name": "White",
+          "hex": "FFFFFF"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `filaments/snapmaker.json`: 21 Snapmaker filament product lines, 122 color
variants total (PLA, PETG, ABS, ASA, TPU, PVA, Nylon, and specialty lines like
Silk, Matte, SnapSpeed, Wood-filled, Glow-in-the-dark, and Breakaway support).

## Sourcing

- Product listing, colors, and hex codes scraped from Snapmaker's own product
  pages (us.snapmaker.com and shop.snapmaker.com).
- Where available, `density`/`extruder_temp`/`bed_temp` come from Snapmaker's
  official Technical Data Sheet PDFs (their own tested "Specimen Test" values)
  or their public per-material spec pages.
- Where no official single value was published, I picked a value from within
  Snapmaker's own stated min/max range, using cross-brand consensus (existing
  entries in this DB for the same material) as a guide.

**Heads up for reviewers**: a meaningful chunk of these numbers were pulled
together via web research rather than copied verbatim from a single
manufacturer spec sheet, since Snapmaker doesn't publish a full datasheet for
every product line. I'm confident in the ones sourced from an official TDS or
spec page, but a few `extruder_temp`/`bed_temp` values (Breakaway Support,
Nylon's bed temp, SnapSpeed/Matte PLA, and the two 95A-shore TPU SKUs without
a datasheet) are my best judgment call within Snapmaker's stated range, not a
value Snapmaker explicitly tested. Flagging so these can be corrected in a
follow-up PR if anyone has more authoritative numbers.

## Testing

Validated locally with `check-jsonschema` against `filaments.schema.json`,
and compiled cleanly with `scripts/compile_filaments.py` (no duplicate IDs,
no missing color data). Also spot-checked in a local Spoolman instance
pointed at the compiled output.