### PR TITLE
VOXELPLA: add 28 colors

### DIFF
--- a/filaments/voxelpla.json
+++ b/filaments/voxelpla.json
@@ -21,6 +21,43 @@
                 {
                     "name": "Black",
                     "hex": "383435"
+                },
+                {
+                        "name": "Blue",
+                        "hex": "2E56F1"
+                },
+                {
+                        "name": "Crystal Clear",
+                        "hex": "E4E7E5",
+                        "translucent": true
+                },
+                {
+                        "name": "Green",
+                        "hex": "32A584"
+                },
+                {
+                        "name": "Grey",
+                        "hex": "9DB6D4"
+                },
+                {
+                        "name": "Orange",
+                        "hex": "FF8133"
+                },
+                {
+                        "name": "Red",
+                        "hex": "E20010"
+                },
+                {
+                        "name": "Silver",
+                        "hex": "C9D0D4"
+                },
+                {
+                        "name": "White",
+                        "hex": "FFFFFF"
+                },
+                {
+                        "name": "Yellow",
+                        "hex": "F5E457"
                 }
             ]
         }, 
@@ -52,7 +89,83 @@
                {
                     "name": "Fire Engine Red",
                     "hex": "8D0823"
-                }
+                },
+               {
+                      "name": "Army Green",
+                      "hex": "6E8451"
+               },
+               {
+                      "name": "Cool White",
+                      "hex": "EFEFEF"
+               },
+               {
+                      "name": "Dark Purple",
+                      "hex": "6C47B2"
+               },
+               {
+                      "name": "Fire Orange",
+                      "hex": "F67405"
+               },
+               {
+                      "name": "Forest Green",
+                      "hex": "32A584"
+               },
+               {
+                      "name": "Gold",
+                      "hex": "E3B145"
+               },
+               {
+                      "name": "Ice Clear",
+                      "hex": "E4E7E5"
+               },
+               {
+                      "name": "Lavender Purple",
+                      "hex": "AAB1FF"
+               },
+               {
+                      "name": "Magenta",
+                      "hex": "F2306E"
+               },
+               {
+                      "name": "Pink",
+                      "hex": "F87FB5"
+               },
+               {
+                      "name": "Silver",
+                      "hex": "AABCCF"
+               },
+               {
+                      "name": "Sky Blue",
+                      "hex": "39B9DB"
+               },
+               {
+                      "name": "Voxel Black",
+                      "hex": "000000"
+               },
+               {
+                      "name": "Voxel Grey",
+                      "hex": "C3CCD5"
+               },
+               {
+                      "name": "VOXEL Phantom Blue",
+                      "hex": "003287"
+               },
+               {
+                      "name": "Voxel Royal Blue",
+                      "hex": "2E56F1"
+               },
+               {
+                      "name": "Witch Green",
+                      "hex": "58C91B"
+               },
+               {
+                      "name": "Wood",
+                      "hex": "DBC9AD"
+               },
+               {
+                      "name": "Yellow",
+                      "hex": "FBE200"
+               }
             ]
         }   
     ]


### PR DESCRIPTION
Adds **28 colors** and **0 product entries** to the existing `filaments/voxelpla.json`, all as additions.

Part of a migration of the [Open Filament Database](https://openfilamentdatabase.org/)
(MIT licensed) into SpoolmanDB, one manufacturer per PR. The text below is the same on
every one of them.

### Source

- OFD brand page: https://openfilamentdatabase.org/brands/voxel_pla
- Manufacturer site: https://voxelpla.com
- (OFD records no data-sheet URL for this brand)

OFD collects its values from manufacturer product pages and technical data sheets.

**Nothing here is AI-generated.** The conversion is a field-mapping script with no
inference step: where OFD has no value, the field is omitted rather than filled. Density,
hex codes, temperature ranges and spool weights are carried across verbatim or not at all.
Script: https://gist.github.com/hochhause/f40c65a020c7bfd5a119b904b7558150

### Existing entries are never edited

Where SpoolmanDB already has a group for a product, new colors go **into that group** —
including where its name predates the current naming rules (eSUN's `PLA-Basic`, for
instance). Creating a correctly-named parallel group would leave two entries for one
product, which seemed worse than an inconsistent name. Existing fields, names and colors
are untouched; every diff is additions only. Say the word if you would rather have the
rename and I will split them.

Where a color is sold in a spool size the existing group does not list, it cannot join
that group without inventing combinations, so it becomes a sibling entry under the same
name with the correct sizes — one product, two spool sizes.

### What was left out, and how to get it back

Three kinds of color are withheld, on the principle that a missing color is cheaper to
fix than a duplicate:

- **Already present** — identical hex in the matching group. Your value stands.
- **Name clashes** — same color name as an existing entry but a different hex. Because
  `name` expands `{color_name}`, both would resolve to the same final product name and
  differ only by swatch. Correcting an existing hex is a separate question this PR does
  not try to answer.
- **Within RGB distance 10** of an existing color under a different name — the same shade
  renamed or resampled, which is a judgement call about product identity.

Spool sizes are limited to **250 g, 500 g, 750 g, 1 kg, 1.1 kg, 2 kg, 3 kg, 5 kg and
10 kg**. Everything else in OFD's long tail is left out: 9 kg, 8 kg, 4.5 kg, 2.5 kg,
2.3 kg, 850 g, 800 g and a scatter of rarer ones, including a few that look like a gross
weight rather than a filament weight (4310 g, 5310 g, 4010 g). A color sold only in an
excluded size is left out entirely rather than attached to a size it is not sold in.

Across the whole migration that is 892 colors already present, 1158 name
clashes, 46 near-identical shades and 227 colors held back on spool size.

**If you want any of it — a size, a clash, a near-shade, for this manufacturer or
globally — just ask and I will add it.** It is one line in the converter, not a re-run
of the research.

### Normalisation applied

- **Material taken out of the name.** `PLA-Matte` → `material: PLA`,
  `name: "Matte {color_name}"`, following the `PETG-Tough` example in CONTRIBUTING.
  Compound tokens that really are a different plastic (`PLA-CF`, `PA6-GF25`, `TPU-95A`,
  `PC+ABS`) move into `material` instead.
- **Manufacturer removed** from the name wherever OFD repeated it.
- **Sizes split so combinations stay real.** Since the build multiplies
  weights × diameters × colors, colors are grouped by the size set they are actually sold
  in and each group split so the cross product contains only combinations that exist.
  Verified against the source: 20,709 real (color, diameter, weight) rows, 0 fabricated,
  0 lost.
- Where OFD records **no size at all** for a color, 1.75 mm / 1 kg is assumed. That is an
  assumption, not a source value, and it affects 13 records in the entire database.

`scripts/lint_filaments.py` reports no new errors against this file.

### Fields left empty

`extruder_temp` / `bed_temp` — OFD stores a min/max range, mapped to `extruder_temp_range`
and `bed_temp_range`. The single-value fields have no source value, so they are omitted
rather than derived from a midpoint. `spool_weight` and `spool_type` are present only
where OFD records them.
