### PR TITLE
Let the catalog preview bot run against already-open PRs

### DIFF
--- a/.github/workflows/catalog-preview.yml
+++ b/.github/workflows/catalog-preview.yml
@@ -5,20 +5,34 @@ name: Catalog preview
 #
 # This uses pull_request_target because a PR from a fork has a read-only token
 # and cannot comment. Nothing from the PR is ever executed: the checkout is of
-# the base branch, and only *.json data files are taken from the PR head.
+# the base branch, and only the *.json data files it changed are taken from the
+# PR head.
+#
+# It can also be run by hand against one PR or every open PR, which is how
+# already-open PRs get their first comment.
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - "filaments/**"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number, or 'all' for every open PR"
+        required: true
+        default: "all"
+      dry_run:
+        description: "Render the comments but don't post them"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: catalog-preview-${{ github.event.pull_request.number }}
+  group: catalog-preview-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 jobs:
@@ -35,48 +49,70 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Take the data files from the PR
-        env:
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          mkdir -p /tmp/base
-          cp filaments/*.json /tmp/base/
-          git fetch --no-tags origin "pull/$PR/head:pr-head"
-          # Restricted to a pathspec, so a PR cannot place files anywhere else.
-          git checkout pr-head -- 'filaments/*.json'
-
-      - name: Work out which files changed
-        id: changed
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-        run: |
-          files=$(git diff --name-only --diff-filter=d "$BASE" pr-head -- 'filaments/*.json' | tr '\n' ' ')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
-          echo "Changed: $files"
-
-      - name: Render the preview
-        if: steps.changed.outputs.files != ''
-        run: |
-          printf '%s\n' '<!-- catalog-preview -->' > preview.md
-          python3 scripts/preview_catalog.py \
-            --base-dir /tmp/base \
-            --out body.md \
-            ${{ steps.changed.outputs.files }}
-          cat body.md >> preview.md
-
-      - name: Post or update the comment
-        if: steps.changed.outputs.files != ''
+      - name: Post a preview on each PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq 'map(select(.body | startswith("<!-- catalog-preview -->"))) | .[0].id // empty')
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@preview.md
-            echo "Updated comment $existing"
+          set -euo pipefail
+
+          # Whatever was checked out: the PR's base branch, or the default
+          # branch for a manual run.
+          base_sha=$(git rev-parse HEAD)
+
+          if [ -n "$EVENT_PR" ]; then
+            prs="$EVENT_PR"
+          elif [ "$INPUT_PR" = "all" ]; then
+            prs=$(gh pr list --repo "$REPO" --limit 300 --json number --jq '.[].number')
           else
-            gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@preview.md
-            echo "Posted a new comment"
+            prs="$INPUT_PR"
           fi
+
+          # The current state of main, used to decide which entries are new. A PR
+          # whose data someone else already merged will show up as adding little.
+          mkdir -p /tmp/base
+          cp filaments/*.json /tmp/base/
+
+          for pr in $prs; do
+            git reset -q --hard "$base_sha"
+            git clean -qfd filaments/
+            git fetch -q --no-tags --force origin "pull/$pr/head:pr-head" || {
+              echo "PR $pr: could not fetch head, skipping"; continue; }
+
+            # Diffing against the merge base keeps unrelated changes that landed
+            # on main since the PR was opened out of the list.
+            merge_base=$(git merge-base "$base_sha" pr-head)
+            files=$(git diff --name-only --diff-filter=d "$merge_base" pr-head \
+              -- 'filaments/*.json' | tr '\n' ' ')
+            if [ -z "$files" ]; then
+              echo "PR $pr: no filament files changed"
+              continue
+            fi
+
+            # Only data files are taken from the PR, and none of it is executed.
+            git checkout -q pr-head -- $files
+
+            printf '%s\n' '<!-- catalog-preview -->' > /tmp/preview.md
+            python3 scripts/preview_catalog.py --base-dir /tmp/base \
+              --out /tmp/body.md $files
+            cat /tmp/body.md >> /tmp/preview.md
+
+            if [ "${DRY_RUN:-false}" = "true" ]; then
+              echo "--- PR $pr (dry run) ---"
+              head -4 /tmp/body.md
+              continue
+            fi
+
+            existing=$(gh api "repos/$REPO/issues/$pr/comments" --paginate \
+              --jq 'map(select(.body | startswith("<!-- catalog-preview -->"))) | .[0].id // empty')
+            if [ -n "$existing" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@/tmp/preview.md >/dev/null
+              echo "PR $pr: updated comment $existing"
+            else
+              gh api -X POST "repos/$REPO/issues/$pr/comments" -F body=@/tmp/preview.md >/dev/null
+              echo "PR $pr: posted a new comment"
+            fi
+          done

--- a/scripts/preview_catalog.py
+++ b/scripts/preview_catalog.py
@@ -50,7 +50,11 @@ def describe_spool(entry: dict) -> str:
 
 def render(new_entries: list[dict]) -> str:
     if not new_entries:
-        return "## Catalog preview\n\nThis PR doesn't add any new filament entries.\n"
+        return (
+            "## Catalog preview\n\n"
+            "This PR doesn't add any new filament entries. It may still be "
+            "correcting existing ones, which this comment doesn't cover.\n"
+        )
 
     total = len(new_entries)
     out = [
@@ -68,17 +72,27 @@ def render(new_entries: list[dict]) -> str:
     ]
 
     new_entries.sort(key=lambda e: (e["manufacturer"], e["material"], e["name"]))
-    for e in new_entries:
-        out.append(
-            f"- {e['manufacturer']} - {e['material']} {e['name']} · {describe_spool(e)}"
-        )
-    out.append("")
+    bullets = [
+        f"- {e['manufacturer']} - {e['material']} {e['name']} · {describe_spool(e)}"
+        for e in new_entries
+    ]
 
-    text = "\n".join(out)
-    if len(text) > COMMENT_LIMIT:
-        text = (
-            text[:COMMENT_LIMIT].rsplit("\n", 1)[0]
-            + "\n\n*(list truncated, it is too long for a single comment)*\n"
+    # Keep as many entries as fit, and be explicit about any that don't.
+    header = "\n".join(out)
+    budget = COMMENT_LIMIT - len(header) - 200
+    kept = []
+    for bullet in bullets:
+        budget -= len(bullet) + 1
+        if budget < 0:
+            break
+        kept.append(bullet)
+
+    text = header + "\n".join(kept) + "\n"
+    dropped = len(bullets) - len(kept)
+    if dropped:
+        text += (
+            f"\n*Showing {len(kept)} of {len(bullets)} entries. The remaining "
+            f"{dropped} don't fit in a single comment.*\n"
         )
     return text
 


### PR DESCRIPTION
Adds a `workflow_dispatch` mode to the catalog preview so it can be run against PRs that are already open (`pull_request_target` only fires on new activity). Takes a PR number or `all`, with a dry run option that renders without posting.

Dry-run locally across all 63 open PRs: 61 render, 2 correctly skipped (#282 and #283 change only the schema), 0 failures. Largest is #231 at 770 entries, which truncates at 668 with a note saying so.

Needs merging before the sweep can be run, since `workflow_dispatch` only works from the default branch.