### PR TITLE
Add XZN (9 filaments, 53 colors)

### DIFF
--- a/filaments/xzn.json
+++ b/filaments/xzn.json
@@ -1,0 +1,439 @@
+{
+    "manufacturer": "XZN",
+    "filaments": [
+        {
+            "name": "{color_name}",
+            "material": "PETG",
+            "density": 1.27,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                220,
+                250
+            ],
+            "bed_temp_range": [
+                70,
+                80
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Green",
+                    "hex": "228B22"
+                },
+                {
+                    "name": "Metallic Brown",
+                    "hex": "8B6914"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "A35724"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF69B4"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "878B95"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "F5F5F5",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "Glow {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Blue",
+                    "hex": "04B8FF",
+                    "glow": true
+                }
+            ]
+        },
+        {
+            "name": "Gradient {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Rainbow",
+                    "hex": "FF0000"
+                }
+            ]
+        },
+        {
+            "name": "Marble {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Grey",
+                    "hex": "B0B0B0",
+                    "pattern": "marble"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF",
+                    "pattern": "marble"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Apple Green",
+                    "hex": "C8FD77"
+                },
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "0000CC"
+                },
+                {
+                    "name": "Brown",
+                    "hex": "8B4513"
+                },
+                {
+                    "name": "Green",
+                    "hex": "00AA00"
+                },
+                {
+                    "name": "Grey",
+                    "hex": "808080"
+                },
+                {
+                    "name": "Orange",
+                    "hex": "FF6600"
+                },
+                {
+                    "name": "Pink",
+                    "hex": "FF69B4"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "800080"
+                },
+                {
+                    "name": "Red",
+                    "hex": "CC0000"
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                },
+                {
+                    "name": "Yellow",
+                    "hex": "FFFF00"
+                }
+            ]
+        },
+        {
+            "name": "{color_name}",
+            "material": "PLA-CF",
+            "density": 1.3,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "fill": "carbon fiber",
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "1A1A1A"
+                },
+                {
+                    "name": "Blue",
+                    "hex": "000080"
+                },
+                {
+                    "name": "Brick Red",
+                    "hex": "CB4154"
+                },
+                {
+                    "name": "Matcha Green",
+                    "hex": "38571A"
+                }
+            ]
+        },
+        {
+            "name": "Silk {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Copper",
+                    "hex": "863D2E"
+                },
+                {
+                    "name": "Dark Green",
+                    "hex": "263E0F"
+                },
+                {
+                    "name": "Gold",
+                    "hex": "CEAF4C"
+                },
+                {
+                    "name": "Magenta",
+                    "hex": "E16B9A"
+                },
+                {
+                    "name": "Purple",
+                    "hex": "6F477E"
+                },
+                {
+                    "name": "Rainbow",
+                    "hex": "FF0000"
+                },
+                {
+                    "name": "Royal Blue",
+                    "hex": "002AFF"
+                },
+                {
+                    "name": "Silver",
+                    "hex": "838893"
+                },
+                {
+                    "name": "Sky Blue",
+                    "hex": "59FCFF"
+                },
+                {
+                    "name": "Tri Gold Silver Copper",
+                    "hex": "FFD700"
+                },
+                {
+                    "name": "Tri Orange Blue Green",
+                    "hex": "E38A0D"
+                },
+                {
+                    "name": "White",
+                    "hex": "F5F7F9"
+                }
+            ]
+        },
+        {
+            "name": "Transparent {color_name}",
+            "material": "PLA",
+            "density": 1.24,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                190,
+                220
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Clear",
+                    "hex": "F4FAFC",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "F3F3F3",
+                    "translucent": true
+                }
+            ]
+        },
+        {
+            "name": "95A {color_name}",
+            "material": "TPU",
+            "density": 1.21,
+            "weights": [
+                {
+                    "weight": 1000
+                }
+            ],
+            "diameters": [
+                1.75
+            ],
+            "extruder_temp_range": [
+                200,
+                230
+            ],
+            "bed_temp_range": [
+                20,
+                60
+            ],
+            "colors": [
+                {
+                    "name": "Black",
+                    "hex": "000000"
+                },
+                {
+                    "name": "Clear Blue",
+                    "hex": "4DA6FF",
+                    "translucent": true
+                },
+                {
+                    "name": "Clear Green",
+                    "hex": "4DFF88",
+                    "translucent": true
+                },
+                {
+                    "name": "Silver",
+                    "hex": "C0C0C0"
+                },
+                {
+                    "name": "Transparent",
+                    "hex": "F5F5F5",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Brown",
+                    "hex": "8B4513",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Orange",
+                    "hex": "FF8C00",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Purple",
+                    "hex": "9B30FF",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Red",
+                    "hex": "FF3030",
+                    "translucent": true
+                },
+                {
+                    "name": "Transparent Silver",
+                    "hex": "D8D8D8",
+                    "translucent": true
+                },
+                {
+                    "name": "White",
+                    "hex": "FFFFFF"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds `filaments/xzn.json` for **XZN** - 9 filaments, 53 colors. XZN is not currently in SpoolmanDB.

Part of a migration of the [Open Filament Database](https://openfilamentdatabase.org/)
(MIT licensed) into SpoolmanDB, one manufacturer per PR. The text below is the same on
every one of them.

### Source

- OFD brand page: https://openfilamentdatabase.org/brands/xzn
- Manufacturer site: https://www.amazon.com/stores/XZN/page/3F9EF060-E315-4821-8C7E-04F10395D221
- (OFD records no data-sheet URL for this brand)

OFD collects its values from manufacturer product pages and technical data sheets.

**Nothing here is AI-generated.** The conversion is a field-mapping script with no
inference step: where OFD has no value, the field is omitted rather than filled. Density,
hex codes, temperature ranges and spool weights are carried across verbatim or not at all.
Script: https://gist.github.com/hochhause/f40c65a020c7bfd5a119b904b7558150

### Existing entries are never edited

Where SpoolmanDB already has a group for a product, new colors go **into that group** —
including where its name predates the current naming rules (eSUN's `PLA-Basic`, for
instance). Creating a correctly-named parallel group would leave two entries for one
product, which seemed worse than an inconsistent name. Existing fields, names and colors
are untouched; every diff is additions only. Say the word if you would rather have the
rename and I will split them.

Where a color is sold in a spool size the existing group does not list, it cannot join
that group without inventing combinations, so it becomes a sibling entry under the same
name with the correct sizes — one product, two spool sizes.

### What was left out, and how to get it back

Three kinds of color are withheld, on the principle that a missing color is cheaper to
fix than a duplicate:

- **Already present** — identical hex in the matching group. Your value stands.
- **Name clashes** — same color name as an existing entry but a different hex. Because
  `name` expands `{color_name}`, both would resolve to the same final product name and
  differ only by swatch. Correcting an existing hex is a separate question this PR does
  not try to answer.
- **Within RGB distance 10** of an existing color under a different name — the same shade
  renamed or resampled, which is a judgement call about product identity.

Spool sizes are limited to **250 g, 500 g, 750 g, 1 kg, 1.1 kg, 2 kg, 3 kg, 5 kg and
10 kg**. Everything else in OFD's long tail is left out: 9 kg, 8 kg, 4.5 kg, 2.5 kg,
2.3 kg, 850 g, 800 g and a scatter of rarer ones, including a few that look like a gross
weight rather than a filament weight (4310 g, 5310 g, 4010 g). A color sold only in an
excluded size is left out entirely rather than attached to a size it is not sold in.

Across the whole migration that is 892 colors already present, 1158 name
clashes, 46 near-identical shades and 227 colors held back on spool size.

**If you want any of it — a size, a clash, a near-shade, for this manufacturer or
globally — just ask and I will add it.** It is one line in the converter, not a re-run
of the research.

### Normalisation applied

- **Material taken out of the name.** `PLA-Matte` → `material: PLA`,
  `name: "Matte {color_name}"`, following the `PETG-Tough` example in CONTRIBUTING.
  Compound tokens that really are a different plastic (`PLA-CF`, `PA6-GF25`, `TPU-95A`,
  `PC+ABS`) move into `material` instead.
- **Manufacturer removed** from the name wherever OFD repeated it.
- **Sizes split so combinations stay real.** Since the build multiplies
  weights × diameters × colors, colors are grouped by the size set they are actually sold
  in and each group split so the cross product contains only combinations that exist.
  Verified against the source: 20,709 real (color, diameter, weight) rows, 0 fabricated,
  0 lost.
- Where OFD records **no size at all** for a color, 1.75 mm / 1 kg is assumed. That is an
  assumption, not a source value, and it affects 13 records in the entire database.

`scripts/lint_filaments.py` reports no new errors against this file.

### Fields left empty

`extruder_temp` / `bed_temp` — OFD stores a min/max range, mapped to `extruder_temp_range`
and `bed_temp_range`. The single-value fields have no source value, so they are omitted
rather than derived from a midpoint. `spool_weight` and `spool_type` are present only
where OFD records them.
