### PR TITLE
Add Verbatim (6 filaments, 26 colors)

### DIFF
--- a/filaments/verbatim.json
+++ b/filaments/verbatim.json
@@ -1,0 +1,252 @@
+{
+    "manufacturer": "Verbatim",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.04,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                260
+            ],
+            "bed_temp_range": [
+                90,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Aluminium Grey",
+                    "hex": "9F9F9F"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2C3294"
+                },
+                {
+                    "name": "Green",
+                    "hex": "739549"
+                },
+                {
+                    "name": "Natural/Milky",
+                    "hex": "DFDFD3"
+                },
+                {
+                    "name": "Red",
+                    "hex": "E60000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "BVOH",
+            "density": 1.14,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Natural",
+                    "hex": "DFDFD3"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2C3294"
+                },
+                {
+                    "name": "Blue Transparent",
+                    "hex": "0099E6",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear",
+                    "hex": "DFDFD3",
+                    "translucent": true
+                },
+                {
+                    "name": "Green Transparent",
+                    "hex": "58C91B",
+                    "translucent": true
+                },
+                {
+                    "name": "Red",
+                    "hex": "E60000"
+                },
+                {
+                    "name": "Red Transparent",
+                    "hex": "E60000",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Aluminium Grey",
+                    "hex": "9F9F9F"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "2C3294"
+                },
+                {
+                    "name": "Green",
+                    "hex": "739549"
+                },
+                {
+                    "name": "Natural/Transparent",
+                    "hex": "DFDFD3"
+                },
+                {
+                    "name": "Red",
+                    "hex": "E60000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PP",
+            "density": 0.9,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                80,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "Natural",
+                    "hex": "DFDFD3",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "Tefabloc {color_name}",
+            "material": "TPE",
+            "density": 1.2,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                30,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds `filaments/verbatim.json` for **Verbatim** - 6 filaments, 26 colors. Verbatim is not currently in SpoolmanDB.

Part of a migration of the [Open Filament Database](https://openfilamentdatabase.org/)
(MIT licensed) into SpoolmanDB, one manufacturer per PR. The text below is the same on
every one of them.

### Source

- OFD brand page: https://openfilamentdatabase.org/brands/verbatim
- Manufacturer site: https://verbatim.com
- (OFD records no data-sheet URL for this brand)

OFD collects its values from manufacturer product pages and technical data sheets.

**Nothing here is AI-generated.** The conversion is a field-mapping script with no
inference step: where OFD has no value, the field is omitted rather than filled. Density,
hex codes, temperature ranges and spool weights are carried across verbatim or not at all.
Script: https://gist.github.com/hochhause/f40c65a020c7bfd5a119b904b7558150

### Existing entries are never edited

Where SpoolmanDB already has a group for a product, new colors go **into that group** —
including where its name predates the current naming rules (eSUN's `PLA-Basic`, for
instance). Creating a correctly-named parallel group would leave two entries for one
product, which seemed worse than an inconsistent name. Existing fields, names and colors
are untouched; every diff is additions only. Say the word if you would rather have the
rename and I will split them.

Where a color is sold in a spool size the existing group does not list, it cannot join
that group without inventing combinations, so it becomes a sibling entry under the same
name with the correct sizes — one product, two spool sizes.

### What was left out, and how to get it back

Three kinds of color are withheld, on the principle that a missing color is cheaper to
fix than a duplicate:

- **Already present** — identical hex in the matching group. Your value stands.
- **Name clashes** — same color name as an existing entry but a different hex. Because
  `name` expands `{color_name}`, both would resolve to the same final product name and
  differ only by swatch. Correcting an existing hex is a separate question this PR does
  not try to answer.
- **Within RGB distance 10** of an existing color under a different name — the same shade
  renamed or resampled, which is a judgement call about product identity.

Spool sizes are limited to **250 g, 500 g, 750 g, 1 kg, 1.1 kg, 2 kg, 3 kg, 5 kg and
10 kg**. Everything else in OFD's long tail is left out: 9 kg, 8 kg, 4.5 kg, 2.5 kg,
2.3 kg, 850 g, 800 g and a scatter of rarer ones, including a few that look like a gross
weight rather than a filament weight (4310 g, 5310 g, 4010 g). A color sold only in an
excluded size is left out entirely rather than attached to a size it is not sold in.

Across the whole migration that is 892 colors already present, 1158 name
clashes, 46 near-identical shades and 227 colors held back on spool size.

**If you want any of it — a size, a clash, a near-shade, for this manufacturer or
globally — just ask and I will add it.** It is one line in the converter, not a re-run
of the research.

### Normalisation applied

- **Material taken out of the name.** `PLA-Matte` → `material: PLA`,
  `name: "Matte {color_name}"`, following the `PETG-Tough` example in CONTRIBUTING.
  Compound tokens that really are a different plastic (`PLA-CF`, `PA6-GF25`, `TPU-95A`,
  `PC+ABS`) move into `material` instead.
- **Manufacturer removed** from the name wherever OFD repeated it.
- **Sizes split so combinations stay real.** Since the build multiplies
  weights × diameters × colors, colors are grouped by the size set they are actually sold
  in and each group split so the cross product contains only combinations that exist.
  Verified against the source: 20,709 real (color, diameter, weight) rows, 0 fabricated,
  0 lost.
- Where OFD records **no size at all** for a color, 1.75 mm / 1 kg is assumed. That is an
  assumption, not a source value, and it affects 13 records in the entire database.

`scripts/lint_filaments.py` reports no new errors against this file.

### Fields left empty

`extruder_temp` / `bed_temp` — OFD stores a min/max range, mapped to `extruder_temp_range`
and `bed_temp_range`. The single-value fields have no source value, so they are omitted
rather than derived from a midpoint. `spool_weight` and `spool_type` are present only
where OFD records them.
