### PR TITLE
Add contributing guide, convention linter and catalog preview bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -34,6 +36,30 @@ jobs:
         run: check-jsonschema --schemafile materials.schema.json materials.json
       - name: Validate Filaments
         run: check-jsonschema --schemafile filaments.schema.json filaments/*
+      - name: Check for generated and editor files
+        if: github.event_name == 'pull_request'
+        run: |
+          changed=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD)
+          bad=$(echo "$changed" | grep -E '^(filaments\.json|\.vscode/|\.idea/)|(^|/)\.DS_Store$' || true)
+          if [ -n "$bad" ]; then
+            echo "These files should not be committed:"
+            echo "$bad"
+            echo
+            echo "filaments.json is generated at build time and is gitignored."
+            echo "See CONTRIBUTING.md."
+            exit 1
+          fi
+      - name: Lint changed filament files
+        if: github.event_name == 'pull_request'
+        run: |
+          changed=$(git diff --name-only --diff-filter=d \
+            ${{ github.event.pull_request.base.sha }} HEAD -- 'filaments/*.json')
+          if [ -z "$changed" ]; then
+            echo "No filament files changed."
+            exit 0
+          fi
+          echo "$changed"
+          python3 scripts/lint_filaments.py $changed
   compile:
     runs-on: ubuntu-latest
     needs: [validate]

--- a/.github/workflows/catalog-preview.yml
+++ b/.github/workflows/catalog-preview.yml
@@ -1,0 +1,82 @@
+name: Catalog preview
+
+# Posts a comment listing the filament entries a PR would add, so the author can
+# check them against the manufacturer's catalog before a maintainer does.
+#
+# This uses pull_request_target because a PR from a fork has a read-only token
+# and cannot comment. Nothing from the PR is ever executed: the checkout is of
+# the base branch, and only *.json data files are taken from the PR head.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "filaments/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: catalog-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the base branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Take the data files from the PR
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p /tmp/base
+          cp filaments/*.json /tmp/base/
+          git fetch --no-tags origin "pull/$PR/head:pr-head"
+          # Restricted to a pathspec, so a PR cannot place files anywhere else.
+          git checkout pr-head -- 'filaments/*.json'
+
+      - name: Work out which files changed
+        id: changed
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          files=$(git diff --name-only --diff-filter=d "$BASE" pr-head -- 'filaments/*.json' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "Changed: $files"
+
+      - name: Render the preview
+        if: steps.changed.outputs.files != ''
+        run: |
+          printf '%s\n' '<!-- catalog-preview -->' > preview.md
+          python3 scripts/preview_catalog.py \
+            --base-dir /tmp/base \
+            --out body.md \
+            ${{ steps.changed.outputs.files }}
+          cat body.md >> preview.md
+
+      - name: Post or update the comment
+        if: steps.changed.outputs.files != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq 'map(select(.body | startswith("<!-- catalog-preview -->"))) | .[0].id // empty')
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@preview.md
+            echo "Updated comment $existing"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@preview.md
+            echo "Posted a new comment"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 filaments.json
+__pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,8 +165,14 @@ Create `filaments/<manufacturer>.json`, lowercase, no spaces.
 pipx install check-jsonschema
 
 check-jsonschema --schemafile filaments.schema.json filaments/*
+python3 scripts/lint_filaments.py filaments/yourfile.json
 python3 scripts/compile_filaments.py
 ```
 
-Both have to pass, CI runs the same thing. The compile step catches what the
-schema can't, like duplicate IDs.
+All three have to pass, CI runs the same thing. The compile step catches what
+the schema can't, like duplicate IDs. The linter checks the conventions on this
+page, and also prints warnings that don't fail the build but are usually worth
+a look.
+
+When you open the PR, a bot comments with every entry your change would add to
+Spoolman. Read it against the manufacturer's catalog before asking for review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,172 @@
+# Contributing
+
+Field descriptions are in the [README](README.md). This page is the rules that
+come up most in review.
+
+## Before you open a PR
+
+- One manufacturer per PR. Size doesn't matter, a full catalog in one PR is fine.
+- Link your sources in the PR description.
+- Check the [open PRs](https://github.com/Donkie/SpoolmanDB/pulls) for the same
+  manufacturer first. Duplicates are common.
+- Run the validation below.
+- Make sure the diff contains only your manufacturer's file.
+
+To update a PR, push to the same branch. Don't open a new one.
+
+## Sources
+
+Link where each product's data came from: product page, technical data sheet, or
+spec sheet. A PR without sources will be closed.
+
+**Don't use AI to generate the data.** It will fill in density, spool weight and
+hex codes with plausible values whether or not the manufacturer publishes them,
+and once merged nobody can tell those apart from real ones. This data is used to
+work out how much filament people have left. Read the values off a real source
+yourself.
+
+If you can't find a value, leave the field out. An empty optional field is fine,
+a guessed one is a bug.
+
+## Naming
+
+**Don't repeat the material in the name.** It's already its own field.
+
+```jsonc
+"material": "PLA", "name": "PLA {color_name}"   // no
+"material": "PLA", "name": "{color_name}"       // yes
+```
+
+**Don't put the manufacturer in the name.** Also already its own field.
+
+**Product lines go in `name`.** Series names, finishes and variants:
+
+```jsonc
+"name": "Matte {color_name}"
+"name": "Silk {color_name}"
+"name": "{color_name} Metallic"
+"name": "Hyper {color_name}"
+```
+
+Spell it the way the manufacturer does, including their capitalisation.
+
+## The material field
+
+`material` is the plastic, not the branding. It's used to group and filter across
+every manufacturer, so it has to mean the same thing everywhere.
+
+| They call it | You write                                             |
+| ------------ | ----------------------------------------------------- |
+| PETG-Tough   | `"material": "PETG"`, `"name": "Tough {color_name}"`  |
+| PETG HF      | `"material": "PETG"`, `"name": "HF {color_name}"`     |
+| TPU for AMS  | `"material": "TPU"`, `"name": "{color_name} for AMS"` |
+
+`-CF` and `-GF` mean a real carbon or glass fiber additive: `PETG-CF`, `ASA-GF`,
+`PETG-CF10`. `-95A` and `-55D` on TPU are shore hardness. Don't use that pattern
+for anything else.
+
+Some blends really are their own material and keep a compound name, like `PA6-GF`
+or `PC+ABS`. If the term describes what the plastic is, it goes in `material`. If
+it describes a product line, it goes in `name`.
+
+## Colors
+
+Use the manufacturer's own color name, translated to English if needed. Don't
+invent nicer ones.
+
+`{color_name}` is a placeholder for the `name` field. Never put it in a color's
+`name`, that field takes the literal color.
+
+`hex` is six hex digits, no leading `#`, optionally two more for alpha on
+transparent filaments. Use the manufacturer's code if they publish one, otherwise
+take it off a product photo. Don't default to `FF0000` for "Red".
+
+Multi-color filaments use `hexes` instead of `hex`, plus `multi_color_direction`:
+`coaxial` if the colors run side by side, `longitudinal` if the color changes
+along the spool.
+
+## Weights, diameters and colors multiply
+
+The build generates every combination of `weights` × `diameters` × `colors`. Two
+weights, two diameters and ten colors gives you forty database entries.
+
+So only group things in one object if every combination is actually sold. If the
+1 kg spool comes in ten colors but the 5 kg only comes in black, that's two
+filament objects, not one object with two weights.
+
+Same for spool types. A filament sold on both cardboard and plastic gets a second
+entry under `weights`, but only if every color is available on both.
+
+`weight` is the filament's net weight and `spool_weight` is the empty spool.
+Don't use the shipping weight from a store listing for either.
+
+## Temperatures
+
+`extruder_temp` and `bed_temp` are single values: the temperature to start at
+that works in most cases. If the manufacturer publishes a range you can also add
+`extruder_temp_range` and `bed_temp_range` as two-element arrays. Leave the bed
+temperature out if none is needed.
+
+## Keep the diff clean
+
+- **Don't commit `filaments.json`.** It's generated and gitignored. Committing it
+  adds a six-figure line count to your diff.
+- Don't commit editor files like `.vscode/` or `.DS_Store`.
+- Don't change the workflows, schema or compile script in a data PR. If the
+  schema needs changing, open a separate PR and say why.
+- Watch your line endings. Some files are CRLF and a Windows editor converting
+  one to LF rewrites every line.
+- Spell the field names exactly. Unknown keys pass validation and then get
+  dropped silently, so `extruder_temp_rang` or a trailing space means your data
+  never lands.
+- 4-space indent.
+
+## Things we don't store
+
+Already been asked, already declined:
+
+- **Price.** Too variable across countries, retailers and sales.
+- **`silk` and `metallic` finishes.** They look like `glossy`, and nobody
+  filtering a list would know which one to pick. Put it in the name and use
+  `"finish": "glossy"`.
+- **Diameter tolerance.** Not consistently published.
+- **Scraping scripts.** Commit the data they produce, not the script. Scripts
+  here become something that has to be maintained here.
+
+## New manufacturer
+
+Create `filaments/<manufacturer>.json`, lowercase, no spaces.
+
+```jsonc
+{
+    "manufacturer": "Example Filaments",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                { "weight": 1000, "spool_weight": 220, "spool_type": "plastic" }
+            ],
+            "diameters": [1.75],
+            "extruder_temp": 210,
+            "bed_temp": 60,
+            "colors": [
+                { "name": "Black", "hex": "1A1A1A" }
+            ]
+        }
+    ]
+}
+```
+
+## Validating
+
+```bash
+pipx install check-jsonschema
+
+check-jsonschema --schemafile filaments.schema.json filaments/*
+python3 scripts/compile_filaments.py
+```
+
+Both have to pass, CI runs the same thing. The compile step catches what the
+schema can't, like duplicate IDs.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A centralized place to store information about 3D printing filaments and their m
 The database is hosted using GitHub Pages, you can browse it at: [https://donkie.github.io/SpoolmanDB/](https://donkie.github.io/SpoolmanDB/)
 
 You can contribute to this database by adding/editing files and submitting pull requests in this repository.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) first.
 
 ## Filaments
 The source files are in the `filaments` folder. When this database is deployed, they will be expanded/compiled into a single JSON file called `filaments.json`.

--- a/scripts/lint_filaments.py
+++ b/scripts/lint_filaments.py
@@ -1,0 +1,276 @@
+"""Lints the filament source files against the conventions in CONTRIBUTING.md.
+
+Errors are things that are mechanically certain to be wrong and fail the build.
+Warnings are heuristics that need a human to judge; they never fail the build.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SCHEMA = Path("filaments.schema.json")
+FILAMENTS_DIR = Path("filaments")
+
+PLACEHOLDER = "{color_name}"
+
+# Colors named these may legitimately use a pure CSS value.
+PURE_HEX_OK = {"000000", "ffffff"}
+
+# Densities outside these bounds are unusual enough to be worth a look. Wide on
+# purpose: filled filaments are genuinely heavy and foaming ones genuinely light.
+DENSITY_BANDS = {
+    "PLA": (1.15, 1.35),
+    "PETG": (1.20, 1.32),
+    "ABS": (1.00, 1.10),
+    "ASA": (1.02, 1.15),
+    "TPU": (1.10, 1.30),
+    "PC": (1.15, 1.25),
+    "PVA": (1.20, 1.30),
+    "HIPS": (1.00, 1.10),
+    "PCTG": (1.20, 1.30),
+}
+
+TEMP_BANDS = {
+    "extruder_temp": (150, 450),
+    "bed_temp": (0, 160),
+}
+
+
+class Report:
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def error(self, where, msg, hint=None):
+        self.errors.append((where, msg, hint))
+
+    def warn(self, where, msg, hint=None):
+        self.warnings.append((where, msg, hint))
+
+
+def allowed_keys(schema: dict) -> tuple[set, set, set]:
+    """Reads the permitted key names straight out of the JSON schema."""
+    item = schema["properties"]["filaments"]["items"]
+    return (
+        set(item["properties"]),
+        set(item["properties"]["colors"]["items"]["properties"]),
+        set(item["properties"]["weights"]["items"]["properties"]),
+    )
+
+
+def base_material(material: str) -> str:
+    return re.split(r"[-+]", material)[0]
+
+
+def squash(text: str) -> str:
+    """Lowercases and drops separators, so 'PLA - ' == 'pla'."""
+    return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
+def squash_material(text: str) -> str:
+    """Like squash, but keeps '+' so that ABS+ stays distinct from ABS."""
+    return re.sub(r"[^a-z0-9+]", "", text.lower())
+
+
+def check_keys(rep, where, obj, permitted, kind):
+    for key in obj:
+        if key in permitted:
+            continue
+        near = [p for p in permitted if squash(p) == squash(key)]
+        hint = f"did you mean {near[0]!r}?" if near else f"allowed: {', '.join(sorted(permitted))}"
+        rep.error(
+            where,
+            f"unknown {kind} field {key!r}",
+            f"{hint} Unknown fields pass schema validation and are then dropped, "
+            "so this data would never reach the database.",
+        )
+
+
+def check_name(rep, where, name, material, manufacturer):
+    if PLACEHOLDER not in name:
+        rep.error(where, f"name {name!r} is missing the {PLACEHOLDER} placeholder")
+        return
+
+    if name != name.strip() or "  " in name:
+        rep.error(where, f"name {name!r} has leading, trailing or doubled whitespace")
+
+    remainder = name.replace(PLACEHOLDER, "")
+
+    # Only an error when the name is *nothing but* the material. Real product
+    # lines that contain the material (PolyLite PLA, CR-PETG) are fine.
+    if squash_material(remainder) in {
+        squash_material(material),
+        squash_material(base_material(material)),
+    }:
+        rep.error(
+            where,
+            f"name {name!r} is just the material, which is already in the material field",
+            f'use "name": "{PLACEHOLDER}"',
+        )
+
+    if squash(remainder) in {squash(manufacturer), squash(manufacturer) + squash(material)}:
+        rep.error(
+            where,
+            f"name {name!r} is just the manufacturer, which is already in the manufacturer field",
+            f'use "name": "{PLACEHOLDER}"',
+        )
+    elif squash(manufacturer) and squash(manufacturer) in squash(remainder):
+        rep.warn(
+            where,
+            f"name {name!r} repeats the manufacturer name",
+            "the manufacturer is already a field, drop it from the name unless "
+            "it is genuinely part of the product name",
+        )
+
+
+def check_colors(rep, where, filament):
+    seen = {}
+    for i, color in enumerate(filament["colors"]):
+        name = color.get("name", "")
+        cwhere = f"{where} color[{i}]"
+
+        if PLACEHOLDER in name:
+            rep.error(
+                cwhere,
+                f"color name {name!r} contains {PLACEHOLDER}",
+                "the placeholder belongs in the filament name field; this field "
+                "takes the literal color name",
+            )
+        if name != name.strip() or "  " in name:
+            rep.error(cwhere, f"color name {name!r} has leading, trailing or doubled whitespace")
+
+        key = squash(name)
+        if key in seen:
+            rep.error(cwhere, f"duplicate color name {name!r} (also at color[{seen[key]}])")
+        else:
+            seen[key] = i
+
+        if ("hex" in color) == ("hexes" in color):
+            rep.error(cwhere, f"color {name!r} must have exactly one of hex or hexes")
+        if ("hexes" in color) != ("multi_color_direction" in color or
+                                  "multi_color_direction" in filament):
+            rep.error(
+                cwhere,
+                f"color {name!r}: hexes and multi_color_direction must be set together",
+            )
+
+        for value in [color["hex"]] if "hex" in color else color.get("hexes", []):
+            v = value.lower()[:6]
+            if v not in PURE_HEX_OK and re.fullmatch(r"(00|ff|80|c0|40){3}", v):
+                rep.warn(
+                    cwhere,
+                    f"color {name!r} uses the pure CSS value {value!r}",
+                    "real filament rarely lands exactly on a web colour; take it "
+                    "from a product photo",
+                )
+
+
+def check_numbers(rep, where, filament):
+    material = filament["material"]
+    band = DENSITY_BANDS.get(base_material(material))
+    density = filament["density"]
+    if band and not (band[0] <= density <= band[1]):
+        rep.warn(
+            where,
+            f"density {density} is outside the usual {band[0]}-{band[1]} for {material}",
+            "fine if the manufacturer publishes it (filled and foaming filaments "
+            "differ a lot); link the source in the PR",
+        )
+
+    for field, (lo, hi) in TEMP_BANDS.items():
+        if field in filament and not (lo <= filament[field] <= hi):
+            rep.error(where, f"{field} {filament[field]} is outside {lo}-{hi}")
+        rng = filament.get(f"{field}_range")
+        if rng and rng[0] > rng[1]:
+            rep.error(where, f"{field}_range {rng} is the wrong way round")
+        if rng and field in filament and not (rng[0] <= filament[field] <= rng[1]):
+            rep.error(
+                where,
+                f"{field} {filament[field]} lies outside its own {field}_range {rng}",
+            )
+
+    for i, weight in enumerate(filament["weights"]):
+        net = weight["weight"]
+        tare = weight.get("spool_weight")
+        if tare is not None and tare >= net:
+            rep.warn(
+                f"{where} weights[{i}]",
+                f"spool_weight {tare} is not less than the filament weight {net}",
+                "weight is the net filament weight and spool_weight the empty "
+                "spool; a store listing's gross weight is neither",
+            )
+
+    combos = (
+        len(filament["weights"]) * len(filament["diameters"]) * len(filament["colors"])
+    )
+    if combos > 60:
+        rep.warn(
+            where,
+            f"expands to {combos} database entries",
+            "every weight x diameter x colour combination is generated; split the "
+            "object up if some of those combinations are not actually sold",
+        )
+
+
+def lint_file(path: Path, keysets) -> Report:
+    rep = Report()
+    fil_keys, color_keys, weight_keys = keysets
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        rep.error(path.name, f"invalid JSON: {exc}")
+        return rep
+
+    manufacturer = data.get("manufacturer", "")
+    expected = re.sub(r"[^a-z0-9]", "", manufacturer.lower())
+    if path.stem.lower() != expected and expected:
+        rep.warn(
+            path.name,
+            f"filename does not match manufacturer {manufacturer!r}",
+            f"consider {expected}.json",
+        )
+
+    for i, filament in enumerate(data.get("filaments", [])):
+        where = f"{path.name} filaments[{i}]"
+        check_keys(rep, where, filament, fil_keys, "filament")
+        for j, color in enumerate(filament.get("colors", [])):
+            check_keys(rep, f"{where} color[{j}]", color, color_keys, "color")
+        for j, weight in enumerate(filament.get("weights", [])):
+            check_keys(rep, f"{where} weights[{j}]", weight, weight_keys, "weight")
+
+        if not {"name", "material", "colors", "weights", "diameters", "density"} <= set(filament):
+            continue  # schema validation reports missing required fields
+
+        check_name(rep, where, filament["name"], filament["material"], manufacturer)
+        check_colors(rep, where, filament)
+        check_numbers(rep, where, filament)
+
+    return rep
+
+
+def main(argv):
+    paths = [Path(a) for a in argv[1:]] or sorted(FILAMENTS_DIR.glob("*.json"))
+    keysets = allowed_keys(json.loads(SCHEMA.read_text(encoding="utf-8")))
+
+    errors = warnings = 0
+    for path in paths:
+        rep = lint_file(path, keysets)
+        errors += len(rep.errors)
+        warnings += len(rep.warnings)
+        for where, msg, hint in rep.errors:
+            print(f"error: {where}: {msg}")
+            if hint:
+                print(f"       {hint}")
+        for where, msg, hint in rep.warnings:
+            print(f"warning: {where}: {msg}")
+            if hint:
+                print(f"         {hint}")
+
+    print(f"\n{len(paths)} file(s), {errors} error(s), {warnings} warning(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/preview_catalog.py
+++ b/scripts/preview_catalog.py
@@ -1,0 +1,121 @@
+"""Renders a markdown summary of the filament entries a PR would add.
+
+It reuses the real expansion logic from compile_filaments, so the list shown to
+the author is exactly what would end up in the database. Grouping the entries by
+weight, spool type and diameter is deliberate: a combination the manufacturer
+does not actually sell is obvious when it appears as its own heading.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from compile_filaments import get_filaments_from_data  # noqa: E402
+
+COMMENT_LIMIT = 60000
+
+
+def load(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def entries(data: dict | None) -> list[dict]:
+    if not data:
+        return []
+    try:
+        return list(get_filaments_from_data(data))
+    except (KeyError, ValueError):
+        return []
+
+
+def describe_spool(entry: dict) -> str:
+    parts = [f"{entry['diameter']} mm", f"{entry['weight']:g} g"]
+    spool = entry.get("spool_type")
+    tare = entry.get("spool_weight")
+    if spool and tare:
+        parts.append(f"{spool} spool ({tare:g} g tare)")
+    elif spool:
+        parts.append(f"{spool} spool")
+    elif tare:
+        parts.append(f"spool {tare:g} g tare")
+    else:
+        parts.append("spool type not set")
+    return " · ".join(parts)
+
+
+def render(new_entries: list[dict]) -> str:
+    if not new_entries:
+        return "## Catalog preview\n\nThis PR doesn't add any new filament entries.\n"
+
+    total = len(new_entries)
+    out = [
+        "## Catalog preview",
+        "",
+        f"This PR would add **{total} entr{'y' if total == 1 else 'ies'}** to Spoolman, "
+        "listed below as they will appear to users.",
+        "",
+        "**Please check this against the manufacturer's product catalog.** Every "
+        "combination of weight, diameter and colour is generated automatically, so "
+        "a spool size or diameter that only exists for some colours will show up "
+        "here as products that aren't really sold. If you see any, split the "
+        "filament into separate objects so only real combinations are produced.",
+        "",
+    ]
+
+    new_entries.sort(key=lambda e: (e["manufacturer"], e["material"], e["name"]))
+    for e in new_entries:
+        out.append(
+            f"- {e['manufacturer']} - {e['material']} {e['name']} · {describe_spool(e)}"
+        )
+    out.append("")
+
+    text = "\n".join(out)
+    if len(text) > COMMENT_LIMIT:
+        text = (
+            text[:COMMENT_LIMIT].rsplit("\n", 1)[0]
+            + "\n\n*(list truncated, it is too long for a single comment)*\n"
+        )
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*", help="changed filament json files")
+    parser.add_argument("--base-dir", help="directory holding the base versions")
+    parser.add_argument("--out", default="preview.md")
+    args = parser.parse_args()
+
+    new_entries = []
+    for name in args.files:
+        path = Path(name)
+        if path.parent.name != "filaments" or path.suffix != ".json":
+            continue
+
+        head = load(path)
+        if head is None:
+            continue
+
+        base_ids = set()
+        if args.base_dir:
+            base = load(Path(args.base_dir) / path.name)
+            base_ids = {e["id"] for e in entries(base)}
+
+        for data_filament in head.get("filaments", []):
+            single = {"manufacturer": head["manufacturer"], "filaments": [data_filament]}
+            for e in entries(single):
+                if e["id"] in base_ids:
+                    continue
+                new_entries.append(e)
+
+    Path(args.out).write_text(render(new_entries), encoding="utf-8")
+    print(f"wrote {args.out} ({len(new_entries)} new entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three things, aimed at cutting the manual part of reviewing data PRs.

**`CONTRIBUTING.md`** — writes down the conventions that come up most in review, taken from the actual review history: one manufacturer per PR, sources in the description, no AI-generated data, the naming and material-field rules, and the weights × diameters × colors expansion.

**`scripts/lint_filaments.py`** — checks those conventions. Errors are mechanically certain (unknown field names, names that are just the material or manufacturer, stray whitespace, duplicate colors, hex/temperature consistency). Heuristics like unusual densities and oversized combination counts are warnings and don't fail the build.

There are 33 pre-existing errors in `main`, all genuine, so CI lints only the files a PR changes. Running the script with no arguments does a full sweep.

Notable existing bugs it found: `spool_material` in `ratrig.json` (×4), `extruder_temp_rang` in `esun.json`, `extruder_temp_Range` in `Numakers.json`, and `"extruder_temp "` with a trailing space in `ldo.json` (×2). Unknown keys pass schema validation and are then dropped by the compiler, so those entries currently ship with no temperature and no spool type.

**`scripts/preview_catalog.py` + `catalog-preview.yml`** — comments on each PR with every entry it would add, for the author to check against the manufacturer's catalog. It imports the expansion from `compile_filaments.py` so it can't drift from what ships, and diffs against the base so only new entries are listed.

Build now also fails if a PR commits `filaments.json` or editor files.

Note: `catalog-preview.yml` uses `pull_request_target` so that fork PRs can be commented on. That event always runs the workflow from the base branch, so the bot only starts working once this is merged to `main`.