### PR TITLE
Add Sindoh filament

### DIFF
--- a/filaments/sindoh.json
+++ b/filaments/sindoh.json
@@ -1,0 +1,191 @@
+{
+    "manufacturer": "Sindoh",
+    "filaments": [
+        {
+            "name": "3DWOX Series {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 700
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FFC0CB"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                }
+            ]
+        },
+        {
+            "name": "3DWOX Series {color_name}",
+            "material": "ABS",
+            "density": 1.06,
+            "weights": [
+                {
+                    "weight": 600
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 230,
+            "bed_temp": 90,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        },
+        {
+            "name": "3DWOX 7X {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1500
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                }
+            ]
+        },
+        {
+            "name": "3DWOX Series Flexible {color_name}",
+            "material": "TPU",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 500
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 240,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Green",
+                    "hex": "008000"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FFA500"
+                }
+            ]
+        },
+        {
+            "name": "3DWOX Series PVA+ {color_name}",
+            "material": "PVA+",
+            "density": 1.19,
+            "weights": [
+                {
+                    "weight": 500
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 200,
+            "bed_temp": 60,
+            "colors": [
+                {
+                    "name": "Natural",
+                    "hex": "F5F0E1",
+                    "translucent": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Add the documented Sindoh 3DWOX filament catalog in the existing SpoolmanDB source format.

## Variants added

- PLA, 700 g, 1.75 mm: White, Black, Gray, Red, Yellow, Green, Blue, Pink, Purple
- ABS, 600 g, 1.75 mm: White, Black, Gray, Red, Yellow, Green, Blue
- 3DWOX 7X PLA, 1.5 kg, 1.75 mm: White, Blue
- Flexible (represented as TPU), 500 g, 1.75 mm: White, Black, Red, Green, Yellow, Orange
- PVA+, 500 g, 1.75 mm: Natural

## Sources

- Sindoh 3DWOX 5X/7X user manual (consumable material/color/weight matrix): https://www.sindoh.com/hubfs/site/catalog/7X_RODIN-H%20%EA%B5%AD%EB%AC%B8_%EC%82%AC%EC%9A%A9%EC%84%9C.pdf
- Sindoh 3DWOX 2X user manual (diameter and recommended temperatures): https://www.sindoh.com/hubfs/site/catalog/2X_%EC%82%AC%EC%9A%A9%EC%84%A4%EB%AA%85%EC%84%9CSDH%20%EA%B5%AD%EB%AC%B8.pdf
- Sindoh PLA refill product page: https://m.sindoh4u.com/goods/view?no=46
- Sindoh ABS refill product page: https://m.sindoh4u.com/goods/view?no=45
- Sindoh 3DWOX 7X 1.5 kg PLA product page: https://m.sindoh4u.com/goods/view_contents?no=77&view_preload=1&zoom=1
- Sindoh PVA+ refill product page: https://m.sindoh4u.com/goods/view_contents?no=72&zoom=1
- Sindoh PLA SDS: https://upload.3dprinter.sindoh.com/supplies/1524015361174__PLA_MSDS.pdf
- Sindoh ABS SDS: https://upload.3dprinter.sindoh.com/supplies/1524015481099__ABS_MSDS.pdf
- Sindoh consumables listing (including Flexible refill kits): https://www.sindoh.com/ko/customer/total-search-result.php?key_word=2X+DP303

## Notes

- Sindoh calls its flexible product `Flexible`; it is represented with the schema-supported `TPU` material key while retaining `Flexible` in the product name.
- These products are refill filament, but the current upstream schema has no refill field. `spool_type` is therefore left unset rather than incorrectly describing a refill as a plastic or cardboard spool.
- PETG and ASA are deliberately omitted because Sindoh documents them as third-party open materials, not Sindoh filament products.
- Color values are conservative representative swatches where Sindoh does not publish official HEX values.

## Validation

- `python -m check_jsonschema --schemafile materials.schema.json materials.json`
- `python -m check_jsonschema --schemafile filaments.schema.json filaments/*`
- `python scripts/compile_filaments.py`
- Manual inspection: 25 Sindoh compiled variants and 25 unique IDs; no unintended weight/color/diameter combinations
- `git diff --check`
