### PR TITLE
Add missing Sunlu PETG colors, correct spool weight; add AzureFilm PETG Hyper Speed line

### DIFF
--- a/filaments/AzureFilm.json
+++ b/filaments/AzureFilm.json
@@ -756,6 +756,27 @@
             ]
         },
         {
+            "name": "Hyper Speed {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000.0
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp": 235,
+            "bed_temp": 70,
+            "colors": [
+                {
+                    "name": "Army Green",
+                    "hex": "013C02"
+                }
+            ]
+        },
+        {
             "name": "{color_name}",
             "material": "PCTG",
             "density": 1.29,

--- a/filaments/sunlu.json
+++ b/filaments/sunlu.json
@@ -294,7 +294,7 @@
             "weights": [
                 {
                     "weight": 1000.0,
-                    "spool_weight": 130.0,
+                    "spool_weight": 209.0,
                     "spool_type": "plastic"
                 }
             ],
@@ -374,6 +374,18 @@
                     "name": "Transparent Blue",
                     "translucent": true,
                     "hex": "3A87FE"
+                },
+                {
+                    "name": "Chocolate",
+                    "hex": "793D00"
+                },
+                {
+                    "name": "Roasted Chestnut",
+                    "hex": "3C3027"
+                },
+                {
+                    "name": "Midnight",
+                    "hex": "0B1F2D"
                 }
             ]
         },


### PR DESCRIPTION
## Summary

- **Sunlu PETG**
  - Corrected `spool_weight` from 130g to 209g (measured empty plastic spool, including the bonded cardboard core, on a calibrated scale).
  - Added 3 missing colors: Chocolate, Roasted Chestnut, Midnight.
- **AzureFilm**
  - Added a new filament entry for the "Hyper Speed" PETG line, which wasn't present in the database yet. Started with the Army Green color; happy to extend with the rest of the line's colors in a follow-up PR if useful.

## Sourcing / confidence

- Spool weight (209g): measured directly by me, high confidence.
- Hex codes for Chocolate, Roasted Chestnut, Midnight, and AzureFilm Army Green: sourced from a third-party filament profile aggregator, not from Sunlu/AzureFilm directly. Visually cross-checked against my own spools where possible, but happy to adjust if anyone has a more authoritative source.
- AzureFilm Hyper Speed density (1.27) and temperatures (235°C / 70°C bed): sourced from a third-party spec aggregator referencing AzureFilm's technical data sheet for this specific line (distinct from their "Original" PETG line).
- No `spool_weight` included for the AzureFilm entry — I own the refill version (no full spool to weigh). Left as optional per the schema; can be added once someone measures a boxed version.

## Testing

- Validated both JSON files still parse correctly after the change.