### PR TITLE
Add TECBEARS (8 filaments, 45 colors)

### DIFF
--- a/filaments/tecbears.json
+++ b/filaments/tecbears.json
@@ -1,0 +1,387 @@
+{
+    "manufacturer": "TECBEARS",
+    "filaments": [
+        {
+            "name": "Glow {color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "1ADAFB",
+                    "glow": true
+                },
+                {
+                    "name": "White to Glow Blue",
+                    "hex": "1ADAFB",
+                    "glow": true
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "EBFF57",
+                    "glow": true
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 157
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "010101"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000FF"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "5C5C5C"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FF8800"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "E4E7E5",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "Glow {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "0099E6",
+                    "glow": true
+                },
+                {
+                    "name": "Green",
+                    "hex": "00CC00",
+                    "glow": true
+                },
+                {
+                    "name": "White to Glow Blue",
+                    "hex": "1ADAFB",
+                    "glow": true
+                },
+                {
+                    "name": "White to Glow Green",
+                    "hex": "FFFFFF",
+                    "glow": true
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "EBFF57",
+                    "glow": true
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Beige",
+                    "hex": "F4E0DC"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0353BA"
+                },
+                {
+                    "name": "Cherry Wood",
+                    "hex": "81615D"
+                },
+                {
+                    "name": "Cyan",
+                    "hex": "1ADAFB"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Maple Wood",
+                    "hex": "CAAC78"
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "4C5E46"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "F67405"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "6C47B2"
+                },
+                {
+                    "name": "Transparent Blue",
+                    "hex": "0353BA",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Green",
+                    "hex": "06B100",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Orange",
+                    "hex": "F67405",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Purple",
+                    "hex": "6C47B2",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Red",
+                    "hex": "DE1619",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Yellow",
+                    "hex": "FBE200",
+                    "translucent": true
+                },
+                {
+                    "name": "Walnut Wood",
+                    "hex": "503529"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Wood",
+                    "hex": "B38F6E"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.25,
+            "weights": [
+                {
+                    "weight": 1100,
+                    "spool_weight": 127
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Green",
+                    "hex": "00FF00"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF00CB"
+                },
+                {
+                    "name": "Red",
+                    "hex": "FF0000"
+                }
+            ]
+        },
+        {
+            "name": "Plus High Speed {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000,
+                    "spool_weight": 250
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Grey",
+                    "hex": "626164"
+                },
+                {
+                    "name": "Olive Green",
+                    "hex": "4D5D4C"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FF8E24"
+                }
+            ]
+        },
+        {
+            "name": "Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Gold",
+                    "hex": "FFCB47"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "A8B0BD"
+                }
+            ]
+        },
+        {
+            "name": "95A {color_name}",
+            "material": "TPU",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                30,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "F67405"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds `filaments/tecbears.json` for **TECBEARS** - 8 filaments, 45 colors. TECBEARS is not currently in SpoolmanDB.

Part of a migration of the [Open Filament Database](https://openfilamentdatabase.org/)
(MIT licensed) into SpoolmanDB, one manufacturer per PR. The text below is the same on
every one of them.

### Source

- OFD brand page: https://openfilamentdatabase.org/brands/tecbears
- Manufacturer site: https://www.facebook.com/tecbears/
- (OFD records no data-sheet URL for this brand)

OFD collects its values from manufacturer product pages and technical data sheets.

**Nothing here is AI-generated.** The conversion is a field-mapping script with no
inference step: where OFD has no value, the field is omitted rather than filled. Density,
hex codes, temperature ranges and spool weights are carried across verbatim or not at all.
Script: https://gist.github.com/hochhause/f40c65a020c7bfd5a119b904b7558150

### Existing entries are never edited

Where SpoolmanDB already has a group for a product, new colors go **into that group** —
including where its name predates the current naming rules (eSUN's `PLA-Basic`, for
instance). Creating a correctly-named parallel group would leave two entries for one
product, which seemed worse than an inconsistent name. Existing fields, names and colors
are untouched; every diff is additions only. Say the word if you would rather have the
rename and I will split them.

Where a color is sold in a spool size the existing group does not list, it cannot join
that group without inventing combinations, so it becomes a sibling entry under the same
name with the correct sizes — one product, two spool sizes.

### What was left out, and how to get it back

Three kinds of color are withheld, on the principle that a missing color is cheaper to
fix than a duplicate:

- **Already present** — identical hex in the matching group. Your value stands.
- **Name clashes** — same color name as an existing entry but a different hex. Because
  `name` expands `{color_name}`, both would resolve to the same final product name and
  differ only by swatch. Correcting an existing hex is a separate question this PR does
  not try to answer.
- **Within RGB distance 10** of an existing color under a different name — the same shade
  renamed or resampled, which is a judgement call about product identity.

Spool sizes are limited to **250 g, 500 g, 750 g, 1 kg, 1.1 kg, 2 kg, 3 kg, 5 kg and
10 kg**. Everything else in OFD's long tail is left out: 9 kg, 8 kg, 4.5 kg, 2.5 kg,
2.3 kg, 850 g, 800 g and a scatter of rarer ones, including a few that look like a gross
weight rather than a filament weight (4310 g, 5310 g, 4010 g). A color sold only in an
excluded size is left out entirely rather than attached to a size it is not sold in.

Across the whole migration that is 892 colors already present, 1158 name
clashes, 46 near-identical shades and 227 colors held back on spool size.

**If you want any of it — a size, a clash, a near-shade, for this manufacturer or
globally — just ask and I will add it.** It is one line in the converter, not a re-run
of the research.

### Normalisation applied

- **Material taken out of the name.** `PLA-Matte` → `material: PLA`,
  `name: "Matte {color_name}"`, following the `PETG-Tough` example in CONTRIBUTING.
  Compound tokens that really are a different plastic (`PLA-CF`, `PA6-GF25`, `TPU-95A`,
  `PC+ABS`) move into `material` instead.
- **Manufacturer removed** from the name wherever OFD repeated it.
- **Sizes split so combinations stay real.** Since the build multiplies
  weights × diameters × colors, colors are grouped by the size set they are actually sold
  in and each group split so the cross product contains only combinations that exist.
  Verified against the source: 20,709 real (color, diameter, weight) rows, 0 fabricated,
  0 lost.
- Where OFD records **no size at all** for a color, 1.75 mm / 1 kg is assumed. That is an
  assumption, not a source value, and it affects 13 records in the entire database.

`scripts/lint_filaments.py` reports no new errors against this file.

### Fields left empty

`extruder_temp` / `bed_temp` — OFD stores a min/max range, mapped to `extruder_temp_range`
and `bed_temp_range`. The single-value fields have no source value, so they are omitted
rather than derived from a midpoint. `spool_weight` and `spool_type` are present only
where OFD records them.
