### PR TITLE
Add Winkle (12 filaments, 108 colors)

### DIFF
--- a/filaments/winkle.json
+++ b/filaments/winkle.json
@@ -1,0 +1,733 @@
+{
+    "manufacturer": "Winkle",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "ABS",
+            "density": 1.05,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                230,
+                260
+            ],
+            "bed_temp_range": [
+                90,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Glacier White",
+                    "hex": "F5F5F5"
+                },
+                {
+                    "name": "Jet Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "F9F3E5"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "ASA",
+            "density": 1.07,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                235,
+                260
+            ],
+            "bed_temp_range": [
+                90,
+                110
+            ],
+            "colors": [
+                {
+                    "name": "Ash Gray",
+                    "hex": "7A838E"
+                },
+                {
+                    "name": "Jet Black",
+                    "hex": "292824"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "F9F3E5"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG-CF",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "fill": "carbon fiber",
+            "colors": [
+                {
+                    "name": "Carbon Black",
+                    "hex": "545252"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.23,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                90
+            ],
+            "colors": [
+                {
+                    "name": "Ash Grey",
+                    "hex": "9C9D9D"
+                },
+                {
+                    "name": "Cristal Amber Orange",
+                    "hex": "F55928",
+                    "translucent": true
+                },
+                {
+                    "name": "Cristal Aquamarine Blue",
+                    "hex": "32CABD",
+                    "translucent": true
+                },
+                {
+                    "name": "Cristal Dark Mauve",
+                    "hex": "916676",
+                    "translucent": true
+                },
+                {
+                    "name": "Cristal Lime Green",
+                    "hex": "91DB01",
+                    "translucent": true
+                },
+                {
+                    "name": "Devil Red",
+                    "hex": "CC2616"
+                },
+                {
+                    "name": "Glacier White",
+                    "hex": "EFEFEF"
+                },
+                {
+                    "name": "Jet Black",
+                    "hex": "3E413F"
+                },
+                {
+                    "name": "Lemon Yellow",
+                    "hex": "F6FB38"
+                },
+                {
+                    "name": "Pine Green",
+                    "hex": "3D9441"
+                },
+                {
+                    "name": "Prototype Transparent",
+                    "hex": "F2ECE9",
+                    "translucent": true
+                },
+                {
+                    "name": "Royal Blue",
+                    "hex": "2C3294"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "AEB8C1"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "F2ECE9",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "Glow {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "HD Glow Alien Green",
+                    "hex": "B4E657",
+                    "glow": true
+                }
+            ]
+        },
+        {
+            "name": "HD {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Acacia Brown",
+                    "hex": "875117"
+                },
+                {
+                    "name": "Ash Gray",
+                    "hex": "9C9D9D"
+                },
+                {
+                    "name": "Avocado Green",
+                    "hex": "26A648"
+                },
+                {
+                    "name": "Beige",
+                    "hex": "E3B899"
+                },
+                {
+                    "name": "Bubblegum Pink",
+                    "hex": "FC6D8E"
+                },
+                {
+                    "name": "Canary Yellow",
+                    "hex": "F2B70A"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "845239"
+                },
+                {
+                    "name": "Devil Red",
+                    "hex": "EC0000"
+                },
+                {
+                    "name": "Ebony Brown",
+                    "hex": "543C27"
+                },
+                {
+                    "name": "Ecotisa Green",
+                    "hex": "9AED51"
+                },
+                {
+                    "name": "Fluorescent Electric Green",
+                    "hex": "70FA00"
+                },
+                {
+                    "name": "Fluorescent Electric Orange",
+                    "hex": "FF5F2E"
+                },
+                {
+                    "name": "Fluorescent Electric Pink",
+                    "hex": "FF5786"
+                },
+                {
+                    "name": "Fluorescent Electric Yellow",
+                    "hex": "E4FF33"
+                },
+                {
+                    "name": "Glacier White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Glitter Coral",
+                    "hex": "D33D3D",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Glitter Galaxy Black",
+                    "hex": "3E413F",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Glitter Midnight Blue",
+                    "hex": "324485",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Glitter Military Green",
+                    "hex": "6E8451",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Glitter Purple",
+                    "hex": "453A72",
+                    "pattern": "sparkle"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "CE9F2E"
+                },
+                {
+                    "name": "Interference Agate Violet",
+                    "hex": "71577E"
+                },
+                {
+                    "name": "Interference Dark Bronze",
+                    "hex": "573F35"
+                },
+                {
+                    "name": "Interference Emerald Green",
+                    "hex": "5F7967"
+                },
+                {
+                    "name": "Interference Galaxy Blue",
+                    "hex": "1E2C73"
+                },
+                {
+                    "name": "Jet Black",
+                    "hex": "292824"
+                },
+                {
+                    "name": "Mahogany Brown",
+                    "hex": "9F2F0D"
+                },
+                {
+                    "name": "Mauve",
+                    "hex": "B33174"
+                },
+                {
+                    "name": "Nemo Orange",
+                    "hex": "FF5F2E"
+                },
+                {
+                    "name": "Pacific Blue",
+                    "hex": "0066D9"
+                },
+                {
+                    "name": "Pastel Banana Yellow",
+                    "hex": "FCE575"
+                },
+                {
+                    "name": "Pastel Cloud Blue",
+                    "hex": "94D0C0"
+                },
+                {
+                    "name": "Pastel Cotton Candy Pink",
+                    "hex": "EAC2B7"
+                },
+                {
+                    "name": "Pastel Soft Lilac",
+                    "hex": "DABCC8"
+                },
+                {
+                    "name": "Pastel Turmeric Yellow",
+                    "hex": "F2B70A"
+                },
+                {
+                    "name": "Pastel Turquoise Blue",
+                    "hex": "96D8C5"
+                },
+                {
+                    "name": "Pearl",
+                    "hex": "E8E8E6"
+                },
+                {
+                    "name": "Phantom White",
+                    "hex": "EFEFEF"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "A368BB"
+                },
+                {
+                    "name": "Royal Blue",
+                    "hex": "2C3294"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "9C9D9D"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "0099E6"
+                },
+                {
+                    "name": "Texture Marble",
+                    "hex": "ECEFED",
+                    "pattern": "marble"
+                },
+                {
+                    "name": "Texture Sand",
+                    "hex": "E0DABB"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "F2ECE9",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "High Speed {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Ash Gray",
+                    "hex": "9F9F9F"
+                },
+                {
+                    "name": "Canary Yellow",
+                    "hex": "FADB24"
+                },
+                {
+                    "name": "Devil Red",
+                    "hex": "BB2E33"
+                },
+                {
+                    "name": "Glacier White",
+                    "hex": "F5F5F5"
+                },
+                {
+                    "name": "Jet Black",
+                    "hex": "292824"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "0099E6"
+                }
+            ]
+        },
+        {
+            "name": "Matte {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Cobalt Blue",
+                    "hex": "0066D9",
+                    "finish": "matte"
+                },
+                {
+                    "name": "Cream White",
+                    "hex": "F5F5F5",
+                    "finish": "matte"
+                },
+                {
+                    "name": "Graphite Black",
+                    "hex": "292824",
+                    "finish": "matte"
+                },
+                {
+                    "name": "Raspberry Red",
+                    "hex": "B7293E",
+                    "finish": "matte"
+                },
+                {
+                    "name": "Smoke Gray",
+                    "hex": "A2AAAD",
+                    "finish": "matte"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Ash Gray",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Avocado Green",
+                    "hex": "3D9441"
+                },
+                {
+                    "name": "Black",
+                    "hex": "292824"
+                },
+                {
+                    "name": "Canary Yellow",
+                    "hex": "F2B70A"
+                },
+                {
+                    "name": "Dark Blue",
+                    "hex": "0353BA"
+                },
+                {
+                    "name": "Devil Red",
+                    "hex": "C01616"
+                },
+                {
+                    "name": "Glacier White",
+                    "hex": "F5F5F5"
+                },
+                {
+                    "name": "Iron Gray",
+                    "hex": "3E413F"
+                },
+                {
+                    "name": "Jet Black",
+                    "hex": "292824"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "EFEADF"
+                },
+                {
+                    "name": "Pacific Blue",
+                    "hex": "0353BA"
+                },
+                {
+                    "name": "Wood Maple",
+                    "hex": "B4AAA2"
+                },
+                {
+                    "name": "Wood Pine",
+                    "hex": "9D733E"
+                }
+            ]
+        },
+        {
+            "name": "Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Antique Copper",
+                    "hex": "C06341"
+                },
+                {
+                    "name": "Irish Green",
+                    "hex": "3D9441"
+                },
+                {
+                    "name": "King Gold",
+                    "hex": "F4AC23"
+                },
+                {
+                    "name": "Maria’s Smile",
+                    "hex": "8ED9F9"
+                },
+                {
+                    "name": "Mercury Silver",
+                    "hex": "949597"
+                },
+                {
+                    "name": "Ruby Pink",
+                    "hex": "C60F3E"
+                },
+                {
+                    "name": "Ruby Red",
+                    "hex": "F14147"
+                },
+                {
+                    "name": "Snow White",
+                    "hex": "EDF0F2"
+                },
+                {
+                    "name": "Steel Blue",
+                    "hex": "0066D9"
+                },
+                {
+                    "name": "Tricolor Dubai Chocolate",
+                    "hex": "26A648"
+                },
+                {
+                    "name": "White Gold",
+                    "hex": "D6D7D8"
+                }
+            ]
+        },
+        {
+            "name": "UL94 V0 {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                230
+            ],
+            "bed_temp_range": [
+                50,
+                70
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "3E413F"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "BDC8C8"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PP",
+            "density": 0.89,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                210,
+                240
+            ],
+            "bed_temp_range": [
+                80,
+                100
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "3E413F"
+                },
+                {
+                    "name": "Natural",
+                    "hex": "DEE2DA"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F5F5"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds `filaments/winkle.json` for **Winkle** - 12 filaments, 108 colors. Winkle is not currently in SpoolmanDB.

Part of a migration of the [Open Filament Database](https://openfilamentdatabase.org/)
(MIT licensed) into SpoolmanDB, one manufacturer per PR. The text below is the same on
every one of them.

### Source

- OFD brand page: https://openfilamentdatabase.org/brands/winkle
- Manufacturer site: https://winkle.com
- (OFD records no data-sheet URL for this brand)

OFD collects its values from manufacturer product pages and technical data sheets.

**Nothing here is AI-generated.** The conversion is a field-mapping script with no
inference step: where OFD has no value, the field is omitted rather than filled. Density,
hex codes, temperature ranges and spool weights are carried across verbatim or not at all.
Script: https://gist.github.com/hochhause/f40c65a020c7bfd5a119b904b7558150

### Existing entries are never edited

Where SpoolmanDB already has a group for a product, new colors go **into that group** —
including where its name predates the current naming rules (eSUN's `PLA-Basic`, for
instance). Creating a correctly-named parallel group would leave two entries for one
product, which seemed worse than an inconsistent name. Existing fields, names and colors
are untouched; every diff is additions only. Say the word if you would rather have the
rename and I will split them.

Where a color is sold in a spool size the existing group does not list, it cannot join
that group without inventing combinations, so it becomes a sibling entry under the same
name with the correct sizes — one product, two spool sizes.

### What was left out, and how to get it back

Three kinds of color are withheld, on the principle that a missing color is cheaper to
fix than a duplicate:

- **Already present** — identical hex in the matching group. Your value stands.
- **Name clashes** — same color name as an existing entry but a different hex. Because
  `name` expands `{color_name}`, both would resolve to the same final product name and
  differ only by swatch. Correcting an existing hex is a separate question this PR does
  not try to answer.
- **Within RGB distance 10** of an existing color under a different name — the same shade
  renamed or resampled, which is a judgement call about product identity.

Spool sizes are limited to **250 g, 500 g, 750 g, 1 kg, 1.1 kg, 2 kg, 3 kg, 5 kg and
10 kg**. Everything else in OFD's long tail is left out: 9 kg, 8 kg, 4.5 kg, 2.5 kg,
2.3 kg, 850 g, 800 g and a scatter of rarer ones, including a few that look like a gross
weight rather than a filament weight (4310 g, 5310 g, 4010 g). A color sold only in an
excluded size is left out entirely rather than attached to a size it is not sold in.

Across the whole migration that is 892 colors already present, 1158 name
clashes, 46 near-identical shades and 227 colors held back on spool size.

**If you want any of it — a size, a clash, a near-shade, for this manufacturer or
globally — just ask and I will add it.** It is one line in the converter, not a re-run
of the research.

### Normalisation applied

- **Material taken out of the name.** `PLA-Matte` → `material: PLA`,
  `name: "Matte {color_name}"`, following the `PETG-Tough` example in CONTRIBUTING.
  Compound tokens that really are a different plastic (`PLA-CF`, `PA6-GF25`, `TPU-95A`,
  `PC+ABS`) move into `material` instead.
- **Manufacturer removed** from the name wherever OFD repeated it.
- **Sizes split so combinations stay real.** Since the build multiplies
  weights × diameters × colors, colors are grouped by the size set they are actually sold
  in and each group split so the cross product contains only combinations that exist.
  Verified against the source: 20,709 real (color, diameter, weight) rows, 0 fabricated,
  0 lost.
- Where OFD records **no size at all** for a color, 1.75 mm / 1 kg is assumed. That is an
  assumption, not a source value, and it affects 13 records in the entire database.

`scripts/lint_filaments.py` reports no new errors against this file.

### Fields left empty

`extruder_temp` / `bed_temp` — OFD stores a min/max range, mapped to `extruder_temp_range`
and `bed_temp_range`. The single-value fields have no source value, so they are omitted
rather than derived from a midpoint. `spool_weight` and `spool_type` are present only
where OFD records them.
